### PR TITLE
Print year report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,4 +36,5 @@ jobs:
           yarn install
           yarn playwright install-deps
           yarn playwright install
+          yarn dist
           yarn test_bos

--- a/bos_components/account_report.jsx
+++ b/bos_components/account_report.jsx
@@ -1,1 +1,1 @@
-return <iframe style={{ width: "100%", height: "600px" }} src="https://ipfs.web4.near.page/ipfs/bafybeiabj7zuahlnm65oayewsahpc55qfekethh5nm2kpgkwemnwhqawam/"></iframe>
+return <iframe style={{ width: "100%", height: "600px" }} src="https://arizportfolio.near.page"></iframe>

--- a/bos_components/account_report.jsx
+++ b/bos_components/account_report.jsx
@@ -1,1 +1,1 @@
-return <iframe style={{ width: "100%", height: "600px" }} src="https://arizportfolio.near.page"></iframe>
+return <iframe style={{ width: "100%", height: "600px" }} src="http://localhost:8081"></iframe>

--- a/bos_test_gateway_server.js
+++ b/bos_test_gateway_server.js
@@ -5,12 +5,22 @@ import { spawn } from "child_process";
 import { homedir } from "os";
 
 // Start the HTTP server
-const server = httpServer.createServer({
+const gatewayserver = httpServer.createServer({
   root: path.join(process.cwd(), "bos_test_gateway"),
 });
 
-server.listen(8080, () => {
-  console.log("HTTP server is listening on port 8080");
+gatewayserver.listen(8080, () => {
+  console.log("Gateway HTTP server is listening on port 8080");
+});
+
+
+// Start the HTTP server
+const appserver = httpServer.createServer({
+  root: path.join(process.cwd(), "dist"),
+});
+
+appserver.listen(8081, () => {
+  console.log("App HTTP server is listening on port 8081");
 });
 
 const bosLoader = spawn(`${homedir()}/.cargo/bin/bos-loader`, ["arizas.near", "--path", "./bos_components"], { stdio: "inherit" });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "wtr --watch",
     "test": "wtr",
     "test_bos": "npx playwright test",
+    "test_bos:watch": "npx playwright test --ui",
     "test_bos:watch:codespaces": "yarn test_bos --ui-host=0.0.0.0",
     "serve": "http-server --cors -p 8081 public_html/",
     "dist": "rm -Rf dist && rollup -c rollup.config.js",

--- a/playwright_tests/tests/app.spec.js
+++ b/playwright_tests/tests/app.spec.js
@@ -1,45 +1,51 @@
 import { test, expect } from "@playwright/test";
 
+async function pause500ifRecordingVideo(page) {
+  let isVideoRecorded = (await page.video()) ? true : false;
+  if (isVideoRecorded) {
+    await page.waitForTimeout(500);
+  }
+}
+
 test("should open app", async ({ page }) => {
   await page.goto(
     "/arizas.near/widget/account_report"
   );
-  expect(await page.frameLocator('iframe').getByRole('link', { name: 'NEAR account report' })).toContainText("NEAR account report");
+  await pause500ifRecordingVideo(page);
+  const iframe = await page.frameLocator('iframe');
+  const header = await iframe.getByRole('link', { name: 'NEAR account report' });
+
+  await expect(header).toContainText("NEAR account report");
 });
+
 test("should open accounts page, add account, and load data", async ({ page }) => {
-  let isVideoRecorded = (await page.video()) ? true : false;
-  const pause500ifRecordingVideo = async () => {
-    if (isVideoRecorded) {
-      await page.waitForTimeout(500);
-    }
-  };
 
   await page.goto(
     "/arizas.near/widget/account_report"
   );
   await page.frameLocator('iframe').getByRole('link', { name: 'Accounts' }).click();
-  await pause500ifRecordingVideo();
+  await pause500ifRecordingVideo(page);
 
   await page.frameLocator('iframe').getByRole('button', { name: 'Add account' }).click();
-  await pause500ifRecordingVideo();
+  await pause500ifRecordingVideo(page);
 
   await page.frameLocator('iframe').getByRole('textbox').fill('petermusic.near');
-  await pause500ifRecordingVideo();
+  await pause500ifRecordingVideo(page);
 
   await page.frameLocator('iframe').getByRole('button', { name: 'load data' }).click();
   const progressbar = await page.frameLocator('iframe').locator('progress-bar');
   await progressbar.waitFor({ state: 'visible', timeout: 10 * 1000 });
   await progressbar.waitFor({ state: 'hidden', timeout: 60 * 1000 });
 
-  await pause500ifRecordingVideo();
+  await pause500ifRecordingVideo(page);
   await page.frameLocator('iframe').getByRole('link', { name: 'Year report' }).click();
-  await pause500ifRecordingVideo();
+  await pause500ifRecordingVideo(page);
 
   await page.frameLocator('iframe').locator('.dailybalancerow_accountchange').first().waitFor({ 'state': 'visible' });
 
   await page.frameLocator('iframe').locator('select#yearselect').selectOption('2021');
-  await pause500ifRecordingVideo();
+  await pause500ifRecordingVideo(page);
 
-  expect(await page.frameLocator('iframe').getByRole('cell', { name: '-12-31' })).toContainText('2021-12-31');
-  await pause500ifRecordingVideo();
+  await expect(await page.frameLocator('iframe').getByRole('cell', { name: '-12-31' })).toContainText('2021-12-31');
+  await pause500ifRecordingVideo(page);
 });

--- a/public_html/app.html.js
+++ b/public_html/app.html.js
@@ -1,4 +1,19 @@
 export default /*html*/ `
+<style>
+@media print {
+    .container {
+        width: 100% !important; /* Ensures the container takes full width */
+        margin: 0 !important; /* Removes horizontal margins */
+        max-width: none !important; /* Ensures there's no max-width limit */
+        padding: 0 !important; /* Removes padding if there's any */
+        min-width: 0 !important; /* Ensures there's no min-width limit */
+        position: static !important; /* Resets position property */
+        float: none !important; /* Avoids floating */
+        border: none !important; /* Removes any borders */
+        box-shadow: none !important; /* Clears box shadows */
+    }
+}
+</style>
 <nav class="navbar navbar-expand-md navbar-dark bg-dark">
     <div class="container-fluid">
         <a class="navbar-brand nav-link" href="/">NEAR account report</a>

--- a/public_html/app.js
+++ b/public_html/app.js
@@ -46,7 +46,9 @@ class AppNearNumbersComponent extends HTMLElement {
             if ((window.top == window) && (location.pathname != path || location.search.indexOf('?account_id') == 0)) {
                 history.pushState({}, null, path);
             }
-            this.shadowRoot.querySelector('nav').remove();
+            if (page.endsWith('-print')) {
+                this.shadowRoot.querySelector('nav').remove();
+            }
             mainContainer.replaceChildren(pageElement);
         }
 

--- a/public_html/app.js
+++ b/public_html/app.js
@@ -7,6 +7,7 @@ import './customexchangerates/customexchangerates-page.component.js';
 import './storage/storage-page.component.js';
 import './yearreport/yearreport-page.component.js';
 import './yearreport/yearreport-print.component.js';
+import './yearreport/yearsummary-alltokens-print.component.js';
 
 import { getCurrencyList } from './pricedata/pricedata.js';
 import { accountsconfigfile, getAccounts, setAccounts } from './storage/domainobjectstore.js';

--- a/public_html/app.js
+++ b/public_html/app.js
@@ -6,6 +6,8 @@ import './stakingview/staking-page.component.js';
 import './customexchangerates/customexchangerates-page.component.js';
 import './storage/storage-page.component.js';
 import './yearreport/yearreport-page.component.js';
+import './yearreport/yearreport-print.component.js';
+
 import { getCurrencyList } from './pricedata/pricedata.js';
 import { accountsconfigfile, getAccounts, setAccounts } from './storage/domainobjectstore.js';
 import html from './app.html.js';
@@ -38,16 +40,17 @@ class AppNearNumbersComponent extends HTMLElement {
         const numDecimals = 2;
 
         window.goToPage = (page) => {
-            const pageElement = document.createElement(`${page}-page`);
+            const pageElement = document.createElement(`${page}${page.endsWith('-print') ? '' : '-page'}`);
             const path = `${basepath}${page}`;
             if ((window.top == window) && (location.pathname != path || location.search.indexOf('?account_id') == 0)) {
                 history.pushState({}, null, path);
             }
+            this.shadowRoot.querySelector('nav').remove();
             mainContainer.replaceChildren(pageElement);
         }
 
         if (location.href != baseurl) {
-            goToPage(location.href.substring(baseurl.length).replace(/\/$/,''));
+            goToPage(location.href.substring(baseurl.length).replace(/\/$/,'').split('?')[0]);
         }
 
         this.shadowRoot.querySelectorAll('a').forEach(a => {

--- a/public_html/pricedata/pricedata.js
+++ b/public_html/pricedata/pricedata.js
@@ -1,4 +1,4 @@
-import { getCustomExchangeRates, setCustomExchangeRates, getHistoricalPriceData, setHistoricalPriceData } from "../storage/domainobjectstore.js";
+import { getCustomExchangeRates, setCustomExchangeRates, getHistoricalPriceData, setHistoricalPriceData, getCustomRealizationRates } from "../storage/domainobjectstore.js";
 
 let cachedCurrencyList = ['USD', 'NOK'];
 const defaultToken = 'NEAR';

--- a/public_html/pricedata/pricedata.js
+++ b/public_html/pricedata/pricedata.js
@@ -65,7 +65,7 @@ export async function getEODPrice(currency, datestring, token = defaultToken) {
     }
     const pricedata = await getHistoricalPriceData(token, currency);
     const price = pricedata[datestring];
-    return price;
+    return price ?? 0;
 }
 
 export async function getCustomSellPrice(currency, datestring, token) {

--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -175,6 +175,8 @@ function getPriceDataPath(token, targetCurrency) {
 export async function getHistoricalPriceData(token, targetCurrency) {
     if (!token) {
         token = 'NEAR';
+    } else if (token === 'wNEAR') {
+        token = 'NEAR';
     }
     const pricedatapath = getPriceDataPath(token, targetCurrency);
     if (await exists(pricedatapath)) {

--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -26,14 +26,17 @@ function getFungibleTokenTransactionsPath(account) {
 }
 
 export async function getDepositAccounts() {
+    const defaultDepositAccounts = {
+        "system": {
+            "description": "Funds from system account should be counted as deposits"
+        },
+        "null": {
+            "description": "Funds from null account should be counted as deposits"
+        }
+    };
     if (await exists(depositaccountsfile)) {
-        return JSON.parse(await readTextFile(depositaccountsfile));
+        return Object.assign(defaultDepositAccounts, JSON.parse(await readTextFile(depositaccountsfile)));
     } else {
-        const defaultDepositAccounts = {
-            "system": {
-                "description": "Funds from system accounts should be counted as deposits"
-            }
-        };
         await setDepositAccounts(defaultDepositAccounts);
         return defaultDepositAccounts;
     }

--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -9,6 +9,7 @@ export const accountsconfigfile = 'accounts.json';
 export const depositaccountsfile = 'depositaccounts.json';
 export const ignorefungibletokensfile = 'ignorefungibletokens.json';
 export const customexchangeratesfile = 'customexchangerates.json';
+export const customrealizationratesfile = 'realizations.json';
 export const pricedatadir = 'pricehistory';
 
 const allFungibleTokenSymbols = {};
@@ -202,6 +203,14 @@ export async function setHistoricalPriceData(token, targetCurrency, pricedata) {
     const pricedatapath = getPriceDataPath(token, targetCurrency);
     await makeDirs(pricedatapath);
     await writeFile(pricedatapath, JSON.stringify(pricedata, null, 1));
+}
+
+export async function getCustomRealizationRates() {
+    if ((await exists(customrealizationratesfile))) {
+        return JSON.parse(await readTextFile(customrealizationratesfile));
+    } else {
+        return {};
+    }
 }
 
 export async function getCustomExchangeRates() {

--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -213,6 +213,11 @@ export async function getCustomRealizationRates() {
     }
 }
 
+export async function setCustomRealizationRates(customRealizationRatesObj) {
+    await makeDirs(customrealizationratesfile);
+    await writeFile(customrealizationratesfile, JSON.stringify(customRealizationRatesObj, null, 1));
+}
+
 export async function getCustomExchangeRates() {
     if ((await exists(customexchangeratesfile))) {
         return JSON.parse(await readTextFile(customexchangeratesfile));

--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -7,6 +7,7 @@ import { getFungibleTokenTransactionsToDate } from '../near/fungibletoken.js';
 export const accountdatadir = 'accountdata';
 export const accountsconfigfile = 'accounts.json';
 export const depositaccountsfile = 'depositaccounts.json';
+export const ignorefungibletokensfile = 'ignorefungibletokens.json';
 export const customexchangeratesfile = 'customexchangerates.json';
 export const pricedatadir = 'pricehistory';
 
@@ -44,6 +45,14 @@ export async function getDepositAccounts() {
 
 export async function setDepositAccounts(depositaccounts) {
     await writeFile(depositaccountsfile, JSON.stringify(depositaccounts));
+}
+
+export async function getIgnoredFungibleTokens() {
+    if (await exists(ignorefungibletokensfile)) {
+        return JSON.parse(await readTextFile(ignorefungibletokensfile));
+    } else {
+        return [];
+    }
 }
 
 export async function getAccounts() {

--- a/public_html/storage/storage-page.component.js
+++ b/public_html/storage/storage-page.component.js
@@ -65,44 +65,37 @@ customElements.define('storage-page',
                 location.reload();
             });
 
-            if (window.top == window) {
-                if ((await walletConnectionPromise).getAccountId()) {
-                    this.loadAccountData();
-                } else {
-                    console.log('no loggedin user');
-                    return;
-                }
+            this.loadAccountData();
 
-                this.remoteRepoInput = this.shadowRoot.querySelector('#remoterepo');
-                this.remoteRepoInput.addEventListener('change', async () => {
-                    await set_remote(this.remoteRepoInput.value);
-                });
+            this.remoteRepoInput = this.shadowRoot.querySelector('#remoterepo');
+            this.remoteRepoInput.addEventListener('change', async () => {
+                await set_remote(this.remoteRepoInput.value);
+            });
 
-                this.remoteRepoInput.value = await get_remote();
-                this.syncbutton = this.shadowRoot.querySelector('#syncbutton');
-                this.syncbutton.addEventListener('click', async () => {
-                    setProgressbarValue('indeterminate', 'syncing with remote');
-                    try {
-                        this.syncbutton.disabled = true;
-                        if (!(await exists('.git'))) {
-                            if (this.remoteRepoInput.value) {
-                                await git_clone(this.remoteRepoInput.value);
-                            } else {
-                                await git_init();
-                            }
+            this.remoteRepoInput.value = await get_remote();
+            this.syncbutton = this.shadowRoot.querySelector('#syncbutton');
+            this.syncbutton.addEventListener('click', async () => {
+                setProgressbarValue('indeterminate', 'syncing with remote');
+                try {
+                    this.syncbutton.disabled = true;
+                    if (!(await exists('.git'))) {
+                        if (this.remoteRepoInput.value) {
+                            await git_clone(this.remoteRepoInput.value);
+                        } else {
+                            await git_init();
                         }
-                        await commit_all();
-                        await sync();
-                        this.dispatchSyncEvent();
-                    } catch (e) {
-                        console.error(e);
-                        modalAlert('Error syncing with remote', e);
                     }
-                    setProgressbarValue(null);
-                    this.syncbutton.disabled = false;
-                });
-            }
-
+                    await commit_all();
+                    await sync();
+                    this.dispatchSyncEvent();
+                } catch (e) {
+                    console.error(e);
+                    modalAlert('Error syncing with remote', e);
+                }
+                setProgressbarValue(null);
+                this.syncbutton.disabled = false;
+            });
+            
             this.shadowRoot.getElementById('fetchnearusdbutton').addEventListener('click', async () => {
                 setProgressbarValue('indeterminate', 'Fetching NEAR/USD prices from nearblocks.io');
                 await fetchNEARHistoricalPrices();

--- a/public_html/storage/storage-page.component.spec.js
+++ b/public_html/storage/storage-page.component.spec.js
@@ -1,13 +1,19 @@
 import './storage-page.component.js';
-import {getHistoricalPriceData} from './domainobjectstore.js';
+import { getHistoricalPriceData } from './domainobjectstore.js';
 
 describe('storage-page component', () => {
     it("should be able to fetch price data when not logged in", async () => {
         const storagePageComponent = document.createElement('storage-page');
         document.body.appendChild(storagePageComponent);
 
+        await storagePageComponent.readyPromise;
         storagePageComponent.shadowRoot.getElementById('fetchnearusdbutton').click();
 
-        expect((await getHistoricalPriceData('', 'USD'))['2020-11-02']).to.equal(0.63411456);        
+        let pricedata;
+        do {
+            pricedata = await getHistoricalPriceData('', 'USD');
+        } while (Object.keys(pricedata).length == 0);
+
+        expect(pricedata['2020-11-02']).to.equal(0.63411456);
     });
 });

--- a/public_html/storage/storage-page.component.spec.js
+++ b/public_html/storage/storage-page.component.spec.js
@@ -1,0 +1,13 @@
+import './storage-page.component.js';
+import {getHistoricalPriceData} from './domainobjectstore.js';
+
+describe('storage-page component', () => {
+    it("should be able to fetch price data when not logged in", async () => {
+        const storagePageComponent = document.createElement('storage-page');
+        document.body.appendChild(storagePageComponent);
+
+        storagePageComponent.shadowRoot.getElementById('fetchnearusdbutton').click();
+
+        expect((await getHistoricalPriceData('', 'USD'))['2020-11-02']).to.equal(0.63411456);        
+    });
+});

--- a/public_html/yearreport/yearreport-page.component.html.js
+++ b/public_html/yearreport/yearreport-page.component.html.js
@@ -44,6 +44,10 @@ export default /*html*/ `<style>
             max-width: none;
         }
     }
+    .token_amount {
+        font-size: 12px;
+        white-space: nowrap;
+    }
 </style>
 <div class="row">
     <div class="col-md-3">

--- a/public_html/yearreport/yearreport-page.component.html.js
+++ b/public_html/yearreport/yearreport-page.component.html.js
@@ -45,7 +45,14 @@ export default /*html*/ `<style>
         }
     }
 </style>
-<h3>Year report ( all accounts )</h3>
+<div class="row">
+    <div class="col-md-9">
+        <h3>Year report ( all accounts )</h3>
+    </div>
+    <div class="col-md-3" style="text-align: right">
+        <button class="btn btn-primary" id="printbutton">Print</button>
+    </div>
+</div>
 <div class="row">
     <div class="col-md-4">
         <label for="yearselect" class="form-label">Select year</label>   

--- a/public_html/yearreport/yearreport-page.component.html.js
+++ b/public_html/yearreport/yearreport-page.component.html.js
@@ -46,29 +46,25 @@ export default /*html*/ `<style>
     }
 </style>
 <div class="row">
-    <div class="col-md-9">
-        <h3>Year report ( all accounts )</h3>
-    </div>
-    <div class="col-md-3" style="text-align: right">
-        <button class="btn btn-primary" id="printbutton">Print</button>
-    </div>
-</div>
-<div class="row">
-    <div class="col-md-4">
+    <div class="col-md-3">
         <label for="yearselect" class="form-label">Select year</label>   
         <select id="yearselect" class="form-select"></select>        
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <label for="tokenselect" class="form-label">Fungible token</label>
         <select class="form-select" aria-label="Select fungible token" id="tokenselect">
             <option value="">NEAR</option>
         </select>        
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <label for="currencyselect" class="form-label">Currency</label>
         <select class="form-select" aria-label="Select conversion currency" id="currencyselect">
             <option value="">No conversion</option>
         </select>        
+    </div>
+    <div class="col-md-3" style="text-align: right">
+        <button class="btn btn-light" id="print_all_tokens_button">Print (all tokens)</button>
+        <button class="btn btn-light" id="print_current_token_button">Print (selected token)</button>
     </div>
 </div>
 

--- a/public_html/yearreport/yearreport-page.component.html.js
+++ b/public_html/yearreport/yearreport-page.component.html.js
@@ -11,27 +11,38 @@ export default /*html*/ `<style>
         white-space: nowrap;
     }
 
-    .table-responsive {
-        max-height: 100%;
-    }
-
-    table thead,
-    table tfoot {
-        position: sticky;
-    }
-
-    table thead {
-        inset-block-start: 0;
-        top: 0;
-    }
-
-    table tfoot {
-        inset-block-end: 0;
-        bottom: 0;
-    }
-
     tr.inforow td {
         font-size: 12px;   
+    }
+
+    @media screen {
+        .table-responsive {
+            max-height: 100%;
+        }
+
+        table thead,
+        table tfoot {
+            position: sticky;
+        }
+
+        table thead {
+            inset-block-start: 0;
+            top: 0;
+        }
+
+        table tfoot {
+            inset-block-end: 0;
+            bottom: 0;
+        }
+    }
+
+    @media print {
+        .table-responsive {
+            overflow: visible !important;
+            display: block;
+            width: 100%;
+            max-width: none;
+        }
     }
 </style>
 <h3>Year report ( all accounts )</h3>
@@ -72,7 +83,7 @@ export default /*html*/ `<style>
         <td><button class="btn btn-light show_transactions_button">&#128194;</button></td>
     </tr>
     <tr class="inforow bg-info">
-        <td colspan="13" >
+        <td colspan="14" >
             <table class="table table-sm table-borderless">
                 <thead>
                     <tr>

--- a/public_html/yearreport/yearreport-page.component.js
+++ b/public_html/yearreport/yearreport-page.component.js
@@ -52,8 +52,11 @@ customElements.define('year-report-page',
             tokenselect.addEventListener('change', () => this.updateView(currencyselect.value, numDecimals, tokenselect.value));
             this.updateView(currencyselect.value, numDecimals, tokenselect.value);
 
-            this.shadowRoot.querySelector('#printbutton').addEventListener('click', () => {
+            this.shadowRoot.querySelector('#print_current_token_button').addEventListener('click', () => {
                 window.open(`year-report-print?token=${this.token}&year=${this.year}&currency=${this.convertToCurrency}`);
+            });
+            this.shadowRoot.querySelector('#print_all_tokens_button').addEventListener('click', () => {
+                window.open(`yearsummary-alltokens-print?year=${this.year}&currency=${this.convertToCurrency}`);
             });
             return this.shadowRoot;
         }

--- a/public_html/yearreport/yearreport-page.component.js
+++ b/public_html/yearreport/yearreport-page.component.js
@@ -1,7 +1,7 @@
-import { calculateYearReportData, calculateProfitLoss, getConvertedValuesForDay, getFungibleTokenConvertedValuesForDay, getDecimalConversionValue } from './yearreportdata.js';
 import { getCurrencyList } from '../pricedata/pricedata.js';
 import html from './yearreport-page.component.html.js';
 import { getAllFungibleTokenSymbols } from '../storage/domainobjectstore.js';
+import { renderYearReportTable } from './yearreport-table-renderer.js';
 
 customElements.define('year-report-page',
     class extends HTMLElement {
@@ -66,114 +66,46 @@ customElements.define('year-report-page',
         }
 
         async refreshView() {
-            let { dailyBalances, transactionsByDate } = await calculateYearReportData(this.token);
-            dailyBalances = (await calculateProfitLoss(dailyBalances, this.convertToCurrency, this.token)).dailyBalances;
-
-            const yearReportData = dailyBalances;
-            const yearReportTable = this.shadowRoot.querySelector('#dailybalancestable');
-
-            while (yearReportTable.lastElementChild) {
-                yearReportTable.removeChild(yearReportTable.lastElementChild);
-            }
-
-            const rowTemplate = this.shadowRoot.querySelector('#dailybalancerowtemplate');
-
-            let currentDate = new Date().getFullYear() === this.year ? new Date(new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toJSON().substring(0, 'yyyy-MM-dd'.length)) : new Date(`${this.year}-12-31`);
-            const endDate = new Date(`${this.year}-01-01`);
-
-            let totalStakingReward = 0;
-            let totalReceived = 0;
-            let totalDeposit = 0;
-            let totalWithdrawal = 0;
-            let totalProfit = 0;
-            let totalLoss = 0;
-
-            const decimalConversionValue = this.token ? getDecimalConversionValue(this.token) : Math.pow(10, -24);
-
-            const transactionsModalElement = this.shadowRoot.querySelector('#show_transactions_modal');
-            const showTransactionsModal = new bootstrap.Modal(transactionsModalElement);
-
-            while (currentDate.getTime() >= endDate) {
-                const datestring = currentDate.toJSON().substring(0, 'yyyy-MM-dd'.length);
-
-                const row = rowTemplate.cloneNode(true).content;
-                const rowdata = yearReportData[datestring];
-
-                const { stakingReward, received, deposit, withdrawal, conversionRate } = this.token ?
-                    await getFungibleTokenConvertedValuesForDay(rowdata, this.token, this.convertToCurrency, datestring) :
-                    await getConvertedValuesForDay(rowdata, this.convertToCurrency, datestring);
-
-                totalStakingReward += stakingReward;
-                totalDeposit += deposit;
-                totalReceived += received;
-                totalWithdrawal += withdrawal;
-                totalProfit += rowdata.profit ?? 0;
-                totalLoss += rowdata.loss ?? 0;
-
-                row.querySelector('.dailybalancerow_datetime').innerHTML = datestring;
-                row.querySelector('.dailybalancerow_totalbalance').innerHTML = (conversionRate * (rowdata.totalBalance * decimalConversionValue)).toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_accountbalance').innerHTML = (conversionRate * (Number(rowdata.accountBalance) * decimalConversionValue)).toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_stakingbalance').innerHTML = (conversionRate * (rowdata.stakingBalance * decimalConversionValue)).toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_change').innerHTML = (conversionRate * (rowdata.totalChange * decimalConversionValue)).toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_accountchange').innerHTML = (conversionRate * (Number(rowdata.accountChange) * decimalConversionValue)).toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_stakingchange').innerHTML = (conversionRate * (rowdata.stakingChange * decimalConversionValue)).toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_stakingreward').innerHTML = stakingReward.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_received').innerHTML = received.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_deposit').innerHTML = deposit.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_withdrawal').innerHTML = withdrawal.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_profit').innerHTML = rowdata.profit?.toFixed(this.numDecimals) ?? '';
-                row.querySelector('.dailybalancerow_loss').innerHTML = rowdata.loss?.toFixed(this.numDecimals) ?? '';
-                row.querySelector('.show_transactions_button').addEventListener('click', () => {
-                    const transactions = transactionsByDate[datestring];
-                    transactionsModalElement.querySelector('.modal-title').innerHTML = `Transactions ${datestring}`;
-                    transactionsModalElement.querySelector('.modal-body').innerHTML = `
-                    <div class="table-responsive">
-                        <table class="table table-sm table-dark">
-                        <thead>
-                            <th>Signer</th>
-                            <th>Received</th>
-                            <th>Changed balance</th>
-                            <th></th>
-                        </thead>
-                        <tbody>
-                        ${transactions ? transactions.map(tx => `<tr>
+            await renderYearReportTable({
+                shadowRoot: this.shadowRoot,
+                token: this.token,
+                year: this.year,
+                convertToCurrency: this.convertToCurrency,
+                numDecimals: this.numDecimals,
+                perRowFunction: async ({
+                    datestring,
+                    transactionsByDate,
+                    decimalConversionValue,
+                    numDecimals,
+                    row
+                }) => {
+                    row.querySelector('.show_transactions_button').addEventListener('click', () => {
+                        const transactions = transactionsByDate[datestring];
+                        transactionsModalElement.querySelector('.modal-title').innerHTML = `Transactions ${datestring}`;
+                        transactionsModalElement.querySelector('.modal-body').innerHTML = `
+                <div class="table-responsive">
+                    <table class="table table-sm table-dark">
+                    <thead>
+                        <th>Signer</th>
+                        <th>Received</th>
+                        <th>Changed balance</th>
+                        <th></th>
+                    </thead>
+                    <tbody>
+                    ${transactions ? transactions.map(tx => `<tr>
 ${this.token ? `<td>${tx.involved_account_id}</td><td>${tx.affected_account_id}</td><td>${tx.delta_amount * decimalConversionValue}</td>` :
-    `<td>${tx.signer_id}</td><td>${tx.receiver_id}</td><td>${tx.visibleChangedBalance}</td>`}
+                                `<td>${tx.signer_id}</td><td>${tx.receiver_id}</td><td>${tx.visibleChangedBalance}</td>`}
 <td><a class="btn btn-light" target="_blank" href="https://nearblocks.io/txns/${tx.hash}">&#128194;</button></a>
 </tr>`).join('') : ''}
-                        </tbody>
-                        </table>
-                        </div>
-                    `;
-                    showTransactionsModal.show();
-                });
-                if (rowdata.realizations) {
-                    const detailInfoElement = row.querySelector('.inforow td table tbody');
-                    detailInfoElement.innerHTML = rowdata.realizations.map(r => `
-                        <tr>
-                            <td>${r.position.date}</td>
-                            <td>${(r.position.initialAmount * decimalConversionValue).toFixed(this.numDecimals)}</td>
-                            <td>${r.position.conversionRate?.toFixed(this.numDecimals)}</td>
-                            <td>${(r.amount * decimalConversionValue).toFixed(this.numDecimals)}</td>
-                            <td>${r.conversionRate?.toFixed(this.numDecimals)}</td>
-                        </tr>
-                    `).join('\n');
-                } else {
-                    row.querySelector('.inforow').remove();
+                    </tbody>
+                    </table>
+                    </div>
+                `;
+                        showTransactionsModal.show();
+                    });
+                    const tableElement = this.shadowRoot.querySelector('.table-responsive');
+                    tableElement.style.height = (window.innerHeight - tableElement.getBoundingClientRect().top) + 'px';
                 }
-                yearReportTable.appendChild(row);
-
-                currentDate = new Date(currentDate.getTime() - 24 * 60 * 60 * 1000);
-            }
-
-            this.shadowRoot.querySelector('#totalreward').innerHTML = totalStakingReward.toFixed(this.numDecimals);
-            this.shadowRoot.querySelector('#totalreceived').innerHTML = totalReceived.toFixed(this.numDecimals);
-            this.shadowRoot.querySelector('#totaldeposit').innerHTML = totalDeposit.toFixed(this.numDecimals);
-            this.shadowRoot.querySelector('#totalwithdrawal').innerHTML = totalWithdrawal.toFixed(this.numDecimals);
-            this.shadowRoot.querySelector('#totalprofit').innerHTML = totalProfit.toFixed(this.numDecimals);
-            this.shadowRoot.querySelector('#totalloss').innerHTML = totalLoss.toFixed(this.numDecimals);
-
-            const tableElement = this.shadowRoot.querySelector('.table-responsive');
-            tableElement.style.height = (window.innerHeight - tableElement.getBoundingClientRect().top) + 'px';
+            });
         }
     });

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -104,7 +104,7 @@ export default /*html*/ `<style>
 <p>
 The following table shows the first and last day of the year, and each day where there are changes in the balance.
 Any transfer to other accounts than those reported for, are counted as withdrawals.
-If there are withdrawals, then profit or loss of the realizations relative to the target currency are calculated, and displayed as a table under
+If there are withdrawals, and a target currency is selected, then profit or loss of the realizations relative to the currency are calculated, and displayed as a table under
 the row for that day. Staking rewards are added without any transaction taking place, and the new staking balance
 is obtained by calling the staking contract for the balance for that specific date.
 </p>

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -43,6 +43,10 @@ export default /*html*/ `<style>
     <td class="numeric" id="totalreceived"></td>
 </tr>
 <tr>
+    <td>Total earnings (Staking rewards + Received)</td>
+    <td class="numeric" id="totalearnings"></td>
+</tr>
+<tr>
     <td>Deposit</td>
     <td class="numeric" id="totaldeposit"></td>
 </tr>

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -35,7 +35,7 @@ export default /*html*/ `<style>
 
 <table class="table">
 <tr>
-    <td>Staking rewards</td
+    <td>Staking rewards</td>
     <td class="numeric" id="totalreward"></td>
 </tr>
 <tr>
@@ -103,7 +103,8 @@ export default /*html*/ `<style>
 <h1>Daily changes</h1>
 <p>
 The following table shows the first and last day of the year, and each day where there are changes in the balance.
-If there is a withdrawal, then profit or loss of the realizations are calculated, and displayed as a table under
+Any transfer to other accounts than those reported for, are counted as withdrawals.
+If there are withdrawals, then profit or loss of the realizations relative to the target currency are calculated, and displayed as a table under
 the row for that day. Staking rewards are added without any transaction taking place, and the new staking balance
 is obtained by calling the staking contract for the balance for that specific date.
 </p>
@@ -152,48 +153,6 @@ is obtained by calling the staking contract for the balance for that specific da
     <tbody id="dailybalancestable">
 
     </tbody>
-    <tfoot class="table-dark">
-        <th scope="col">
-
-        </th>
-        <th scope="col">
-
-        </th>
-        <th scope="col">
-
-        </th>
-        <th scope="col">
-
-        </th>
-        <th scope="col">
-
-        </th>
-        <th scope="col">
-
-        </th>
-        <th scope="col">
-
-        </th>
-        <th scope="col" class="numeric" id="totalreward">
-
-        </th>
-        <th scope="col" class="numeric" id="totalreceived">
-
-        </th>
-        <th scope="col" class="numeric" id="totaldeposit">
-
-        </th>
-        <th scope="col" class="numeric" id="totalwithdrawal">
-
-        </th>
-        <th scope="col" class="numeric" id="totalprofit">
-
-        </th>
-        <th scope="col" class="numeric" id="totalloss">
-
-        </th>
-        <th></th>
-    </tfoot>
 </table>
 
 <div class="pagebreak"></div>

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -14,10 +14,56 @@ export default /*html*/ `<style>
     tr.inforow td {
         font-size: 12px;   
     }
+
+    #transactionstablebody td:nth-child(2) {
+        max-width: 300px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    #transactionstablebody td:nth-child(3) {
+        max-width: 300px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .pagebreak {
+        page-break-after: always;
+    }
 </style>
-<h3>Year report ( all accounts )</h3>
+<h1><span id="tokenspan"></span> <span id="currencyspan"></span> <span id="yearspan"></span></h1>
 
-
+<table class="table">
+<tr>
+    <td>Staking rewards</td
+    <td class="numeric" id="totalreward"></td>
+</tr>
+<tr>
+    <td>Received (Earnings)</td>
+    <td class="numeric" id="totalreceived"></td>
+</tr>
+<tr>
+    <td>Deposit</td>
+    <td class="numeric" id="totaldeposit"></td>
+</tr>
+<tr>
+    <td>Withdrawal</td>
+    <td class="numeric" id="totalwithdrawal"></td>
+</tr>
+<tr>
+    <td>Profit on realizations</td>
+    <td class="numeric" id="totalprofit"></td>
+</tr>
+<tr>
+    <td>Loss on realizations</td>
+    <td class="numeric" id="totalloss"></td>
+</tr>
+<tr>
+    <td>Accounts</td>
+    <td id="accountscolumn"></td>
+</tr>
+</table>
+        
 <template id="dailybalancerowtemplate">
     <tr>
         <td class="dailybalancerow_datetime"></td>
@@ -52,45 +98,54 @@ export default /*html*/ `<style>
     </tr>
 </template>
 
+<div class="pagebreak"></div>
+
+<h1>Daily changes</h1>
+<p>
+The following table shows the first and last day of the year, and each day where there are changes in the balance.
+If there is a withdrawal, then profit or loss of the realizations are calculated, and displayed as a table under
+the row for that day. Staking rewards are added without any transaction taking place, and the new staking balance
+is obtained by calling the staking contract for the balance for that specific date.
+</p>
 <table class="table table-sm table-hover">
     <thead class="table-dark">
         <th scope="col">
             date
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             total balance
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             change
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             account balance
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             change
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             staking balance
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             change
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             reward
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             ext received
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             deposit
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             withdrawals
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             profit
         </th>
-        <th scope="col">
+        <th scope="col" class="numeric">
             loss
         </th>
     </thead>
@@ -141,11 +196,25 @@ export default /*html*/ `<style>
     </tfoot>
 </table>
 
-<h1>Transactions</h1>
+<div class="pagebreak"></div>
 
+<h1>Transactions</h1>
+<p>
+Below are all the transactions recorded for the accounts. Transactions may be because of function calls to
+smart contracts, transfers, adding access keys and more. The balance change is calculated by querying the account
+for the balance before and after the transaction. The balance changes are viewed as token amounts, and not converted
+to the currency used above. Note that for each row there is a link to <a href="https://nearblocks.io">nearblocks.io</a> for
+more details about the transaction.
+</p>
 <table class="table table-sm">
 <thead>
     <tr>
+        <th>Date</th>
+        <th>Signer</th>
+        <th>Receiver</th>
+        <th>Type</th>
+        <th class="numeric">Changed balance</th>
+        <th></th>
     </tr>
 </thead>
 <tbody id="transactionstablebody">

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -58,10 +58,6 @@ export default /*html*/ `<style>
     <td>Loss on realizations</td>
     <td class="numeric" id="totalloss"></td>
 </tr>
-<tr>
-    <td>Accounts</td>
-    <td id="accountscolumn"></td>
-</tr>
 </table>
         
 <template id="dailybalancerowtemplate">

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -30,6 +30,10 @@ export default /*html*/ `<style>
     .pagebreak {
         page-break-after: always;
     }
+    .token_amount {
+        font-size: 12px;
+        white-space: nowrap;
+    }
 </style>
 <h1><span id="tokenspan"></span> <span id="currencyspan"></span> <span id="yearspan"></span></h1>
 

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -54,11 +54,11 @@ export default /*html*/ `<style>
     <td>Withdrawal</td>
     <td class="numeric" id="totalwithdrawal"></td>
 </tr>
-<tr>
+<tr class="profit">
     <td>Profit on realizations</td>
     <td class="numeric" id="totalprofit"></td>
 </tr>
-<tr>
+<tr class="loss">
     <td>Loss on realizations</td>
     <td class="numeric" id="totalloss"></td>
 </tr>
@@ -143,10 +143,10 @@ is obtained by calling the staking contract for the balance for that specific da
         <th scope="col" class="numeric">
             withdrawals
         </th>
-        <th scope="col" class="numeric">
+        <th scope="col" class="numeric profit">
             profit
         </th>
-        <th scope="col" class="numeric">
+        <th scope="col" class="numeric loss">
             loss
         </th>
     </thead>

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -1,0 +1,154 @@
+export default /*html*/ `<style>
+    .numeric {
+        text-align: right;
+    }
+
+    .dailybalancerow_datetime {
+        white-space: nowrap;
+    }
+
+    .dailybalancerow_balance {
+        white-space: nowrap;
+    }
+
+    tr.inforow td {
+        font-size: 12px;   
+    }
+</style>
+<h3>Year report ( all accounts )</h3>
+
+
+<template id="dailybalancerowtemplate">
+    <tr>
+        <td class="dailybalancerow_datetime"></td>
+        <td class="dailybalancerow_totalbalance numeric"></td>
+        <td class="dailybalancerow_change numeric"></td>
+        <td class="dailybalancerow_accountbalance numeric"></td>
+        <td class="dailybalancerow_accountchange numeric"></td>
+        <td class="dailybalancerow_stakingbalance numeric"></td>
+        <td class="dailybalancerow_stakingchange numeric"></td>
+        <td class="dailybalancerow_stakingreward numeric"></td>
+        <td class="dailybalancerow_received numeric"></td>
+        <td class="dailybalancerow_deposit numeric"></td>
+        <td class="dailybalancerow_withdrawal numeric"></td>
+        <td class="dailybalancerow_profit numeric"></td>
+        <td class="dailybalancerow_loss numeric"></td>
+    </tr>
+    <tr class="inforow bg-info">
+        <td colspan="13" >
+            <table class="table table-sm table-borderless">
+                <thead>
+                    <tr>
+                        <th scope="col">acquisition date</th>
+                        <th scope="col">acquired amount</th>
+                        <th scope="col">acquisition price</th>
+                        <th scope="col">realized amount</th>
+                        <th scope="col">realization price</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </td>
+    </tr>
+</template>
+
+<table class="table table-sm table-hover">
+    <thead class="table-dark">
+        <th scope="col">
+            date
+        </th>
+        <th scope="col">
+            total balance
+        </th>
+        <th scope="col">
+            change
+        </th>
+        <th scope="col">
+            account balance
+        </th>
+        <th scope="col">
+            change
+        </th>
+        <th scope="col">
+            staking balance
+        </th>
+        <th scope="col">
+            change
+        </th>
+        <th scope="col">
+            reward
+        </th>
+        <th scope="col">
+            ext received
+        </th>
+        <th scope="col">
+            deposit
+        </th>
+        <th scope="col">
+            withdrawals
+        </th>
+        <th scope="col">
+            profit
+        </th>
+        <th scope="col">
+            loss
+        </th>
+    </thead>
+    <tbody id="dailybalancestable">
+
+    </tbody>
+    <tfoot class="table-dark">
+        <th scope="col">
+
+        </th>
+        <th scope="col">
+
+        </th>
+        <th scope="col">
+
+        </th>
+        <th scope="col">
+
+        </th>
+        <th scope="col">
+
+        </th>
+        <th scope="col">
+
+        </th>
+        <th scope="col">
+
+        </th>
+        <th scope="col" class="numeric" id="totalreward">
+
+        </th>
+        <th scope="col" class="numeric" id="totalreceived">
+
+        </th>
+        <th scope="col" class="numeric" id="totaldeposit">
+
+        </th>
+        <th scope="col" class="numeric" id="totalwithdrawal">
+
+        </th>
+        <th scope="col" class="numeric" id="totalprofit">
+
+        </th>
+        <th scope="col" class="numeric" id="totalloss">
+
+        </th>
+        <th></th>
+    </tfoot>
+</table>
+
+<h1>Transactions</h1>
+
+<table class="table table-sm">
+<thead>
+    <tr>
+    </tr>
+</thead>
+<tbody id="transactionstablebody">
+</tbody>
+</table>
+`;

--- a/public_html/yearreport/yearreport-print.component.js
+++ b/public_html/yearreport/yearreport-print.component.js
@@ -1,5 +1,5 @@
 import html from './yearreport-print.component.html.js';
-import { getNumberFormatter, renderYearReportTable } from './yearreport-table-renderer.js';
+import { getNumberFormatter, hideProfitLossIfNoConvertToCurrency, renderYearReportTable } from './yearreport-table-renderer.js';
 
 customElements.define('year-report-print',
     class extends HTMLElement {
@@ -13,6 +13,8 @@ customElements.define('year-report-print',
             this.year = searchParams.get('year');
             this.convertToCurrency = searchParams.get('currency');
 
+            hideProfitLossIfNoConvertToCurrency(this.convertToCurrency, this.shadowRoot);
+
             if (this.token !== null) {
                 this.createReport();
             }
@@ -22,6 +24,7 @@ customElements.define('year-report-print',
             this.year = this.dataset.year;
             this.convertToCurrency = this.dataset.currency;
             this.token = this.dataset.token;
+            hideProfitLossIfNoConvertToCurrency(this.convertToCurrency, this.shadowRoot);
         }
 
         async createReport() {

--- a/public_html/yearreport/yearreport-print.component.js
+++ b/public_html/yearreport/yearreport-print.component.js
@@ -1,5 +1,5 @@
 import html from './yearreport-print.component.html.js';
-import { renderYearReportTable } from './yearreport-table-renderer.js';
+import { getNumberFormatter, renderYearReportTable } from './yearreport-table-renderer.js';
 
 customElements.define('year-report-print',
     class extends HTMLElement {
@@ -31,7 +31,9 @@ customElements.define('year-report-print',
             document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
             const transactionstablebody = this.shadowRoot.querySelector('#transactionstablebody');
 
-            return await renderYearReportTable({
+            const formatNumber = getNumberFormatter(this.convertToCurrency);
+
+            const result = await renderYearReportTable({
                 shadowRoot: this.shadowRoot,
                 token: this.token,
                 year: this.year,
@@ -68,6 +70,8 @@ customElements.define('year-report-print',
                     }
                 }
             });
+            this.shadowRoot.getElementById('totalearnings').innerText = formatNumber(result.totalReceived + result.totalStakingReward);
+            return result;
         }
     }
 );

--- a/public_html/yearreport/yearreport-print.component.js
+++ b/public_html/yearreport/yearreport-print.component.js
@@ -1,5 +1,5 @@
 import html from './yearreport-print.component.html.js';
-import { calculateYearReportData, calculateProfitLoss, getConvertedValuesForDay, getFungibleTokenConvertedValuesForDay, getDecimalConversionValue } from './yearreportdata.js';
+import { renderYearReportTable } from './yearreport-table-renderer.js';
 
 customElements.define('year-report-print',
     class extends HTMLElement {
@@ -12,9 +12,7 @@ customElements.define('year-report-print',
             this.year = searchParams.get('year');
             this.convertToCurrency = searchParams.get('currency');
 
-            this.numDecimals = 2;
             if (this.token !== null) {
-                console.log(this.token);
                 this.createReport();
             }
         }
@@ -31,132 +29,45 @@ customElements.define('year-report-print',
             this.shadowRoot.getElementById('tokenspan').innerText = this.token ? this.token : 'NEAR';
             this.shadowRoot.getElementById('currencyspan').innerText = this.convertToCurrency;
             document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
-
-            let { dailyBalances, transactionsByDate, accounts } = await calculateYearReportData(this.token);
-            this.shadowRoot.getElementById('accountscolumn').innerHTML = accounts.join('<br />');
-            dailyBalances = (await calculateProfitLoss(dailyBalances, this.convertToCurrency, this.token)).dailyBalances;
-
-            const yearReportData = dailyBalances;
-            const yearReportTable = this.shadowRoot.querySelector('#dailybalancestable');
-
-            while (yearReportTable.lastElementChild) {
-                yearReportTable.removeChild(yearReportTable.lastElementChild);
-            }
-
-            const rowTemplate = this.shadowRoot.querySelector('#dailybalancerowtemplate');
-
-            let currentDate = new Date().getFullYear() === this.year ? new Date(new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toJSON().substring(0, 'yyyy-MM-dd'.length)) : new Date(`${this.year}-12-31`);
-            const endDate = new Date(`${this.year}-01-01`);
-
-            let totalStakingReward = 0;
-            let totalReceived = 0;
-            let totalDeposit = 0;
-            let totalWithdrawal = 0;
-            let totalProfit = 0;
-            let totalLoss = 0;
-
-            const decimalConversionValue = this.token ? getDecimalConversionValue(this.token) : Math.pow(10, -24);
             const transactionstablebody = this.shadowRoot.querySelector('#transactionstablebody');
 
-            while (currentDate.getTime() >= endDate) {
-                const datestring = currentDate.toJSON().substring(0, 'yyyy-MM-dd'.length);
-
-                const row = rowTemplate.cloneNode(true).content;
-                const rowdata = yearReportData[datestring];
-
-                const { stakingReward, received, deposit, withdrawal, conversionRate } = this.token ?
-                    await getFungibleTokenConvertedValuesForDay(rowdata, this.token, this.convertToCurrency, datestring) :
-                    await getConvertedValuesForDay(rowdata, this.convertToCurrency, datestring);
-
-                totalStakingReward += stakingReward;
-                totalDeposit += deposit;
-                totalReceived += received;
-                totalWithdrawal += withdrawal;
-                totalProfit += rowdata.profit ?? 0;
-                totalLoss += rowdata.loss ?? 0;
-
-                rowdata.convertedTotalBalance = conversionRate * (rowdata.totalBalance * decimalConversionValue);
-                rowdata.convertedAccountBalance = conversionRate * (Number(rowdata.accountBalance) * decimalConversionValue);
-                rowdata.convertedStakingBalance = conversionRate * (rowdata.stakingBalance * decimalConversionValue);
-                rowdata.convertedTotalChange = conversionRate * (rowdata.totalChange * decimalConversionValue);
-                rowdata.convertedAccountChange = conversionRate * (Number(rowdata.accountChange) * decimalConversionValue);
-                rowdata.convertedStakingChange = conversionRate * (rowdata.stakingChange * decimalConversionValue);
-
-                row.querySelector('.dailybalancerow_datetime').innerHTML = datestring;
-                row.querySelector('.dailybalancerow_totalbalance').innerHTML = rowdata.convertedTotalBalance.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_accountbalance').innerHTML = rowdata.convertedAccountBalance.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_stakingbalance').innerHTML = rowdata.convertedStakingBalance.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_change').innerHTML = rowdata.convertedTotalChange.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_accountchange').innerHTML = rowdata.convertedAccountChange.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_stakingchange').innerHTML = rowdata.convertedStakingChange.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_stakingreward').innerHTML = stakingReward.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_received').innerHTML = received.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_deposit').innerHTML = deposit.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_withdrawal').innerHTML = withdrawal.toFixed(this.numDecimals);
-                row.querySelector('.dailybalancerow_profit').innerHTML = rowdata.profit?.toFixed(this.numDecimals) ?? '';
-                row.querySelector('.dailybalancerow_loss').innerHTML = rowdata.loss?.toFixed(this.numDecimals) ?? '';
-
-                if (transactionsByDate[datestring]) {
-                    const transactions = transactionsByDate[datestring];
-                    for (let tx of transactions) {
-                        const transactionRow = document.createElement('tr');
-                        transactionRow.innerHTML = `<td>
-${datestring}
-</td>
-${this.token ? `
-<td>${tx.involved_account_id}</td>
-<td>${tx.affected_account_id}</td>
-<td>${tx.cause}</td>
-
-<td class="numeric">${(tx.delta_amount * decimalConversionValue).toFixed(this.numDecimals)}</td>`
-        :
-        `<td>${tx.signer_id}</td>
-    <td>${tx.receiver_id}</td>
-    <td>${tx.action_kind}</td>
-    <td class="numeric">${tx.visibleChangedBalance.toFixed(this.numDecimals)}</td>`}
-<td><a class="btn btn-light" target="_blank" href="https://nearblocks.io/txns/${tx.hash}">&#128194;</a>
-</td>`;
-                        transactionstablebody.appendChild(transactionRow);
+            return await renderYearReportTable({
+                shadowRoot: this.shadowRoot,
+                token: this.token,
+                year: this.year,
+                convertToCurrency: this.convertToCurrency,
+                numDecimals: this.numDecimals,
+                perRowFunction: async ({
+                    datestring,
+                    transactionsByDate,
+                    decimalConversionValue,
+                    numDecimals
+                }) => {
+                    if (transactionsByDate[datestring]) {
+                        const transactions = transactionsByDate[datestring];
+                        for (let tx of transactions) {
+                            const transactionRow = document.createElement('tr');
+                            transactionRow.innerHTML = `<td>
+                ${datestring}
+                </td>
+                ${this.token ? `
+                <td>${tx.involved_account_id}</td>
+                <td>${tx.affected_account_id}</td>
+                <td>${tx.cause}</td>
+            
+                <td class="numeric">${(tx.delta_amount * decimalConversionValue).toFixed(numDecimals)}</td>`
+                                    :
+                                    `<td>${tx.signer_id}</td>
+                <td>${tx.receiver_id}</td>
+                <td>${tx.action_kind}</td>
+                <td class="numeric">${tx.visibleChangedBalance.toFixed(numDecimals)}</td>`}
+                <td><a class="btn btn-light" target="_blank" href="https://nearblocks.io/txns/${tx.hash}">&#128194;</a>
+                </td>`;
+                            transactionstablebody.appendChild(transactionRow);
+                        }
                     }
                 }
-
-                if (rowdata.realizations) {
-                    const detailInfoElement = row.querySelector('.inforow td table tbody');
-                    detailInfoElement.innerHTML = rowdata.realizations.map(r => `
-                        <tr>
-                            <td>${r.position.date}</td>
-                            <td>${(r.position.initialAmount * decimalConversionValue).toFixed(this.numDecimals)}</td>
-                            <td>${r.position.conversionRate?.toFixed(this.numDecimals)}</td>
-                            <td>${(r.amount * decimalConversionValue).toFixed(this.numDecimals)}</td>
-                            <td>${r.conversionRate?.toFixed(this.numDecimals)}</td>
-                        </tr>
-                    `).join('\n');
-                } else {
-                    row.querySelector('.inforow').remove();
-                }
-
-                if (datestring.endsWith('12-31') || datestring.endsWith('01-01') || rowdata.totalChange !== 0) {
-                    yearReportTable.appendChild(row);
-                }
-
-                currentDate = new Date(currentDate.getTime() - 24 * 60 * 60 * 1000);
-                this.shadowRoot.querySelector('#totalreward').innerHTML = totalStakingReward.toFixed(this.numDecimals);
-                this.shadowRoot.querySelector('#totalreceived').innerHTML = totalReceived.toFixed(this.numDecimals);
-                this.shadowRoot.querySelector('#totaldeposit').innerHTML = totalDeposit.toFixed(this.numDecimals);
-                this.shadowRoot.querySelector('#totalwithdrawal').innerHTML = totalWithdrawal.toFixed(this.numDecimals);
-                this.shadowRoot.querySelector('#totalprofit').innerHTML = totalProfit.toFixed(this.numDecimals);
-                this.shadowRoot.querySelector('#totalloss').innerHTML = totalLoss.toFixed(this.numDecimals);
-            }
-            return {
-                totalStakingReward,
-                totalReceived,
-                totalDeposit,
-                totalWithdrawal,
-                totalProfit,
-                totalLoss,
-                outboundBalance: dailyBalances[`${this.year}-12-31`],
-                inboundBalance: dailyBalances[`${this.year}-01-01`]
-            }
+            });
         }
     }
 );

--- a/public_html/yearreport/yearreport-print.component.js
+++ b/public_html/yearreport/yearreport-print.component.js
@@ -6,6 +6,7 @@ customElements.define('year-report-print',
         constructor() {
             super();
             this.attachShadow({ mode: 'open' });
+            this.shadowRoot.innerHTML = html;
 
             const searchParams = new URLSearchParams(location.search);
             this.token = searchParams.get('token');
@@ -24,7 +25,6 @@ customElements.define('year-report-print',
         }
 
         async createReport() {
-            this.shadowRoot.innerHTML = html;
             this.shadowRoot.getElementById('yearspan').innerText = this.year;
             this.shadowRoot.getElementById('tokenspan').innerText = this.token ? this.token : 'NEAR';
             this.shadowRoot.getElementById('currencyspan').innerText = this.convertToCurrency;

--- a/public_html/yearreport/yearreport-table-renderer.js
+++ b/public_html/yearreport/yearreport-table-renderer.js
@@ -45,6 +45,11 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
     let totalProfit = 0;
     let totalLoss = 0;
 
+    let token_totalStakingReward = 0;
+    let token_totalReceived = 0n;
+    let token_totalDeposit = 0;
+    let token_totalWithdrawal = 0;
+
     const decimalConversionValue = token ? getDecimalConversionValue(token) : Math.pow(10, -24);
     const tokenNumberFormatter = getNumberFormatter();
     const symbol = token === '' ? 'NEAR' : token;
@@ -68,6 +73,11 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
         totalWithdrawal += withdrawal;
         totalProfit += rowdata.profit ?? 0;
         totalLoss += rowdata.loss ?? 0;
+
+        token_totalStakingReward += rowdata.stakingRewards;
+        token_totalReceived += rowdata.received;
+        token_totalDeposit += rowdata.deposit;
+        token_totalWithdrawal += rowdata.withdrawal;
 
         rowdata.convertedTotalBalance = conversionRate * (rowdata.totalBalance * decimalConversionValue);
         rowdata.convertedAccountBalance = conversionRate * (Number(rowdata.accountBalance) * decimalConversionValue);
@@ -119,10 +129,10 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
         }
 
         currentDate = new Date(currentDate.getTime() - 24 * 60 * 60 * 1000);
-        shadowRoot.querySelector('#totalreward').innerHTML = `${formatNumber(totalStakingReward)}`;
-        shadowRoot.querySelector('#totalreceived').innerHTML = `${formatNumber(totalReceived)}`;
-        shadowRoot.querySelector('#totaldeposit').innerHTML = `${formatNumber(totalDeposit)}`;
-        shadowRoot.querySelector('#totalwithdrawal').innerHTML = `${formatNumber(totalWithdrawal)}`;
+        shadowRoot.querySelector('#totalreward').innerHTML = `${formatNumber(totalStakingReward)} ${convertToCurrency ? `<br />${formatTokenAmount(token_totalStakingReward)}` : ''}`;
+        shadowRoot.querySelector('#totalreceived').innerHTML = `${formatNumber(totalReceived)} ${convertToCurrency ? `<br />${formatTokenAmount(Number(token_totalReceived))}` : ''}`;
+        shadowRoot.querySelector('#totaldeposit').innerHTML = `${formatNumber(totalDeposit)} ${convertToCurrency ? `<br />${formatTokenAmount(token_totalDeposit)}` : ''}`;
+        shadowRoot.querySelector('#totalwithdrawal').innerHTML = `${formatNumber(totalWithdrawal)} ${convertToCurrency ? `<br />${formatTokenAmount(token_totalWithdrawal)}` : ''}`;
         if (convertToCurrency) {
             shadowRoot.querySelector('#totalprofit').innerText = formatNumber(totalProfit);
             shadowRoot.querySelector('#totalloss').innerText = formatNumber(totalLoss);

--- a/public_html/yearreport/yearreport-table-renderer.js
+++ b/public_html/yearreport/yearreport-table-renderer.js
@@ -5,7 +5,7 @@ const numDecimals = 2;
 export function getNumberFormatter(currency) {
     const format = currency ? Intl.NumberFormat(navigator.language, { style: 'currency', currency: currency }).format :
         Intl.NumberFormat(navigator.language).format;
-    return (number) => number!==null && number!==undefined && !isNaN(number) ? format(number) : '';;
+    return (number) => number !== null && number !== undefined && !isNaN(number) ? format(number) : '';;
 }
 
 export function hideProfitLossIfNoConvertToCurrency(convertToCurrency, shadowRoot) {
@@ -17,7 +17,7 @@ export function hideProfitLossIfNoConvertToCurrency(convertToCurrency, shadowRoo
 }
         `;
         shadowRoot.appendChild(style);
-    }   
+    }
 }
 
 export async function renderYearReportTable({ shadowRoot, token, year, convertToCurrency, perRowFunction }) {
@@ -94,9 +94,9 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
             detailInfoElement.innerHTML = rowdata.realizations.map(r => `
                 <tr>
                     <td>${r.position.date}</td>
-                    <td>${formatNumber(r.position.initialAmount * decimalConversionValue)}</td>
+                    <td>${r.position.initialAmount * decimalConversionValue}</td>
                     <td>${formatNumber(r.position.conversionRate)}</td>
-                    <td>${formatNumber(r.amount * decimalConversionValue)}</td>
+                    <td>${r.amount * decimalConversionValue}</td>
                     <td>${formatNumber(r.conversionRate)}</td>
                 </tr>
             `).join('\n');

--- a/public_html/yearreport/yearreport-table-renderer.js
+++ b/public_html/yearreport/yearreport-table-renderer.js
@@ -2,6 +2,12 @@ import { calculateYearReportData, calculateProfitLoss, getConvertedValuesForDay,
 
 const numDecimals = 2;
 
+export function getNumberFormatter(currency) {
+    const format = currency ? Intl.NumberFormat(navigator.language, { style: 'currency', currency: currency }).format :
+        Intl.NumberFormat(navigator.language).format;
+    return (number) => number!==null && number!==undefined && !isNaN(number) ? format(number) : '';;
+}
+
 export async function renderYearReportTable({ shadowRoot, token, year, convertToCurrency, perRowFunction }) {
     let { dailyBalances, transactionsByDate } = await calculateYearReportData(token);
     dailyBalances = (await calculateProfitLoss(dailyBalances, convertToCurrency, token)).dailyBalances;
@@ -14,6 +20,8 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
     }
 
     const rowTemplate = shadowRoot.querySelector('#dailybalancerowtemplate');
+
+    const formatNumber = getNumberFormatter(convertToCurrency);
 
     let currentDate = new Date().getFullYear() === year ? new Date(new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toJSON().substring(0, 'yyyy-MM-dd'.length)) : new Date(`${year}-12-31`);
     const endDate = new Date(`${year}-01-01`);
@@ -51,19 +59,19 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
         rowdata.convertedAccountChange = conversionRate * (Number(rowdata.accountChange) * decimalConversionValue);
         rowdata.convertedStakingChange = conversionRate * (rowdata.stakingChange * decimalConversionValue);
 
-        row.querySelector('.dailybalancerow_datetime').innerHTML = datestring;
-        row.querySelector('.dailybalancerow_totalbalance').innerHTML = rowdata.convertedTotalBalance.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_accountbalance').innerHTML = rowdata.convertedAccountBalance.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_stakingbalance').innerHTML = rowdata.convertedStakingBalance.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_change').innerHTML = rowdata.convertedTotalChange.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_accountchange').innerHTML = rowdata.convertedAccountChange.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_stakingchange').innerHTML = rowdata.convertedStakingChange.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_stakingreward').innerHTML = stakingReward.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_received').innerHTML = received.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_deposit').innerHTML = deposit.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_withdrawal').innerHTML = withdrawal.toFixed(numDecimals);
-        row.querySelector('.dailybalancerow_profit').innerHTML = rowdata.profit?.toFixed(numDecimals) ?? '';
-        row.querySelector('.dailybalancerow_loss').innerHTML = rowdata.loss?.toFixed(numDecimals) ?? '';
+        row.querySelector('.dailybalancerow_datetime').innerText = datestring;
+        row.querySelector('.dailybalancerow_totalbalance').innerText = formatNumber(rowdata.convertedTotalBalance);
+        row.querySelector('.dailybalancerow_accountbalance').innerText = formatNumber(rowdata.convertedAccountBalance);
+        row.querySelector('.dailybalancerow_stakingbalance').innerText = formatNumber(rowdata.convertedStakingBalance);
+        row.querySelector('.dailybalancerow_change').innerText = formatNumber(rowdata.convertedTotalChange);
+        row.querySelector('.dailybalancerow_accountchange').innerText = formatNumber(rowdata.convertedAccountChange);
+        row.querySelector('.dailybalancerow_stakingchange').innerText = formatNumber(rowdata.convertedStakingChange);
+        row.querySelector('.dailybalancerow_stakingreward').innerText = formatNumber(stakingReward);
+        row.querySelector('.dailybalancerow_received').innerText = formatNumber(received);
+        row.querySelector('.dailybalancerow_deposit').innerText = formatNumber(deposit);
+        row.querySelector('.dailybalancerow_withdrawal').innerText = formatNumber(withdrawal);
+        row.querySelector('.dailybalancerow_profit').innerText = formatNumber(rowdata.profit) ?? '';
+        row.querySelector('.dailybalancerow_loss').innerText = formatNumber(rowdata.loss) ?? '';
 
         await perRowFunction({ transactionsByDate, datestring, row, decimalConversionValue, numDecimals });
 
@@ -72,10 +80,10 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
             detailInfoElement.innerHTML = rowdata.realizations.map(r => `
                 <tr>
                     <td>${r.position.date}</td>
-                    <td>${(r.position.initialAmount * decimalConversionValue).toFixed(numDecimals)}</td>
-                    <td>${r.position.conversionRate?.toFixed(numDecimals)}</td>
-                    <td>${(r.amount * decimalConversionValue).toFixed(numDecimals)}</td>
-                    <td>${r.conversionRate?.toFixed(numDecimals)}</td>
+                    <td>${formatNumber(r.position.initialAmount * decimalConversionValue)}</td>
+                    <td>${formatNumber(r.position.conversionRate)}</td>
+                    <td>${formatNumber(r.amount * decimalConversionValue)}</td>
+                    <td>${formatNumber(r.conversionRate)}</td>
                 </tr>
             `).join('\n');
         } else {
@@ -92,12 +100,12 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
         }
 
         currentDate = new Date(currentDate.getTime() - 24 * 60 * 60 * 1000);
-        shadowRoot.querySelector('#totalreward').innerHTML = totalStakingReward.toFixed(numDecimals);
-        shadowRoot.querySelector('#totalreceived').innerHTML = totalReceived.toFixed(numDecimals);
-        shadowRoot.querySelector('#totaldeposit').innerHTML = totalDeposit.toFixed(numDecimals);
-        shadowRoot.querySelector('#totalwithdrawal').innerHTML = totalWithdrawal.toFixed(numDecimals);
-        shadowRoot.querySelector('#totalprofit').innerHTML = totalProfit.toFixed(numDecimals);
-        shadowRoot.querySelector('#totalloss').innerHTML = totalLoss.toFixed(numDecimals);
+        shadowRoot.querySelector('#totalreward').innerText = formatNumber(totalStakingReward);
+        shadowRoot.querySelector('#totalreceived').innerText = formatNumber(totalReceived);
+        shadowRoot.querySelector('#totaldeposit').innerText = formatNumber(totalDeposit);
+        shadowRoot.querySelector('#totalwithdrawal').innerText = formatNumber(totalWithdrawal);
+        shadowRoot.querySelector('#totalprofit').innerText = formatNumber(totalProfit);
+        shadowRoot.querySelector('#totalloss').innerText = formatNumber(totalLoss);
     }
     return {
         totalStakingReward,

--- a/public_html/yearreport/yearreport-table-renderer.js
+++ b/public_html/yearreport/yearreport-table-renderer.js
@@ -46,6 +46,11 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
     let totalLoss = 0;
 
     const decimalConversionValue = token ? getDecimalConversionValue(token) : Math.pow(10, -24);
+    const tokenNumberFormatter = getNumberFormatter();
+    const symbol = token === '' ? 'NEAR' : token;
+    const formatTokenAmount = (amount) => {
+        return `<span class="token_amount">${tokenNumberFormatter(amount * decimalConversionValue)} ${symbol}</span>`;
+    };
 
     while (currentDate.getTime() >= endDate) {
         const datestring = currentDate.toJSON().substring(0, 'yyyy-MM-dd'.length);
@@ -72,16 +77,16 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
         rowdata.convertedStakingChange = conversionRate * (rowdata.stakingChange * decimalConversionValue);
 
         row.querySelector('.dailybalancerow_datetime').innerText = datestring;
-        row.querySelector('.dailybalancerow_totalbalance').innerText = formatNumber(rowdata.convertedTotalBalance);
-        row.querySelector('.dailybalancerow_accountbalance').innerText = formatNumber(rowdata.convertedAccountBalance);
-        row.querySelector('.dailybalancerow_stakingbalance').innerText = formatNumber(rowdata.convertedStakingBalance);
-        row.querySelector('.dailybalancerow_change').innerText = formatNumber(rowdata.convertedTotalChange);
-        row.querySelector('.dailybalancerow_accountchange').innerText = formatNumber(rowdata.convertedAccountChange);
-        row.querySelector('.dailybalancerow_stakingchange').innerText = formatNumber(rowdata.convertedStakingChange);
-        row.querySelector('.dailybalancerow_stakingreward').innerText = formatNumber(stakingReward);
-        row.querySelector('.dailybalancerow_received').innerText = formatNumber(received);
-        row.querySelector('.dailybalancerow_deposit').innerText = formatNumber(deposit);
-        row.querySelector('.dailybalancerow_withdrawal').innerText = formatNumber(withdrawal);
+        row.querySelector('.dailybalancerow_totalbalance').innerHTML = `${formatNumber(rowdata.convertedTotalBalance)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.totalBalance)}` : ''}`;
+        row.querySelector('.dailybalancerow_accountbalance').innerHTML = `${formatNumber(rowdata.convertedAccountBalance)} ${convertToCurrency ? `<br />${formatTokenAmount(Number(rowdata.accountBalance))}` : ''}`;
+        row.querySelector('.dailybalancerow_stakingbalance').innerHTML = `${formatNumber(rowdata.convertedStakingBalance)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.stakingBalance)}` : ''}`;
+        row.querySelector('.dailybalancerow_change').innerHTML = `${formatNumber(rowdata.convertedTotalChange)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.totalChange)}` : ''}`;
+        row.querySelector('.dailybalancerow_accountchange').innerHTML = `${formatNumber(rowdata.convertedAccountChange)} ${convertToCurrency ? `<br />${formatTokenAmount(Number(rowdata.accountChange))}` : ''}`;
+        row.querySelector('.dailybalancerow_stakingchange').innerHTML = `${formatNumber(rowdata.convertedStakingChange)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.stakingChange)}` : ''}`;
+        row.querySelector('.dailybalancerow_stakingreward').innerHTML = `${formatNumber(stakingReward)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.stakingRewards)}` : ''}`;
+        row.querySelector('.dailybalancerow_received').innerHTML = `${formatNumber(received)} ${convertToCurrency ? `<br />${formatTokenAmount(Number(rowdata.received))}` : ''}`;
+        row.querySelector('.dailybalancerow_deposit').innerHTML = `${formatNumber(deposit)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.deposit)}` : ''}`;
+        row.querySelector('.dailybalancerow_withdrawal').innerHTML = `${formatNumber(withdrawal)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.withdrawal)}` : ''}`;
         if (convertToCurrency) {
             row.querySelector('.dailybalancerow_profit').innerText = formatNumber(rowdata.profit) ?? '';
             row.querySelector('.dailybalancerow_loss').innerText = formatNumber(rowdata.loss) ?? '';
@@ -94,9 +99,9 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
             detailInfoElement.innerHTML = rowdata.realizations.map(r => `
                 <tr>
                     <td>${r.position.date}</td>
-                    <td>${r.position.initialAmount * decimalConversionValue}</td>
+                    <td>${formatTokenAmount(r.position.initialAmount)}</td>
                     <td>${formatNumber(r.position.conversionRate)}</td>
-                    <td>${r.amount * decimalConversionValue}</td>
+                    <td>${formatTokenAmount(r.amount)}</td>
                     <td>${formatNumber(r.conversionRate)}</td>
                 </tr>
             `).join('\n');
@@ -114,10 +119,10 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
         }
 
         currentDate = new Date(currentDate.getTime() - 24 * 60 * 60 * 1000);
-        shadowRoot.querySelector('#totalreward').innerText = formatNumber(totalStakingReward);
-        shadowRoot.querySelector('#totalreceived').innerText = formatNumber(totalReceived);
-        shadowRoot.querySelector('#totaldeposit').innerText = formatNumber(totalDeposit);
-        shadowRoot.querySelector('#totalwithdrawal').innerText = formatNumber(totalWithdrawal);
+        shadowRoot.querySelector('#totalreward').innerHTML = `${formatNumber(totalStakingReward)}`;
+        shadowRoot.querySelector('#totalreceived').innerHTML = `${formatNumber(totalReceived)}`;
+        shadowRoot.querySelector('#totaldeposit').innerHTML = `${formatNumber(totalDeposit)}`;
+        shadowRoot.querySelector('#totalwithdrawal').innerHTML = `${formatNumber(totalWithdrawal)}`;
         if (convertToCurrency) {
             shadowRoot.querySelector('#totalprofit').innerText = formatNumber(totalProfit);
             shadowRoot.querySelector('#totalloss').innerText = formatNumber(totalLoss);

--- a/public_html/yearreport/yearreport-table-renderer.js
+++ b/public_html/yearreport/yearreport-table-renderer.js
@@ -1,0 +1,112 @@
+import { calculateYearReportData, calculateProfitLoss, getConvertedValuesForDay, getFungibleTokenConvertedValuesForDay, getDecimalConversionValue } from './yearreportdata.js';
+
+const numDecimals = 2;
+
+export async function renderYearReportTable({ shadowRoot, token, year, convertToCurrency, perRowFunction }) {
+    let { dailyBalances, transactionsByDate } = await calculateYearReportData(token);
+    dailyBalances = (await calculateProfitLoss(dailyBalances, convertToCurrency, token)).dailyBalances;
+
+    const yearReportData = dailyBalances;
+    const yearReportTable = shadowRoot.querySelector('#dailybalancestable');
+
+    while (yearReportTable.lastElementChild) {
+        yearReportTable.removeChild(yearReportTable.lastElementChild);
+    }
+
+    const rowTemplate = shadowRoot.querySelector('#dailybalancerowtemplate');
+
+    let currentDate = new Date().getFullYear() === year ? new Date(new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toJSON().substring(0, 'yyyy-MM-dd'.length)) : new Date(`${year}-12-31`);
+    const endDate = new Date(`${year}-01-01`);
+
+    let totalStakingReward = 0;
+    let totalReceived = 0;
+    let totalDeposit = 0;
+    let totalWithdrawal = 0;
+    let totalProfit = 0;
+    let totalLoss = 0;
+
+    const decimalConversionValue = token ? getDecimalConversionValue(token) : Math.pow(10, -24);
+
+    while (currentDate.getTime() >= endDate) {
+        const datestring = currentDate.toJSON().substring(0, 'yyyy-MM-dd'.length);
+
+        const row = rowTemplate.cloneNode(true).content;
+        const rowdata = yearReportData[datestring];
+
+        const { stakingReward, received, deposit, withdrawal, conversionRate } = token ?
+            await getFungibleTokenConvertedValuesForDay(rowdata, token, convertToCurrency, datestring) :
+            await getConvertedValuesForDay(rowdata, convertToCurrency, datestring);
+
+        totalStakingReward += stakingReward;
+        totalDeposit += deposit;
+        totalReceived += received;
+        totalWithdrawal += withdrawal;
+        totalProfit += rowdata.profit ?? 0;
+        totalLoss += rowdata.loss ?? 0;
+
+        rowdata.convertedTotalBalance = conversionRate * (rowdata.totalBalance * decimalConversionValue);
+        rowdata.convertedAccountBalance = conversionRate * (Number(rowdata.accountBalance) * decimalConversionValue);
+        rowdata.convertedStakingBalance = conversionRate * (rowdata.stakingBalance * decimalConversionValue);
+        rowdata.convertedTotalChange = conversionRate * (rowdata.totalChange * decimalConversionValue);
+        rowdata.convertedAccountChange = conversionRate * (Number(rowdata.accountChange) * decimalConversionValue);
+        rowdata.convertedStakingChange = conversionRate * (rowdata.stakingChange * decimalConversionValue);
+
+        row.querySelector('.dailybalancerow_datetime').innerHTML = datestring;
+        row.querySelector('.dailybalancerow_totalbalance').innerHTML = rowdata.convertedTotalBalance.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_accountbalance').innerHTML = rowdata.convertedAccountBalance.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_stakingbalance').innerHTML = rowdata.convertedStakingBalance.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_change').innerHTML = rowdata.convertedTotalChange.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_accountchange').innerHTML = rowdata.convertedAccountChange.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_stakingchange').innerHTML = rowdata.convertedStakingChange.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_stakingreward').innerHTML = stakingReward.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_received').innerHTML = received.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_deposit').innerHTML = deposit.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_withdrawal').innerHTML = withdrawal.toFixed(numDecimals);
+        row.querySelector('.dailybalancerow_profit').innerHTML = rowdata.profit?.toFixed(numDecimals) ?? '';
+        row.querySelector('.dailybalancerow_loss').innerHTML = rowdata.loss?.toFixed(numDecimals) ?? '';
+
+        await perRowFunction({ transactionsByDate, datestring, row, decimalConversionValue, numDecimals });
+
+        if (rowdata.realizations) {
+            const detailInfoElement = row.querySelector('.inforow td table tbody');
+            detailInfoElement.innerHTML = rowdata.realizations.map(r => `
+                <tr>
+                    <td>${r.position.date}</td>
+                    <td>${(r.position.initialAmount * decimalConversionValue).toFixed(numDecimals)}</td>
+                    <td>${r.position.conversionRate?.toFixed(numDecimals)}</td>
+                    <td>${(r.amount * decimalConversionValue).toFixed(numDecimals)}</td>
+                    <td>${r.conversionRate?.toFixed(numDecimals)}</td>
+                </tr>
+            `).join('\n');
+        } else {
+            row.querySelector('.inforow').remove();
+        }
+
+        if (datestring.endsWith('12-31') || datestring.endsWith('01-01') ||
+            rowdata.totalChange !== 0 ||
+            received !== 0 ||
+            deposit !== 0 ||
+            withdrawal !== 0
+        ) {
+            yearReportTable.appendChild(row);
+        }
+
+        currentDate = new Date(currentDate.getTime() - 24 * 60 * 60 * 1000);
+        shadowRoot.querySelector('#totalreward').innerHTML = totalStakingReward.toFixed(numDecimals);
+        shadowRoot.querySelector('#totalreceived').innerHTML = totalReceived.toFixed(numDecimals);
+        shadowRoot.querySelector('#totaldeposit').innerHTML = totalDeposit.toFixed(numDecimals);
+        shadowRoot.querySelector('#totalwithdrawal').innerHTML = totalWithdrawal.toFixed(numDecimals);
+        shadowRoot.querySelector('#totalprofit').innerHTML = totalProfit.toFixed(numDecimals);
+        shadowRoot.querySelector('#totalloss').innerHTML = totalLoss.toFixed(numDecimals);
+    }
+    return {
+        totalStakingReward,
+        totalReceived,
+        totalDeposit,
+        totalWithdrawal,
+        totalProfit,
+        totalLoss,
+        outboundBalance: dailyBalances[`${year}-12-31`],
+        inboundBalance: dailyBalances[`${year}-01-01`]
+    }
+}

--- a/public_html/yearreport/yearreport-table-renderer.js
+++ b/public_html/yearreport/yearreport-table-renderer.js
@@ -8,6 +8,18 @@ export function getNumberFormatter(currency) {
     return (number) => number!==null && number!==undefined && !isNaN(number) ? format(number) : '';;
 }
 
+export function hideProfitLossIfNoConvertToCurrency(convertToCurrency, shadowRoot) {
+    if (!convertToCurrency) {
+        const style = document.createElement('style');
+        style.innerHTML = `
+.profit, .loss, .summary_profit, .summary_loss, .dailybalancerow_profit, .dailybalancerow_loss, #summarytablefooter {
+    display: none;
+}
+        `;
+        shadowRoot.appendChild(style);
+    }   
+}
+
 export async function renderYearReportTable({ shadowRoot, token, year, convertToCurrency, perRowFunction }) {
     let { dailyBalances, transactionsByDate } = await calculateYearReportData(token);
     dailyBalances = (await calculateProfitLoss(dailyBalances, convertToCurrency, token)).dailyBalances;
@@ -70,8 +82,10 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
         row.querySelector('.dailybalancerow_received').innerText = formatNumber(received);
         row.querySelector('.dailybalancerow_deposit').innerText = formatNumber(deposit);
         row.querySelector('.dailybalancerow_withdrawal').innerText = formatNumber(withdrawal);
-        row.querySelector('.dailybalancerow_profit').innerText = formatNumber(rowdata.profit) ?? '';
-        row.querySelector('.dailybalancerow_loss').innerText = formatNumber(rowdata.loss) ?? '';
+        if (convertToCurrency) {
+            row.querySelector('.dailybalancerow_profit').innerText = formatNumber(rowdata.profit) ?? '';
+            row.querySelector('.dailybalancerow_loss').innerText = formatNumber(rowdata.loss) ?? '';
+        }
 
         await perRowFunction({ transactionsByDate, datestring, row, decimalConversionValue, numDecimals });
 
@@ -104,8 +118,10 @@ export async function renderYearReportTable({ shadowRoot, token, year, convertTo
         shadowRoot.querySelector('#totalreceived').innerText = formatNumber(totalReceived);
         shadowRoot.querySelector('#totaldeposit').innerText = formatNumber(totalDeposit);
         shadowRoot.querySelector('#totalwithdrawal').innerText = formatNumber(totalWithdrawal);
-        shadowRoot.querySelector('#totalprofit').innerText = formatNumber(totalProfit);
-        shadowRoot.querySelector('#totalloss').innerText = formatNumber(totalLoss);
+        if (convertToCurrency) {
+            shadowRoot.querySelector('#totalprofit').innerText = formatNumber(totalProfit);
+            shadowRoot.querySelector('#totalloss').innerText = formatNumber(totalLoss);
+        }
     }
     return {
         totalStakingReward,

--- a/public_html/yearreport/yearreport-table-renderer.spec.js
+++ b/public_html/yearreport/yearreport-table-renderer.spec.js
@@ -1,0 +1,35 @@
+import { fetchNEARHistoricalPrices } from '../pricedata/pricedata.js';
+import { fetchTransactionsForAccount, setAccounts } from '../storage/domainobjectstore.js';
+import './yearreport-print.component.js';
+import { renderYearReportTable } from "./yearreport-table-renderer.js";
+
+describe('year-report-table-renderer', () => {
+    it('should render table for year report', async function () {
+        const account = 'psalomo.near';
+        const startDate = new Date(2021, 4, 1);
+        await setAccounts([account]);
+        await fetchNEARHistoricalPrices();
+
+        await fetchTransactionsForAccount(account, startDate.getTime() * 1_000_000);
+
+        const yearReportPrintComponent = document.createElement('year-report-print');
+
+        const result = await renderYearReportTable({
+            shadowRoot: yearReportPrintComponent.getRootNode().shadowRoot,
+            token: '',
+            year: 2021,
+            convertToCurrency: 'USD',
+
+            perRowFunction: async ({
+                row
+            }) => {
+
+            }
+        });
+        expect(result.totalReceived).to.be.closeTo(720.83, 0.01);
+        expect(result.inboundBalance.convertedTotalBalance).to.be.closeTo(11.14, 0.01);
+        expect(result.outboundBalance.convertedTotalBalance).to.be.closeTo(243.29, 0.01);
+        expect(result.totalProfit).to.be.closeTo(69.63, 0.01);
+        expect(result.totalLoss).to.be.closeTo(27.46, 0.01);
+    });
+});

--- a/public_html/yearreport/yearreportdata.js
+++ b/public_html/yearreport/yearreportdata.js
@@ -164,7 +164,7 @@ export async function calculateYearReportData(fungibleTokenSymbol) {
         prevDateString = datestring;
     }
 
-    return { dailyBalances, transactionsByDate };
+    return { dailyBalances, transactionsByDate, accounts };
 }
 
 export async function calculateProfitLoss(dailyBalances, targetCurrency, token) {

--- a/public_html/yearreport/yearreportdata.js
+++ b/public_html/yearreport/yearreportdata.js
@@ -190,6 +190,8 @@ export async function calculateProfitLoss(dailyBalances, targetCurrency, token) 
 
     for (const datestring in dailyBalances) {
         const dailyEntry = dailyBalances[datestring];
+        dailyEntry.convertToCurrencyWithdrawalAmount = 0;
+
         let dayProfit = 0;
         let dayLoss = 0;
         if (dailyEntry.received > 0n || dailyEntry.deposit > 0 || dailyEntry.reward > 0) {
@@ -207,7 +209,6 @@ export async function calculateProfitLoss(dailyBalances, targetCurrency, token) 
 
         if (dailyEntry.withdrawal > 0) {
             dailyEntry.realizations = [];
-            dailyEntry.convertToCurrencyWithdrawalAmount = 0;
 
             const createRealizationsForWithdrawal = (withdrawalAmount, conversionRate) => {
                 let dayRealizedAmount = 0;
@@ -312,10 +313,9 @@ export async function getConvertedValuesForDay(rowdata, convertToCurrency, dates
     const received = (conversionRate * (Number(rowdata.received) / 1e+24));
     const depositConversionRate = convertToCurrencyIsNEAR ? 1 : await getCustomBuyPrice(convertToCurrency, datestring);
     const deposit = (depositConversionRate * (rowdata.deposit / 1e+24));
-    const withdrawalConversionRate = convertToCurrencyIsNEAR ? 1 : await getCustomSellPrice(convertToCurrency, datestring);
-    const withdrawal = (withdrawalConversionRate * (rowdata.withdrawal / 1e+24));
+    const withdrawal = rowdata.convertToCurrencyWithdrawalAmount;
 
-    return { stakingReward, received, deposit, withdrawal, depositConversionRate, withdrawalConversionRate, conversionRate };
+    return { stakingReward, received, deposit, withdrawal, conversionRate };
 }
 
 export async function getFungibleTokenConvertedValuesForDay(rowdata, symbol, convertToCurrency, datestring) {
@@ -328,5 +328,5 @@ export async function getFungibleTokenConvertedValuesForDay(rowdata, symbol, con
     const deposit = (conversionRate * (rowdata.deposit * decimalConversionValue));
     const withdrawal = (conversionRate * (rowdata.withdrawal * decimalConversionValue));
 
-    return { stakingReward, received, deposit, withdrawal, conversionRate, conversionRate, conversionRate };
+    return { stakingReward, received, deposit, withdrawal, conversionRate };
 }

--- a/public_html/yearreport/yearreportdata.js
+++ b/public_html/yearreport/yearreportdata.js
@@ -207,10 +207,12 @@ export async function calculateProfitLoss(dailyBalances, targetCurrency, token) 
 
         if (dailyEntry.withdrawal > 0) {
             dailyEntry.realizations = [];
-
+            dailyEntry.convertToCurrencyWithdrawalAmount = 0;
 
             const createRealizationsForWithdrawal = (withdrawalAmount, conversionRate) => {
                 let dayRealizedAmount = 0;
+                dailyEntry.convertToCurrencyWithdrawalAmount += withdrawalAmount * conversionRate * decimalConversionValue;
+
                 while (openPositions.length > 0 && dayRealizedAmount < withdrawalAmount) {
                     const position = openPositions[0];
                     if ((dayRealizedAmount + position.remainingAmount) > withdrawalAmount) {

--- a/public_html/yearreport/yearreportdata.spec.js
+++ b/public_html/yearreport/yearreportdata.spec.js
@@ -267,13 +267,13 @@ describe('year-report-data', () => {
         nearValues = yearReportData['2022-08-21'];
         convertedValues = await getConvertedValuesForDay(yearReportData['2022-08-21'], 'NOK', '2022-08-21');
         expect(nearValues.withdrawal).to.equal(2.000000849110125e+26);
-        expect(convertedValues.withdrawal).to.equal(8200);
+        expect(convertedValues.withdrawal).to.be.closeTo(8200, 0.00001);
 
         expect((nearValues.profit - nearValues.loss)).to.be.closeTo(8200 - (nearValues.realizations.reduce((p, c) => {
             return p + c.initialConvertedValue;
         }, 0)), 12);
     });
-    it.only('should use manually specified realization value for a specific transaction when calculating profit/loss and total withdrawal', async function () {
+    it('should use manually specified realization value for a specific transaction when calculating profit/loss and total withdrawal', async function () {
         const account = 'psalomo.near';
         const convertToCurrency = 'NOK';
 
@@ -299,7 +299,7 @@ describe('year-report-data', () => {
         expect(nearValues.convertToCurrencyWithdrawalAmount / (nearValues.withdrawal / Math.pow(10, 24)))
             .to.be.closeTo(customRealizationRatesObj['64YHGt8Tsp8x28ksvi1vWA3pv9sWs4AhRSAdWPUbtdEC'].realizationPrice, 0.01);
         expect(nearValues.withdrawal / Math.pow(10, 24)).to.be.closeTo(4.0, 0.01);
-        expect(convertedValues.withdrawal).to.be.closeTo(199.7, 0.01);
+        expect(convertedValues.withdrawal).to.be.closeTo(203.68, 0.01);
 
         expect(nearValues.profit).to.be.closeTo(18.84, 0.01);
     });

--- a/public_html/yearreport/yearsummary-alltokens-print.component.html.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.html.js
@@ -34,23 +34,23 @@ export default /*html*/ `
         <th scope="col" class="numeric">
             earnings
         </th>
-        <th scope="col" class="numeric">
+        <th scope="col" class="numeric profit">
             profit
         </th>
-        <th scope="col" class="numeric">
+        <th scope="col" class="numeric loss">
             loss
         </th>
     </tr>
 </thead>
 <tbody id="summarytablebody">
 </tbody>
-<tfoot>
+<tfoot id="summarytablefooter">
     <tr>
         <th>Total</th>
         <th id="summary_total_balance" class="numeric"></th>
         <th id="summary_total_earnings" class="numeric"></th>
-        <th id="summary_total_profit" class="numeric"></th>
-        <th id="summary_total_loss" class="numeric"></th>
+        <th id="summary_total_profit" class="numeric profit"></th>
+        <th id="summary_total_loss" class="numeric loss"></th>
     </tr>
 </tfoot>
 </table>

--- a/public_html/yearreport/yearsummary-alltokens-print.component.html.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.html.js
@@ -1,0 +1,55 @@
+export default /*html*/ `
+<style>
+    .numeric {
+        text-align: right;
+    }
+    .pagebreak {
+        page-break-after: always;
+    }
+</style>
+<h1>Year report</h1>
+
+<template id="symmaryrowtemplate">
+    <tr>
+        <td class="summary_token"></td>
+        <td class="summary_balance numeric"></td>
+        <td class="summary_earnings numeric"></td>
+        <td class="summary_profit numeric"></td>
+        <td class="summary_loss numeric"></td>
+    </tr>
+</template>
+<table class="table">
+<thead>
+    <tr>
+        <th scope="col">
+            token
+        </th>
+        <th scope="col" class="numeric">
+            balance
+        </th>
+        <th scope="col" class="numeric">
+            earnings
+        </th>
+        <th scope="col" class="numeric">
+            profit
+        </th>
+        <th scope="col" class="numeric">
+            loss
+        </th>
+    </tr>
+</thead>
+<tbody id="summarytablebody">
+</tbody>
+<tfoot>
+    <tr>
+        <th>Total</th>
+        <th id="summary_total_balance" class="numeric"></th>
+        <th id="summary_total_earnings" class="numeric"></th>
+        <th id="summary_total_profit" class="numeric"></th>
+        <th id="summary_total_loss" class="numeric"></th>
+    </tr>
+</tfoot>
+</table>
+<div class="pagebreak"></div>
+<div id="tokenyearreports"></div>
+`;

--- a/public_html/yearreport/yearsummary-alltokens-print.component.html.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.html.js
@@ -9,9 +9,13 @@ export default /*html*/ `
 </style>
 <h1>Year report <span id="yearspan"></span></h1>
 
+<p><b>Disclaimer:</b> <em>This report is based on the configurations of the user, and the calculations of the software that generated the report.
+Readers of this report, and users of the reporting tool should verify the correctness of the calculations, and ensure that all relevant data is collected.
+<b>The reporting software does not guarantee correctness in calculations or accuracy and completeness in the underlying data</b>.
+</em></p>
 <p>This report is for activity in the following accounts: <span style="font-style: italic;" id="accountsspan"></span></p>
 
-<p>The following table shows the outbound balance, earnings, and profit/loss on realizations per fungible token.</p>
+<p>The following table shows the outbound balance, earnings. If a target currency is selected, it also shows profit/loss on realizations per fungible token relative to the currency.</p>
 
 <template id="symmaryrowtemplate">
     <tr>

--- a/public_html/yearreport/yearsummary-alltokens-print.component.html.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.html.js
@@ -11,15 +11,17 @@ export default /*html*/ `
 
 <p><b>Disclaimer:</b> <em>This report is based on the configurations of the user, and the calculations of the software that generated the report.
 Readers of this report, and users of the reporting tool should verify the correctness of the calculations, and ensure that all relevant data is collected.
-<b>The reporting software does not guarantee correctness in calculations or accuracy and completeness in the underlying data</b>.
+<b>The reporting software does not guarantee correctness in calculations or accuracy and completeness in the underlying data</b>. The source code of the
+reporting software is available at <a href="https://github.com/arizas/Ariz-Portfolio">https://github.com/arizas/Ariz-Portfolio</a>.
 </em></p>
-<p>This report is for activity in the following accounts: <span style="font-style: italic;" id="accountsspan"></span></p>
+<p>This report is for activity in the following accounts on the <a href="https://near.org">NEAR protocol</a> blockchain: <span style="font-style: italic;" id="accountsspan"></span></p>
 
 <p>The following table shows the outbound balance, earnings. If a target currency is selected, it also shows profit/loss on realizations per fungible token relative to the currency.</p>
 
 <template id="symmaryrowtemplate">
     <tr>
         <td class="summary_token"></td>
+        <td class="summary_amount numeric"></td>
         <td class="summary_balance numeric"></td>
         <td class="summary_earnings numeric"></td>
         <td class="summary_profit numeric"></td>
@@ -31,6 +33,9 @@ Readers of this report, and users of the reporting tool should verify the correc
     <tr>
         <th scope="col">
             token
+        </th>
+        <th scope="col" class="numeric">
+            amount
         </th>
         <th scope="col" class="numeric">
             balance
@@ -51,6 +56,7 @@ Readers of this report, and users of the reporting tool should verify the correc
 <tfoot id="summarytablefooter">
     <tr>
         <th>Total</th>
+        <th></th>
         <th id="summary_total_balance" class="numeric"></th>
         <th id="summary_total_earnings" class="numeric"></th>
         <th id="summary_total_profit" class="numeric profit"></th>

--- a/public_html/yearreport/yearsummary-alltokens-print.component.html.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.html.js
@@ -7,7 +7,11 @@ export default /*html*/ `
         page-break-after: always;
     }
 </style>
-<h1>Year report</h1>
+<h1>Year report <span id="yearspan"></span></h1>
+
+<p>This report is for activity in the following accounts: <span style="font-style: italic;" id="accountsspan"></span></p>
+
+<p>The following table shows the outbound balance, earnings, and profit/loss on realizations per fungible token.</p>
 
 <template id="symmaryrowtemplate">
     <tr>
@@ -50,6 +54,8 @@ export default /*html*/ `
     </tr>
 </tfoot>
 </table>
-<div class="pagebreak"></div>
+
+<p>In the following pages there are detailed reports for each fungible token.</p>
+
 <div id="tokenyearreports"></div>
 `;

--- a/public_html/yearreport/yearsummary-alltokens-print.component.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.js
@@ -1,6 +1,7 @@
 import html from './yearsummary-alltokens-print.component.html.js';
 import { getAccounts, getAllFungibleTokenSymbols, getIgnoredFungibleTokens } from '../storage/domainobjectstore.js';
 import { getNumberFormatter, hideProfitLossIfNoConvertToCurrency } from './yearreport-table-renderer.js';
+import { getDecimalConversionValue } from './yearreportdata.js';
 
 customElements.define('yearsummary-alltokens-print',
     class extends HTMLElement {
@@ -28,6 +29,7 @@ customElements.define('yearsummary-alltokens-print',
             this.shadowRoot.getElementById('yearspan').innerText = this.year;
 
             const format = getNumberFormatter(this.currency);
+            const formatToken = getNumberFormatter();
             let totalBalance = 0;
             let totalEarnings = 0;
             let totalProfit = 0;
@@ -57,9 +59,11 @@ customElements.define('yearsummary-alltokens-print',
                     tokenYearReportsElement.appendChild(pageBreakElement);
 
                     tokenYearReportsElement.appendChild(tokenreport);
+                    const decimalConversionValue = token ? getDecimalConversionValue(token) : Math.pow(10, -24);
                     const row = rowTemplate.cloneNode(true).content;
                     const earnings = result.totalReceived + result.totalStakingReward;
                     row.querySelector('.summary_token').innerText = token === '' ? 'NEAR' : token;
+                    row.querySelector('.summary_amount').innerText = formatToken(result.outboundBalance.totalBalance * decimalConversionValue);
                     row.querySelector('.summary_balance').innerText = format(result.outboundBalance.convertedTotalBalance);
                     row.querySelector('.summary_earnings').innerText = format(earnings);
                     row.querySelector('.summary_profit').innerText = format(result.totalProfit);

--- a/public_html/yearreport/yearsummary-alltokens-print.component.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.js
@@ -37,7 +37,12 @@ customElements.define('yearsummary-alltokens-print',
 
                 const result = await tokenreport.createReport();
                 
-                if (!isNaN(result.outboundBalance.convertedTotalBalance)) {
+                if (!isNaN(result.outboundBalance.convertedTotalBalance) && (
+                    result.totalReceived !== 0
+                    || result.totalStakingReward !== 0
+                    || result.totalDeposit !== 0
+                    || result.totalWithdrawal !== 0
+                )) {
                     tokenYearReportsElement.appendChild(tokenreport);
                     const row = rowTemplate.cloneNode(true).content;
                     const earnings = result.totalReceived + result.totalStakingReward;

--- a/public_html/yearreport/yearsummary-alltokens-print.component.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.js
@@ -1,5 +1,5 @@
 import html from './yearsummary-alltokens-print.component.html.js';
-import { getAllFungibleTokenSymbols } from '../storage/domainobjectstore.js';
+import { getAccounts, getAllFungibleTokenSymbols } from '../storage/domainobjectstore.js';
 
 customElements.define('yearsummary-alltokens-print',
     class extends HTMLElement {
@@ -22,6 +22,9 @@ customElements.define('yearsummary-alltokens-print',
             const summarytablebody = this.shadowRoot.getElementById('summarytablebody');
             const rowTemplate = this.shadowRoot.querySelector('#symmaryrowtemplate');
 
+            this.shadowRoot.getElementById('accountsspan').innerText = (await getAccounts()).join(', ');
+            this.shadowRoot.getElementById('yearspan').innerText = this.year;
+
             const format = Intl.NumberFormat(navigator.language, {style: 'currency', currency: this.currency}).format;
             let totalBalance = 0;
             let totalEarnings = 0;
@@ -43,6 +46,10 @@ customElements.define('yearsummary-alltokens-print',
                     || result.totalDeposit !== 0
                     || result.totalWithdrawal !== 0
                 )) {
+                    const pageBreakElement = documen.createElement('div');
+                    pageBreakElement.classList.add('pagebreak');
+                    tokenYearReportsElement.appendChild(pageBreakElement);
+
                     tokenYearReportsElement.appendChild(tokenreport);
                     const row = rowTemplate.cloneNode(true).content;
                     const earnings = result.totalReceived + result.totalStakingReward;

--- a/public_html/yearreport/yearsummary-alltokens-print.component.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.js
@@ -1,5 +1,5 @@
 import html from './yearsummary-alltokens-print.component.html.js';
-import { getAccounts, getAllFungibleTokenSymbols } from '../storage/domainobjectstore.js';
+import { getAccounts, getAllFungibleTokenSymbols, getIgnoredFungibleTokens } from '../storage/domainobjectstore.js';
 import { getNumberFormatter } from './yearreport-table-renderer.js';
 
 customElements.define('yearsummary-alltokens-print',
@@ -32,7 +32,12 @@ customElements.define('yearsummary-alltokens-print',
             let totalProfit = 0;
             let totalLoss = 0;
 
+            const ignoredFungibleTokens = await getIgnoredFungibleTokens();
+            console.log(ignoredFungibleTokens);
             for (const token of tokens) {
+                if (ignoredFungibleTokens.find(t => t.symbol === token)) {
+                    continue;
+                }
                 const tokenreport = document.createElement('year-report-print');
                 tokenreport.dataset.year = this.year;
                 tokenreport.dataset.currency = this.currency;

--- a/public_html/yearreport/yearsummary-alltokens-print.component.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.js
@@ -1,6 +1,6 @@
 import html from './yearsummary-alltokens-print.component.html.js';
 import { getAccounts, getAllFungibleTokenSymbols, getIgnoredFungibleTokens } from '../storage/domainobjectstore.js';
-import { getNumberFormatter } from './yearreport-table-renderer.js';
+import { getNumberFormatter, hideProfitLossIfNoConvertToCurrency } from './yearreport-table-renderer.js';
 
 customElements.define('yearsummary-alltokens-print',
     class extends HTMLElement {
@@ -13,6 +13,7 @@ customElements.define('yearsummary-alltokens-print',
             const searchParams = new URLSearchParams(location.search);
             this.year = searchParams.get('year');
             this.currency = searchParams.get('currency');
+            hideProfitLossIfNoConvertToCurrency(this.currency, this.shadowRoot);
 
             this.createReport();
         }
@@ -33,7 +34,6 @@ customElements.define('yearsummary-alltokens-print',
             let totalLoss = 0;
 
             const ignoredFungibleTokens = await getIgnoredFungibleTokens();
-            console.log(ignoredFungibleTokens);
             for (const token of tokens) {
                 if (ignoredFungibleTokens.find(t => t.symbol === token)) {
                     continue;

--- a/public_html/yearreport/yearsummary-alltokens-print.component.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.js
@@ -1,5 +1,6 @@
 import html from './yearsummary-alltokens-print.component.html.js';
 import { getAccounts, getAllFungibleTokenSymbols } from '../storage/domainobjectstore.js';
+import { getNumberFormatter } from './yearreport-table-renderer.js';
 
 customElements.define('yearsummary-alltokens-print',
     class extends HTMLElement {
@@ -25,7 +26,7 @@ customElements.define('yearsummary-alltokens-print',
             this.shadowRoot.getElementById('accountsspan').innerText = (await getAccounts()).join(', ');
             this.shadowRoot.getElementById('yearspan').innerText = this.year;
 
-            const format = Intl.NumberFormat(navigator.language, { style: 'currency', currency: this.currency }).format;
+            const format = getNumberFormatter(this.currency);
             let totalBalance = 0;
             let totalEarnings = 0;
             let totalProfit = 0;

--- a/public_html/yearreport/yearsummary-alltokens-print.component.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.js
@@ -1,0 +1,64 @@
+import html from './yearsummary-alltokens-print.component.html.js';
+import { getAllFungibleTokenSymbols } from '../storage/domainobjectstore.js';
+
+customElements.define('yearsummary-alltokens-print',
+    class extends HTMLElement {
+        constructor() {
+            super();
+            this.attachShadow({ mode: 'open' });
+            this.shadowRoot.innerHTML = html;
+            document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
+
+            const searchParams = new URLSearchParams(location.search);
+            this.year = searchParams.get('year');
+            this.currency = searchParams.get('currency');
+
+            this.createReport();
+        }
+
+        async createReport() {
+            const tokenYearReportsElement = this.shadowRoot.getElementById('tokenyearreports');
+            const tokens = ['', ...await getAllFungibleTokenSymbols()];
+            const summarytablebody = this.shadowRoot.getElementById('summarytablebody');
+            const rowTemplate = this.shadowRoot.querySelector('#symmaryrowtemplate');
+
+            const format = Intl.NumberFormat(navigator.language, {style: 'currency', currency: this.currency}).format;
+            let totalBalance = 0;
+            let totalEarnings = 0;
+            let totalProfit = 0;
+            let totalLoss = 0;
+
+            for (const token of tokens) {
+                const tokenreport = document.createElement('year-report-print');
+                tokenreport.dataset.year = this.year;
+                tokenreport.dataset.currency = this.currency;
+                tokenreport.dataset.token = token;
+                tokenreport.useDataset();
+
+                const result = await tokenreport.createReport();
+                
+                if (!isNaN(result.outboundBalance.convertedTotalBalance)) {
+                    tokenYearReportsElement.appendChild(tokenreport);
+                    const row = rowTemplate.cloneNode(true).content;
+                    const earnings = result.totalReceived + result.totalStakingReward;
+                    row.querySelector('.summary_token').innerText = token === '' ? 'NEAR' : token;
+                    row.querySelector('.summary_balance').innerText = format(result.outboundBalance.convertedTotalBalance);
+                    row.querySelector('.summary_earnings').innerText = format(earnings);
+                    row.querySelector('.summary_profit').innerText = format(result.totalProfit);
+                    row.querySelector('.summary_loss').innerText = format(result.totalLoss);
+                    summarytablebody.appendChild(row);
+
+                    totalBalance += result.outboundBalance.convertedTotalBalance;
+                    totalEarnings += earnings;
+                    totalProfit += result.totalProfit;
+                    totalLoss += result.totalLoss;
+
+                    this.shadowRoot.getElementById('summary_total_balance').innerText = format(totalBalance);
+                    this.shadowRoot.getElementById('summary_total_earnings').innerText = format(totalEarnings);
+                    this.shadowRoot.getElementById('summary_total_profit').innerText = format(totalProfit);
+                    this.shadowRoot.getElementById('summary_total_loss').innerText = format(totalLoss);
+                }
+            };
+        }
+    }
+);

--- a/public_html/yearreport/yearsummary-alltokens-print.component.js
+++ b/public_html/yearreport/yearsummary-alltokens-print.component.js
@@ -25,7 +25,7 @@ customElements.define('yearsummary-alltokens-print',
             this.shadowRoot.getElementById('accountsspan').innerText = (await getAccounts()).join(', ');
             this.shadowRoot.getElementById('yearspan').innerText = this.year;
 
-            const format = Intl.NumberFormat(navigator.language, {style: 'currency', currency: this.currency}).format;
+            const format = Intl.NumberFormat(navigator.language, { style: 'currency', currency: this.currency }).format;
             let totalBalance = 0;
             let totalEarnings = 0;
             let totalProfit = 0;
@@ -39,14 +39,14 @@ customElements.define('yearsummary-alltokens-print',
                 tokenreport.useDataset();
 
                 const result = await tokenreport.createReport();
-                
+
                 if (!isNaN(result.outboundBalance.convertedTotalBalance) && (
                     result.totalReceived !== 0
                     || result.totalStakingReward !== 0
                     || result.totalDeposit !== 0
                     || result.totalWithdrawal !== 0
                 )) {
-                    const pageBreakElement = documen.createElement('div');
+                    const pageBreakElement = document.createElement('div');
                     pageBreakElement.classList.add('pagebreak');
                     tokenYearReportsElement.appendChild(pageBreakElement);
 

--- a/web4contract/web4contract.wat.js
+++ b/web4contract/web4contract.wat.js
@@ -3,7 +3,7 @@ import { writeFile } from 'fs/promises';
 const web4json = {
     contentType: 
     "text/html; charset=UTF-8", 
-    bodyUrl: "https://ipfs.web4.near.page/ipfs/bafybeiabj7zuahlnm65oayewsahpc55qfekethh5nm2kpgkwemnwhqawam/"
+    bodyUrl: "https://ipfs.web4.near.page/ipfs/bafybeif3e2buqdefz2q4zf4xxnh66lmdd3inqy4paptca6asb4v3akq4me/"
 };
 
 const web4jsonstring = JSON.stringify(web4json);

--- a/web4contract/web4contract.wat.js
+++ b/web4contract/web4contract.wat.js
@@ -3,7 +3,7 @@ import { writeFile } from 'fs/promises';
 const web4json = {
     contentType: 
     "text/html; charset=UTF-8", 
-    bodyUrl: "https://ipfs.web4.near.page/ipfs/bafybeiezgjo43hoalm6hyk4efblhuqxytpryv4u7zz2zc3wmonzijtmckm/"
+    bodyUrl: "https://ipfs.web4.near.page/ipfs/bafybeih6adi5l3n7mmbz6rq6mxox5ecsvv7wojdddqfew4w2mtekwuah4q/"
 };
 
 const web4jsonstring = JSON.stringify(web4json);

--- a/web4contract/web4contract.wat.js
+++ b/web4contract/web4contract.wat.js
@@ -3,7 +3,7 @@ import { writeFile } from 'fs/promises';
 const web4json = {
     contentType: 
     "text/html; charset=UTF-8", 
-    bodyUrl: "https://ipfs.web4.near.page/ipfs/bafybeif3e2buqdefz2q4zf4xxnh66lmdd3inqy4paptca6asb4v3akq4me/"
+    bodyUrl: "https://ipfs.web4.near.page/ipfs/bafybeiezgjo43hoalm6hyk4efblhuqxytpryv4u7zz2zc3wmonzijtmckm/"
 };
 
 const web4jsonstring = JSON.stringify(web4json);


### PR DESCRIPTION
This PR adds two buttons for creating print friendly year reports:

<img width="1440" alt="image" src="https://github.com/arizas/Ariz-Portfolio/assets/9760441/3aaf0bab-8cfb-4086-b6aa-f11644c72477">

- [x] CSS for print media
- [x] Separate web component for print
- [x] Summary page summing key numbers for all fungible token   
- [x] Show transactions in print
- [x] Possibility to configure fungible tokens to be hidden (Hide scam fungible tokens)
- [x] Do not show profilt/loss when there is no target currency 
- [x] Custom realization rates ( for specifying the actual price when selling on external exchange )

fixes #19  