### PR TITLE
Fix so that existing staking balances are not re-fetched, Adjust to nearblocks rate limit

### DIFF
--- a/public_html/near/account.js
+++ b/public_html/near/account.js
@@ -293,5 +293,6 @@ export async function getAccountBalanceAfterTransaction(account_id, tx_hash, blo
     if (!balance) {
         balance = (await viewAccount(blockdata.block.header.hash, account_id)).amount;
     }
-    return { transaction: transactionInFirstBlock, balance };
+
+    return { transaction: transactionInFirstBlock, balance, blockdata };
 }

--- a/public_html/near/account.spec.js
+++ b/public_html/near/account.spec.js
@@ -128,12 +128,12 @@ describe('nearaccount transactions petersalomonsen.near', function () {
         expect(await (getBalanceForTxHash('2xXghNC1GhjFYokX1nWdWLzMCn7yN3SWyhRowtpGuost', 'psalomo.near'))).to.equal('16710096912904207620297833');
         expect(await (getBalanceForTxHash('GHP8GDYN6gdHqq6ZH7adZUUNbmovjC1i25bxAp6Jvb5W', 'psalomo.near'))).to.equal('16710096912904207620297833');
     });
-    it('should find balance for transaction when passed blockheight is not the first block for the transaction', async function() {
+    it('should find balance for transaction when passed blockheight is not the first block for the transaction', async function () {
         expect((await (getAccountBalanceAfterTransaction('petersalomonsen.near', 'H5TRhv1wZgBtRHrWpkHpcQ3KiBkFC6wfj1Zcq9XDCJ3L', 111132053))).balance).to.equal('65262119033825266605299669');
         expect((await (getAccountBalanceAfterTransaction('petersalomonsen.near', 'EvRStyT6VavKxba8U3pMYQ9KVbd9VUXLupYem8EBFESu', 110377210))).balance).to.equal('65264527225561096005299669');
         expect((await (getAccountBalanceAfterTransaction('petersalomonsen.near', 'GtHtwySAVBppR8rUH5xXWaqz4XhChDJZDd2ZZvmMVv27', 110293816))).balance).to.equal('47532452152970436125563667');
     });
-    it('should handle transaction without any action', async function() {
+    it('should handle transaction without any action', async function () {
         const transactions = [{
             "block_hash": "9zt3XU7PuC3zZnuhWGZ2H8DrJcjWx3p8AaWGtyfmpjUX",
             "block_timestamp": "1714576046443461074",
@@ -141,11 +141,11 @@ describe('nearaccount transactions petersalomonsen.near', function () {
             "signer_id": "devgovgigs.petersalomonsen.near",
             "receiver_id": "devgovgigs.petersalomonsen.near",
             "args": {
-                
+
             },
             "block_height": 118024815
         }];
-        await fixTransactionsWithoutBalance({account: 'devgovgigs.petersalomonsen.near', transactions});
+        await fixTransactionsWithoutBalance({ account: 'devgovgigs.petersalomonsen.near', transactions });
         expect(transactions[0].action_kind).to.be.null;
         expect(transactions[0].args.method_name).to.be.null;
     });

--- a/public_html/near/account.spec.js
+++ b/public_html/near/account.spec.js
@@ -1,10 +1,11 @@
 import { TRANSACTION_DATA_API_PIKESPEAKAI, fixTransactionsWithoutBalance, getAccountBalanceAfterTransaction, getNearblocksAccountHistory, getPikespeakaiAccountHistory, getTransactionsToDate, setTransactionDataApi } from './account.js';
 import { getTransactionsForAccount, fetchTransactionsForAccount } from '../storage/domainobjectstore.js';
+import { getFromNearBlocks } from './nearblocks.js';
 
 describe('nearaccount transactions petersalomonsen.near', function () {
     const account = 'petersalomonsen.near';
     const getBalanceForTxHash = async (txHash, accountId) => {
-        const transaction = await fetch(`https://api3.nearblocks.io/v1/txns/${txHash}`).then(r => r.json());
+        const transaction = await getFromNearBlocks(`/v1/txns/${txHash}`);
         const block_height = transaction.txns[0].block.block_height;
         const { balance } = await getAccountBalanceAfterTransaction(accountId, txHash, block_height);
         return balance;

--- a/public_html/near/fungibletoken.js
+++ b/public_html/near/fungibletoken.js
@@ -1,8 +1,9 @@
 import { setProgressbarValue } from '../ui/progress-bar.js';
+import { getFromNearBlocks } from './nearblocks.js';
 
 export async function fetchFungibleTokenHistory(account_id, maxentries = 25, page = 1) {
-    const url = `https://api.nearblocks.io/v1/account/${account_id}/ft-txns?page=${page}&per_page=${maxentries}&order=desc`;
-    const result = await fetch(url).then(r => r.json());
+    const path = `/v1/account/${account_id}/ft-txns?page=${page}&per_page=${maxentries}&order=desc`;
+    const result = await getFromNearBlocks(path);
     return result.txns;
 }
 

--- a/public_html/near/nearblocks.js
+++ b/public_html/near/nearblocks.js
@@ -1,0 +1,35 @@
+export const MAX_CALLS_PER_MINUTE = 6;
+let lastCountStartTime = new Date().getTime();
+let countSinceStartTime = 0;
+
+export async function getFromNearBlocks(path) {
+    countSinceStartTime++;
+    if (countSinceStartTime >= MAX_CALLS_PER_MINUTE) {
+        const timeoutMillis = lastCountStartTime + 60_000 - new Date().getTime();
+        if (timeoutMillis > 0) {
+            await new Promise(resolve => setTimeout(() => resolve(), timeoutMillis));
+        }
+    }
+    if (lastCountStartTime < (new Date().getTime() - 60_000)) {
+        lastCountStartTime = new Date().getTime();
+        countSinceStartTime = 0;
+    }
+    const fetchFunc = async () => await fetch(`https://api.nearblocks.io${path}`, { mode: 'cors' });
+
+    let response = await fetchFunc();
+    if (response.status === 429) {
+        console.error('too many requests', response, 'retry in 60 seconds');
+        await new Promise(resolve => setTimeout(() => resolve(), 60_000));
+        response = await fetchFunc();
+    }
+
+    if (response.status === 200) {
+        if (response.headers.get('x-cache-hit') === 'true' && countSinceStartTime > 0) {
+            countSinceStartTime--;
+        }
+        return await response.json();
+    } else {
+        console.error(response);
+        throw new Error(`${response.status}: ${await response.text()}`);
+    }
+}

--- a/public_html/near/nearblocks.js
+++ b/public_html/near/nearblocks.js
@@ -1,10 +1,10 @@
-export const MAX_CALLS_PER_MINUTE = 6;
+export const MAX_CALLS_PER_MINUTE = 5;
 let lastCountStartTime = new Date().getTime();
 let countSinceStartTime = 0;
 
 export async function getFromNearBlocks(path) {
     countSinceStartTime++;
-    if (countSinceStartTime >= MAX_CALLS_PER_MINUTE) {
+    if (countSinceStartTime > MAX_CALLS_PER_MINUTE) {
         const timeoutMillis = lastCountStartTime + 60_000 - new Date().getTime();
         if (timeoutMillis > 0) {
             await new Promise(resolve => setTimeout(() => resolve(), timeoutMillis));

--- a/public_html/near/nearblocks.spec.js
+++ b/public_html/near/nearblocks.spec.js
@@ -1,14 +1,14 @@
 import { getFromNearBlocks, MAX_CALLS_PER_MINUTE } from "./nearblocks.js";
 
 describe('get data from nearblocks api', function () {
-    it('should respect the rate limit', async function() {
+    it('should respect the rate limit', async function () {
         this.timeout(2 * 60_000);
         const startTime = new Date().getTime();
         for (let n = 0; n < MAX_CALLS_PER_MINUTE; n++) {
-            await getFromNearBlocks('/v1/charts/tps');
+            await getFromNearBlocks('/v1/blocks/count');
         }
         expect(new Date().getTime()).to.be.lessThan(startTime + 60_000);
-        await getFromNearBlocks('/v1/charts/tps');
+        await getFromNearBlocks('/v1/blocks/count');
         expect(new Date().getTime()).to.be.above(startTime + 60_000);
     });
 });

--- a/public_html/near/nearblocks.spec.js
+++ b/public_html/near/nearblocks.spec.js
@@ -1,0 +1,14 @@
+import { getFromNearBlocks, MAX_CALLS_PER_MINUTE } from "./nearblocks.js";
+
+describe('get data from nearblocks api', function () {
+    it('should respect the rate limit', async function() {
+        this.timeout(2 * 60_000);
+        const startTime = new Date().getTime();
+        for (let n = 0; n < MAX_CALLS_PER_MINUTE; n++) {
+            await getFromNearBlocks('/v1/charts/tps');
+        }
+        expect(new Date().getTime()).to.be.lessThan(startTime + 60_000);
+        await getFromNearBlocks('/v1/charts/tps');
+        expect(new Date().getTime()).to.be.above(startTime + 60_000);
+    });
+});

--- a/public_html/near/retry.js
+++ b/public_html/near/retry.js
@@ -2,14 +2,16 @@ import { setProgressbarValue } from "../ui/progress-bar.js";
 
 export async function retry(func, max_retries = 10, pause_millis = 30000) {
     let err;
-    for (let n = 0; n < max_retries; n++) {
+    for (let n = 0; n < (max_retries + 1); n++) {
         try {
             return await func();
         } catch (e) {
             err = e;
-            console.error('error', e, 'retrying in ', pause_millis, 'milliseconds');
-            setProgressbarValue('indeterminate', `error ${e} retrying in ${(pause_millis / 1000).toFixed(0)} seconds`);
-            await new Promise(r => setTimeout(r, pause_millis));
+            if ( n < max_retries) {
+                console.error('error', e, 'retrying in ', pause_millis, 'milliseconds');
+                setProgressbarValue('indeterminate', `error ${e} retrying in ${(pause_millis / 1000).toFixed(0)} seconds`);            
+                await new Promise(r => setTimeout(r, pause_millis));
+            }
         }
     }
     setProgressbarValue(null);

--- a/public_html/near/rpc.js
+++ b/public_html/near/rpc.js
@@ -1,10 +1,10 @@
 let rpcIndex = 0;
 
 export const rpcs = [
-    /*'https://free.rpc.fastnear.com',
-    'https://near.lava.build',
+    'https://free.rpc.fastnear.com',
     'https://rpc.mainnet.near.org',
-    'https://1rpc.io/near',*/
+    'https://1rpc.io/near',
+    'https://near.lava.build',
     'https://archival-rpc.mainnet.near.org',
     'https://archival-rpc.mainnet.pagoda.co'
 ];

--- a/public_html/near/stakingpool.js
+++ b/public_html/near/stakingpool.js
@@ -1,5 +1,6 @@
 import { getTransactionsForAccount } from '../storage/domainobjectstore.js';
 import { setProgressbarValue } from '../ui/progress-bar.js';
+import { getAccountBalanceAfterTransaction } from './account.js';
 import { retry } from './retry.js';
 import { queryMultipleRPC } from './rpc.js';
 
@@ -170,7 +171,9 @@ export async function fetchAllStakingEarnings(stakingpool_id, account_id, stakin
             }
             
             const stakingBalanceBeforeTransaction = await retry(() => getAccountBalanceInPool(stakingpool_id, account_id, block.header.height), 1);
-            const stakingBalanceAfterTransaction = await retry(() => getAccountBalanceInPool(stakingpool_id, account_id, block.header.height + 10), 1);
+            const { blockdata } = await getAccountBalanceAfterTransaction(account_id, stakingTransaction.hash, block.header.height);
+
+            const stakingBalanceAfterTransaction = await retry(() => getAccountBalanceInPool(stakingpool_id, account_id, blockdata.block.header.height), 1);
 
             const timestamp = new Date(stakingTransaction.block_timestamp / 1_000_000);
             let withdrawal = 0;

--- a/public_html/near/stakingpool.js
+++ b/public_html/near/stakingpool.js
@@ -138,7 +138,7 @@ export async function fetchAllStakingEarnings(stakingpool_id, account_id, stakin
         }
 
         let next_epoch_id = block.header.next_epoch_id;
-        let existingStakingBalanceEntryForNextEpoch = stakingBalanceEntries.find(sbe => block.header.next_epoch_id === sbe.next_epoch_id);
+        let existingStakingBalanceEntryForNextEpoch = stakingBalanceEntries.find(sbe => block.header.next_epoch_id === sbe.epoch_id);
 
         while (existingStakingBalanceEntryForNextEpoch) {
             next_epoch_id = existingStakingBalanceEntryForNextEpoch.epoch_id;

--- a/public_html/near/stakingpool.spec.js
+++ b/public_html/near/stakingpool.spec.js
@@ -19,7 +19,6 @@ describe('stakingpool', () => {
         expect(blockdata.header).to.deep.equal(blockInfo.header);
     });
     it('should fetch staking balances', async function () {
-        this.timeout(60_000);
         const account_id = 'psalomo.near';
         const stakingpool_id = '01node.poolv1.near';
 

--- a/public_html/near/stakingpool.spec.js
+++ b/public_html/near/stakingpool.spec.js
@@ -1,6 +1,7 @@
 import { fetchAllStakingEarnings, findStakingPoolsInTransactions, getAccountBalanceInPool, getBlockData, getBlockInfo, getStakingAccounts } from './stakingpool.js';
 import { getTransactionsToDate } from './account.js';
-import { fetchTransactionsForAccount } from '../storage/domainobjectstore.js';
+import { fetchTransactionsForAccount, writeTransactions } from '../storage/domainobjectstore.js';
+import { stakingBalances } from '../../testdata/stakingbalances.js';
 
 describe('stakingpool', () => {
     it('should get account balance', async function () {
@@ -47,6 +48,140 @@ describe('stakingpool', () => {
                 stakingBalanceEntry.withdrawal
             );
         }
+    });
+
+    it('should not fetch from staking pools with no balance ( should not re-fetch old balances )', async function () {
+        this.timeout(10_000);
+        const account_id = 'petersalomonsen.near';
+        const stakingpool_id = 'dokiacapital.poolv1.near';
+
+        const stakingTransactions = [
+            {
+                block_hash: 'HRNCVGdq8RtbeTEAmyjbjrHSFqAg5sQrMRveaHkALvE5',
+                block_timestamp: '1700805291286078571',
+                hash: 'Gu7kjCsPaoYQUdQpvxHm6L2LvStZ6go7AGFypQWpNCJx',
+                action_index: 0,
+                signer_id: 'dokiacapital.poolv1.near',
+                receiver_id: 'petersalomonsen.near',
+                action_kind: 'TRANSFER',
+                args: { deposit: '107781876121379430562795333' },
+                balance: '140070757487458768247810272'
+            },
+            {
+                block_hash: 'ByGmv11KH9T8N1ULwLMXN31BJ1upMf8Ry5Rfi2v4ZMC4',
+                block_timestamp: '1700805289955243055',
+                hash: 'Gu7kjCsPaoYQUdQpvxHm6L2LvStZ6go7AGFypQWpNCJx',
+                action_index: 0,
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'dokiacapital.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: {
+                    gas: 175000000000000,
+                    deposit: '0',
+                    args_json: {},
+                    method_name: 'withdraw_all'
+                },
+                balance: '140070757487458768247810272'
+            },
+            {
+                block_hash: '9pSfArFzMaVHGL98N4pQZNU5FqCxCgogkfTqiqxHLA5Z',
+                block_timestamp: '1700501307576148206',
+                hash: '8b3CKnA6y7PKHr4TFz6X4ntJ4PHWtQTHpkdtzqkbHL4e',
+                action_index: 0,
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'dokiacapital.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: {
+                    gas: 125000000000000,
+                    deposit: '0',
+                    args_json: {},
+                    method_name: 'unstake_all'
+                },
+                balance: '28550460865852622885014943'
+            },
+            {
+                block_hash: '2BbALSrcbohGrUxujSrDbVYG6TsNKhUE3VBqnNHkAeJ6',
+                block_timestamp: '1670965041080322963',
+                hash: '4syZCwYR9MdRvfPPV1FCt6XPtdSQX2PGyfA58tcbBy4w',
+                action_index: 0,
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'dokiacapital.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: {
+                    gas: 125000000000000,
+                    deposit: '100000000000000000000000000',
+                    args_json: {},
+                    method_name: 'deposit_and_stake'
+                },
+                balance: '35952228543679286747001536'
+            },
+            {
+                block_hash: '991n8RQDRHSMP54aKLorU2thwdU6U6CXzQzB3NQM4H2x',
+                block_timestamp: '1670965004801621827',
+                hash: 'GJof1hwvnEtw3TpV5K9XZwpQfxrYgM2af38EHmdUnZSW',
+                action_index: 0,
+                signer_id: 'dokiacapital.poolv1.near',
+                receiver_id: 'petersalomonsen.near',
+                action_kind: 'TRANSFER',
+                args: { deposit: '111780575950537918979824444' },
+                balance: '135953495946786343047001536'
+            },
+            {
+                block_hash: 'A2rbaqpKfiY3471AfGkxQEB5hLkBKMJYQEdSwBTQEADx',
+                block_timestamp: '1670965003692394709',
+                hash: 'GJof1hwvnEtw3TpV5K9XZwpQfxrYgM2af38EHmdUnZSW',
+                action_index: 0,
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'dokiacapital.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: {
+                    gas: 175000000000000,
+                    deposit: '0',
+                    args_json: {},
+                    method_name: 'withdraw_all'
+                },
+                balance: '135953495946786343047001536'
+            },
+            {
+                block_hash: 'BD7d8dMnUHrUKbwJdmoMminzP89z6GifY3L7WtEVmtmf',
+                block_timestamp: '1670648821661501076',
+                hash: '8EDs6Rn1LPmG5hFopCErGTTYA5YTGxEbNeBNb37Jkrfg',
+                action_index: 0,
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'dokiacapital.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: {
+                    gas: 125000000000000,
+                    deposit: '0',
+                    args_json: {},
+                    method_name: 'unstake_all'
+                },
+                balance: '24190526013605135667177092'
+            },
+            {
+                block_hash: 'BLvLAPGrsdsfN9TfoJzTDqxXgrrnG2hE5RoGUBPCPzay',
+                block_timestamp: '1635612819158468503',
+                hash: 'FShAiHofxY2MA6KEvnPoeQyyP9stAs7n91m3LAGASKPY',
+                action_index: 0,
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'dokiacapital.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: {
+                    gas: 125000000000000,
+                    deposit: '100000000000000000000000000',
+                    args_json: {},
+                    args_base64: 'e30=',
+                    method_name: 'deposit_and_stake'
+                },
+                balance: '57076767884778730300000000'
+            }
+        ];
+        await writeTransactions(account_id, stakingTransactions);
+
+        const first_block = 106501900 + 43_200 * 3;
+        const newStakingBalances = await fetchAllStakingEarnings(stakingpool_id, account_id, stakingBalances, first_block);
+        
+        expect(newStakingBalances.length).to.equal(stakingBalances.length);
     });
 
     it('should identify staking pool accounts in transactions', async function () {

--- a/public_html/near/stakingpool.spec.js
+++ b/public_html/near/stakingpool.spec.js
@@ -1,7 +1,7 @@
 import { fetchAllStakingEarnings, findStakingPoolsInTransactions, getAccountBalanceInPool, getBlockData, getBlockInfo, getStakingAccounts } from './stakingpool.js';
 import { getTransactionsToDate } from './account.js';
 import { fetchTransactionsForAccount, writeTransactions } from '../storage/domainobjectstore.js';
-import { stakingBalances } from '../../testdata/stakingbalances.js';
+import { dokiacapitaltransactions, dokiaCapitalStakingBalances, sweedenpooltransactions, swedenPoolStakingBalances } from '../../testdata/stakingbalances.js';
 
 describe('stakingpool', () => {
     it('should get account balance', async function () {
@@ -55,133 +55,13 @@ describe('stakingpool', () => {
         const account_id = 'petersalomonsen.near';
         const stakingpool_id = 'dokiacapital.poolv1.near';
 
-        const stakingTransactions = [
-            {
-                block_hash: 'HRNCVGdq8RtbeTEAmyjbjrHSFqAg5sQrMRveaHkALvE5',
-                block_timestamp: '1700805291286078571',
-                hash: 'Gu7kjCsPaoYQUdQpvxHm6L2LvStZ6go7AGFypQWpNCJx',
-                action_index: 0,
-                signer_id: 'dokiacapital.poolv1.near',
-                receiver_id: 'petersalomonsen.near',
-                action_kind: 'TRANSFER',
-                args: { deposit: '107781876121379430562795333' },
-                balance: '140070757487458768247810272'
-            },
-            {
-                block_hash: 'ByGmv11KH9T8N1ULwLMXN31BJ1upMf8Ry5Rfi2v4ZMC4',
-                block_timestamp: '1700805289955243055',
-                hash: 'Gu7kjCsPaoYQUdQpvxHm6L2LvStZ6go7AGFypQWpNCJx',
-                action_index: 0,
-                signer_id: 'petersalomonsen.near',
-                receiver_id: 'dokiacapital.poolv1.near',
-                action_kind: 'FUNCTION_CALL',
-                args: {
-                    gas: 175000000000000,
-                    deposit: '0',
-                    args_json: {},
-                    method_name: 'withdraw_all'
-                },
-                balance: '140070757487458768247810272'
-            },
-            {
-                block_hash: '9pSfArFzMaVHGL98N4pQZNU5FqCxCgogkfTqiqxHLA5Z',
-                block_timestamp: '1700501307576148206',
-                hash: '8b3CKnA6y7PKHr4TFz6X4ntJ4PHWtQTHpkdtzqkbHL4e',
-                action_index: 0,
-                signer_id: 'petersalomonsen.near',
-                receiver_id: 'dokiacapital.poolv1.near',
-                action_kind: 'FUNCTION_CALL',
-                args: {
-                    gas: 125000000000000,
-                    deposit: '0',
-                    args_json: {},
-                    method_name: 'unstake_all'
-                },
-                balance: '28550460865852622885014943'
-            },
-            {
-                block_hash: '2BbALSrcbohGrUxujSrDbVYG6TsNKhUE3VBqnNHkAeJ6',
-                block_timestamp: '1670965041080322963',
-                hash: '4syZCwYR9MdRvfPPV1FCt6XPtdSQX2PGyfA58tcbBy4w',
-                action_index: 0,
-                signer_id: 'petersalomonsen.near',
-                receiver_id: 'dokiacapital.poolv1.near',
-                action_kind: 'FUNCTION_CALL',
-                args: {
-                    gas: 125000000000000,
-                    deposit: '100000000000000000000000000',
-                    args_json: {},
-                    method_name: 'deposit_and_stake'
-                },
-                balance: '35952228543679286747001536'
-            },
-            {
-                block_hash: '991n8RQDRHSMP54aKLorU2thwdU6U6CXzQzB3NQM4H2x',
-                block_timestamp: '1670965004801621827',
-                hash: 'GJof1hwvnEtw3TpV5K9XZwpQfxrYgM2af38EHmdUnZSW',
-                action_index: 0,
-                signer_id: 'dokiacapital.poolv1.near',
-                receiver_id: 'petersalomonsen.near',
-                action_kind: 'TRANSFER',
-                args: { deposit: '111780575950537918979824444' },
-                balance: '135953495946786343047001536'
-            },
-            {
-                block_hash: 'A2rbaqpKfiY3471AfGkxQEB5hLkBKMJYQEdSwBTQEADx',
-                block_timestamp: '1670965003692394709',
-                hash: 'GJof1hwvnEtw3TpV5K9XZwpQfxrYgM2af38EHmdUnZSW',
-                action_index: 0,
-                signer_id: 'petersalomonsen.near',
-                receiver_id: 'dokiacapital.poolv1.near',
-                action_kind: 'FUNCTION_CALL',
-                args: {
-                    gas: 175000000000000,
-                    deposit: '0',
-                    args_json: {},
-                    method_name: 'withdraw_all'
-                },
-                balance: '135953495946786343047001536'
-            },
-            {
-                block_hash: 'BD7d8dMnUHrUKbwJdmoMminzP89z6GifY3L7WtEVmtmf',
-                block_timestamp: '1670648821661501076',
-                hash: '8EDs6Rn1LPmG5hFopCErGTTYA5YTGxEbNeBNb37Jkrfg',
-                action_index: 0,
-                signer_id: 'petersalomonsen.near',
-                receiver_id: 'dokiacapital.poolv1.near',
-                action_kind: 'FUNCTION_CALL',
-                args: {
-                    gas: 125000000000000,
-                    deposit: '0',
-                    args_json: {},
-                    method_name: 'unstake_all'
-                },
-                balance: '24190526013605135667177092'
-            },
-            {
-                block_hash: 'BLvLAPGrsdsfN9TfoJzTDqxXgrrnG2hE5RoGUBPCPzay',
-                block_timestamp: '1635612819158468503',
-                hash: 'FShAiHofxY2MA6KEvnPoeQyyP9stAs7n91m3LAGASKPY',
-                action_index: 0,
-                signer_id: 'petersalomonsen.near',
-                receiver_id: 'dokiacapital.poolv1.near',
-                action_kind: 'FUNCTION_CALL',
-                args: {
-                    gas: 125000000000000,
-                    deposit: '100000000000000000000000000',
-                    args_json: {},
-                    args_base64: 'e30=',
-                    method_name: 'deposit_and_stake'
-                },
-                balance: '57076767884778730300000000'
-            }
-        ];
+        const stakingTransactions = dokiacapitaltransactions;
         await writeTransactions(account_id, stakingTransactions);
 
         const first_block = 106501900 + 43_200 * 3;
-        const newStakingBalances = await fetchAllStakingEarnings(stakingpool_id, account_id, stakingBalances, first_block);
+        const newStakingBalances = await fetchAllStakingEarnings(stakingpool_id, account_id, dokiaCapitalStakingBalances, first_block);
         
-        expect(newStakingBalances.length).to.equal(stakingBalances.length);
+        expect(newStakingBalances.length).to.equal(dokiaCapitalStakingBalances.length);
     });
 
     it('should identify staking pool accounts in transactions', async function () {

--- a/public_html/near/stakingpool.spec.js
+++ b/public_html/near/stakingpool.spec.js
@@ -46,6 +46,7 @@ describe('stakingpool', () => {
                 stakingBalanceEntry.deposit -
                 stakingBalanceEntry.withdrawal
             );
+            expect(stakingBalanceEntry.epoch_id).to.equal(stakingBalances[n + 1].next_epoch_id, `${JSON.stringify(stakingBalanceEntry, null, 1)}\n${JSON.stringify(stakingBalances[n + 1], null, 1)}`);
         }
     });
 
@@ -59,7 +60,7 @@ describe('stakingpool', () => {
 
         const first_block = 106501900 + 43_200 * 3;
         const newStakingBalances = await fetchAllStakingEarnings(stakingpool_id, account_id, dokiaCapitalStakingBalances, first_block);
-        
+
         expect(newStakingBalances.length).to.equal(dokiaCapitalStakingBalances.length);
     });
 

--- a/public_html/near/stakingpool.spec.js
+++ b/public_html/near/stakingpool.spec.js
@@ -19,6 +19,7 @@ describe('stakingpool', () => {
         expect(blockdata.header).to.deep.equal(blockInfo.header);
     });
     it('should fetch staking balances', async function () {
+        this.timeout(5 * 60_000);
         const account_id = 'psalomo.near';
         const stakingpool_id = '01node.poolv1.near';
 

--- a/public_html/near/stakingpool.spec.js
+++ b/public_html/near/stakingpool.spec.js
@@ -1,7 +1,7 @@
 import { fetchAllStakingEarnings, findStakingPoolsInTransactions, getAccountBalanceInPool, getBlockData, getBlockInfo, getStakingAccounts } from './stakingpool.js';
 import { getTransactionsToDate } from './account.js';
 import { fetchTransactionsForAccount, writeTransactions } from '../storage/domainobjectstore.js';
-import { dokiacapitaltransactions, dokiaCapitalStakingBalances, sweedenpooltransactions, swedenPoolStakingBalances } from '../../testdata/stakingbalances.js';
+import { dokiacapitaltransactions, dokiaCapitalStakingBalances } from '../../testdata/stakingbalances.js';
 
 describe('stakingpool', () => {
     it('should get account balance', async function () {

--- a/public_html/near/stakingpool.spec.js
+++ b/public_html/near/stakingpool.spec.js
@@ -1,7 +1,7 @@
 import { fetchAllStakingEarnings, findStakingPoolsInTransactions, getAccountBalanceInPool, getBlockData, getBlockInfo, getStakingAccounts } from './stakingpool.js';
 import { getTransactionsToDate } from './account.js';
 import { fetchTransactionsForAccount, writeTransactions } from '../storage/domainobjectstore.js';
-import { dokiacapitaltransactions, dokiaCapitalStakingBalances } from '../../testdata/stakingbalances.js';
+import { dokiacapitaltransactions, dokiaCapitalStakingBalances, nearDevGovStakingBalances } from '../../testdata/stakingbalances.js';
 
 describe('stakingpool', () => {
     it('should get account balance', async function () {
@@ -47,7 +47,9 @@ describe('stakingpool', () => {
                 stakingBalanceEntry.deposit -
                 stakingBalanceEntry.withdrawal
             );
-            expect(stakingBalanceEntry.epoch_id).to.equal(stakingBalances[n + 1].next_epoch_id, `${JSON.stringify(stakingBalanceEntry, null, 1)}\n${JSON.stringify(stakingBalances[n + 1], null, 1)}`);
+            if (stakingBalanceEntry.epoch_id !== stakingBalances[n + 1].epoch_id) {
+                expect(stakingBalanceEntry.epoch_id).to.equal(stakingBalances[n + 1].next_epoch_id, `${JSON.stringify(stakingBalanceEntry, null, 1)}\n${JSON.stringify(stakingBalances[n + 1], null, 1)}`);
+            }
         }
     });
 
@@ -87,6 +89,80 @@ describe('stakingpool', () => {
         ]) {
             expect(stakingAccounts).to.contain(stakingAccount);
         }
+    });
+
+    it('should handle re-staking in the same pool', async function () {
+        const account_id = 'petersalomonsen.near';
+        const stakingpool_id = 'neardevgov.poolv1.near';
+
+        const stakingTransactions = [
+            {
+                block_hash: 'EqvVekayFaKU4qzTBa2hkRRVi4tRZ6TiFbkn5qABr3CX',
+                block_timestamp: '1710577749873416321',
+                hash: 'HQriCRcAbxttRWmz3LCQaRK5os1jaNhPSqda2Rwb5p4f',
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'neardevgov.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: { method_name: 'deposit_and_stake' },
+                block_height: 114812639,
+                balance: '289892893215402145134832152'
+            },
+            {
+                block_hash: '6TN47GHg7k28KDPQL72zRxWBhXcHpUPzWxn9k2vmPy2s',
+                block_timestamp: '1710577671446260276',
+                hash: 'J1zJ7XMaYvFuLyxKxR3kuVFwcCMtb8qoExZkBowHFgRT',
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'neardevgov.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: { method_name: 'withdraw_all' },
+                block_height: 114812581,
+                balance: '389894181702489608434832152'
+            },
+            {
+                block_hash: '5uc7RqzcZGrd1PCqKvzRoeWortesw3Pn318EMn1GRTM5',
+                block_timestamp: '1710341895673443883',
+                hash: '8L9herYruWMnDBpsQLmZUWdnpHp529289dtrbmFUCpo7',
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'neardevgov.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: { method_name: 'unstake_all' },
+                block_height: 114634819,
+                balance: '13016672830145115485299667'
+            },
+            {
+                block_hash: '24Zq2UbijVwD52NXfrR4MKcngZoz239DBWFb6VXgCM2s',
+                block_timestamp: '1688668591697599600',
+                hash: 'Af2ZfAHULc4Eh3KpctLtLARViaqo2c7aXgo5okkLJ7pz',
+                action_index: 0,
+                signer_id: 'petersalomonsen.near',
+                receiver_id: 'neardevgov.poolv1.near',
+                action_kind: 'FUNCTION_CALL',
+                args: {
+                    gas: 125000000000000,
+                    deposit: '350000000000000000000000000',
+                    args_json: {},
+                    method_name: 'deposit_and_stake'
+                },
+                balance: '410368406246815598818050335'
+            }
+        ];
+        await writeTransactions(account_id, stakingTransactions);
+
+        const first_block = 114812639 + 43_200 * 3;
+        const newStakingBalances = await fetchAllStakingEarnings(stakingpool_id, account_id, nearDevGovStakingBalances, first_block);
+
+        const stakingBalancesOnReStakingDate = newStakingBalances.filter(st => st.timestamp.toJSON && st.timestamp.toJSON().startsWith('2024-03-16'));
+        let sumEarnings = 0;
+        let sumDeposit = 0;
+        let sumWithdrawal = 0;
+        for (const stakingBalance of stakingBalancesOnReStakingDate) {
+            sumEarnings += stakingBalance.earnings;
+            sumDeposit += stakingBalance.deposit;
+            sumWithdrawal += stakingBalance.withdrawal;
+        }
+        expect(sumEarnings).to.equal(0);
+        expect(sumWithdrawal / 1e+24).to.be.closeTo(376.885366, 0.0001);
+        expect(sumDeposit).to.equal(100 * 1e+24);
     });
 
 });

--- a/public_html/pricedata/pricedata.js
+++ b/public_html/pricedata/pricedata.js
@@ -1,4 +1,5 @@
 import { fetchFromArizGateway } from "../arizgateway/arizgatewayaccess.js";
+import { getFromNearBlocks } from "../near/nearblocks.js";
 import { getCustomExchangeRates, setCustomExchangeRates, getHistoricalPriceData, setHistoricalPriceData, getCurrencyList as getStoredCurrencyList, setCurrencyList } from "../storage/domainobjectstore.js";
 import { modalAlert, modalYesNo } from "../ui/modal.js";
 
@@ -21,7 +22,7 @@ export async function fetchHistoricalPricesFromArizGateway({ baseToken = "near",
 }
 
 export async function fetchNEARHistoricalPricesFromNearBlocks() {
-    const chartdata = await fetch('https://api.nearblocks.io/v1/charts').then(r => r.json());
+    const chartdata = await getFromNearBlocks('/v1/charts');
     const pricedata = await getHistoricalPriceData(defaultToken, 'USD');
     chartdata.charts.forEach(dayEntry => pricedata[dayEntry.date.substring(0, 'yyyy-MM-dd'.length)] = Number(dayEntry.near_price));
     await setHistoricalPriceData(defaultToken, 'USD', pricedata);

--- a/public_html/yearreport/yearreport-table-renderer.spec.js
+++ b/public_html/yearreport/yearreport-table-renderer.spec.js
@@ -21,7 +21,6 @@ describe('year-report-table-renderer', () => {
     });
 
     it('should render table for year report', async function () {
-        this.timeout(2 * 60000);
         const account = 'psalomo.near';
         const startDate = new Date(2021, 4, 1);
         await setAccounts([account]);
@@ -54,7 +53,6 @@ describe('year-report-table-renderer', () => {
     });
 
     it('should render table for period report', async function () {
-        this.timeout(2 * 60000);
         const account = 'psalomo.near';
         const startDate = new Date(2021, 4, 1);
         await setAccounts([account]);
@@ -85,7 +83,6 @@ describe('year-report-table-renderer', () => {
     });
 
     it('should render table for period report', async function () {
-        this.timeout(2 * 60000);
         const account = 'psalomo.near';
         const startDate = new Date(2021, 4, 1);
         await setAccounts([account]);

--- a/testdata/stakingbalances.js
+++ b/testdata/stakingbalances.js
@@ -12939,3 +12939,7628 @@ export const dokiacapitaltransactions = [
         balance: '57076767884778730300000000'
     }
 ];
+
+export const nearDevGovStakingBalances = [
+    {
+        "timestamp": "2024-09-15T06:41:10.278Z",
+        "balance": 1.0356271045777196e+26,
+        "block_height": 128091761,
+        "epoch_id": "EUVYKXbDnaySkZUReEbA37oCGhggGC7iYFZhpobc5Y4w",
+        "next_epoch_id": "EQ4R81dVRvRWgb3nEAZj3juWUEDmWeuNfpvAkrXJxtYj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2422784702995981e+22
+    },
+    {
+        "timestamp": "2024-09-14T09:00:56.157Z",
+        "balance": 1.0355028767306896e+26,
+        "block_height": 128021278,
+        "epoch_id": "BcFvqvsf36V2VVWRTU1NbaZDjcmT9rrTgm4UDH5LLb1Y",
+        "next_epoch_id": "EUVYKXbDnaySkZUReEbA37oCGhggGC7iYFZhpobc5Y4w",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2413738435035089e+22
+    },
+    {
+        "timestamp": "2024-09-13T20:17:28.177Z",
+        "balance": 1.0353787393463393e+26,
+        "block_height": 127979919,
+        "epoch_id": "29oyp3KqVtx2S3Pmo5XATKmSAGnY2qgHapJ8mnEgQaeZ",
+        "next_epoch_id": "BcFvqvsf36V2VVWRTU1NbaZDjcmT9rrTgm4UDH5LLb1Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2467857837559837e+22
+    },
+    {
+        "timestamp": "2024-09-13T17:56:03.535Z",
+        "balance": 1.0352540607679637e+26,
+        "block_height": 127972310,
+        "epoch_id": "4duFpgwcxHjtyc8CX1uEJtovduKYEZWWfMzGGLyjx22i",
+        "next_epoch_id": "29oyp3KqVtx2S3Pmo5XATKmSAGnY2qgHapJ8mnEgQaeZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.248300246404312e+22
+    },
+    {
+        "timestamp": "2024-09-12T19:44:53.798Z",
+        "balance": 1.0351292307433232e+26,
+        "block_height": 127900411,
+        "epoch_id": "5XizAVFY85eUEuWGrrGj6pdELSEob9iGJL8Fh1johJB8",
+        "next_epoch_id": "4duFpgwcxHjtyc8CX1uEJtovduKYEZWWfMzGGLyjx22i",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2954638260245476e+22
+    },
+    {
+        "timestamp": "2024-09-12T15:14:35.277Z",
+        "balance": 1.0349996843607208e+26,
+        "block_height": 127885910,
+        "epoch_id": "28QA1pJVtzYJ4eRiBvDEZeohmFZ3uG2e9qNW2bTBDJvs",
+        "next_epoch_id": "5XizAVFY85eUEuWGrrGj6pdELSEob9iGJL8Fh1johJB8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.629737691513803e+22
+    },
+    {
+        "timestamp": "2024-09-11T11:17:43.080Z",
+        "balance": 1.0347367105915694e+26,
+        "block_height": 127799510,
+        "epoch_id": "7TUPSvHkWBZS81zzqHi16C2PheG7dJ6svjyvXeH5vWmk",
+        "next_epoch_id": "EsEQwWtjtURiwejU64TR5CVR37kCv6fWi5nN7W4yVRCs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-11T11:17:43.080Z",
+        "balance": 1.0347367105915694e+26,
+        "block_height": 127799510,
+        "epoch_id": "7TUPSvHkWBZS81zzqHi16C2PheG7dJ6svjyvXeH5vWmk",
+        "next_epoch_id": "EsEQwWtjtURiwejU64TR5CVR37kCv6fWi5nN7W4yVRCs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2701351282094652e+22
+    },
+    {
+        "timestamp": "2024-09-10T21:20:21.682Z",
+        "balance": 1.0346096970787484e+26,
+        "block_height": 127756310,
+        "epoch_id": "EuzPvfoXd71sfgPRVoiGME3muncV5h3bhkJMc8bm3CCp",
+        "next_epoch_id": "7TUPSvHkWBZS81zzqHi16C2PheG7dJ6svjyvXeH5vWmk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-10T21:20:21.682Z",
+        "balance": 1.0346096970787484e+26,
+        "block_height": 127756310,
+        "epoch_id": "EuzPvfoXd71sfgPRVoiGME3muncV5h3bhkJMc8bm3CCp",
+        "next_epoch_id": "7TUPSvHkWBZS81zzqHi16C2PheG7dJ6svjyvXeH5vWmk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.566250342139058e+22
+    },
+    {
+        "timestamp": "2024-09-09T18:01:07.838Z",
+        "balance": 1.0343530720445345e+26,
+        "block_height": 127669910,
+        "epoch_id": "5LKoXYXUkWH9TryL4d7DM5DKLZiEMNnjUCSPrxhsA5Y3",
+        "next_epoch_id": "A6faGmnyqHh6gZYa8bX8NjrPuPYqY3eG1TtzDS67GXp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-09T18:01:07.838Z",
+        "balance": 1.0343530720445345e+26,
+        "block_height": 127669910,
+        "epoch_id": "5LKoXYXUkWH9TryL4d7DM5DKLZiEMNnjUCSPrxhsA5Y3",
+        "next_epoch_id": "A6faGmnyqHh6gZYa8bX8NjrPuPYqY3eG1TtzDS67GXp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2576669888767595e+22
+    },
+    {
+        "timestamp": "2024-09-09T04:43:01.339Z",
+        "balance": 1.0342273053456469e+26,
+        "block_height": 127626710,
+        "epoch_id": "E6ZuoRwoYsbcTkDVRVStQ4TLJCEtQCd4zkFqfCfgM9e8",
+        "next_epoch_id": "5LKoXYXUkWH9TryL4d7DM5DKLZiEMNnjUCSPrxhsA5Y3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-09T04:43:01.339Z",
+        "balance": 1.0342273053456469e+26,
+        "block_height": 127626710,
+        "epoch_id": "E6ZuoRwoYsbcTkDVRVStQ4TLJCEtQCd4zkFqfCfgM9e8",
+        "next_epoch_id": "5LKoXYXUkWH9TryL4d7DM5DKLZiEMNnjUCSPrxhsA5Y3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.5597301175733566e+22
+    },
+    {
+        "timestamp": "2024-09-08T01:47:25.708Z",
+        "balance": 1.0339713323338895e+26,
+        "block_height": 127540310,
+        "epoch_id": "8f5hSjPaLSh9eVyq8heVpoVsuWGDUwfb44gvTW51gez8",
+        "next_epoch_id": "DSRM4oErXpURAktMb8N3VTCuumhxmBR6fDFcPtzsZqfa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-08T01:47:25.708Z",
+        "balance": 1.0339713323338895e+26,
+        "block_height": 127540310,
+        "epoch_id": "8f5hSjPaLSh9eVyq8heVpoVsuWGDUwfb44gvTW51gez8",
+        "next_epoch_id": "DSRM4oErXpURAktMb8N3VTCuumhxmBR6fDFcPtzsZqfa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2855086003565474e+22
+    },
+    {
+        "timestamp": "2024-09-07T12:15:54.335Z",
+        "balance": 1.0338427814738539e+26,
+        "block_height": 127497110,
+        "epoch_id": "EmXfxjWYb4nhcuNzXjorqysMHCj1MBRxyLiju4GtefLc",
+        "next_epoch_id": "8f5hSjPaLSh9eVyq8heVpoVsuWGDUwfb44gvTW51gez8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-07T12:15:54.335Z",
+        "balance": 1.0338427814738539e+26,
+        "block_height": 127497110,
+        "epoch_id": "EmXfxjWYb4nhcuNzXjorqysMHCj1MBRxyLiju4GtefLc",
+        "next_epoch_id": "8f5hSjPaLSh9eVyq8heVpoVsuWGDUwfb44gvTW51gez8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.6167538575881703e+22
+    },
+    {
+        "timestamp": "2024-09-06T09:08:08.252Z",
+        "balance": 1.033581106088095e+26,
+        "block_height": 127410710,
+        "epoch_id": "53f9XpSxYhvMmg3QoUDCHEcKKL2U3DgXUumWzY2jQUYw",
+        "next_epoch_id": "Bjssb1BBQaEm45VKEpp8ZtfuvEnMWdn9KFs87wUxijji",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-06T09:08:08.252Z",
+        "balance": 1.033581106088095e+26,
+        "block_height": 127410710,
+        "epoch_id": "53f9XpSxYhvMmg3QoUDCHEcKKL2U3DgXUumWzY2jQUYw",
+        "next_epoch_id": "Bjssb1BBQaEm45VKEpp8ZtfuvEnMWdn9KFs87wUxijji",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.375409635807523e+22
+    },
+    {
+        "timestamp": "2024-09-05T19:00:01.931Z",
+        "balance": 1.0334435651245143e+26,
+        "block_height": 127367510,
+        "epoch_id": "Hy1dhpHQLQASUdGuEJqYdxJqzhHLCDZojHPVu2BBG7pc",
+        "next_epoch_id": "53f9XpSxYhvMmg3QoUDCHEcKKL2U3DgXUumWzY2jQUYw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-05T19:00:01.931Z",
+        "balance": 1.0334435651245143e+26,
+        "block_height": 127367510,
+        "epoch_id": "Hy1dhpHQLQASUdGuEJqYdxJqzhHLCDZojHPVu2BBG7pc",
+        "next_epoch_id": "53f9XpSxYhvMmg3QoUDCHEcKKL2U3DgXUumWzY2jQUYw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.5827340024982394e+22
+    },
+    {
+        "timestamp": "2024-09-04T14:10:57.001Z",
+        "balance": 1.0331852917242645e+26,
+        "block_height": 127281110,
+        "epoch_id": "6QKmvuZcPLLZXyyBJst68kz5ayyvKQA676KmxcuisB5f",
+        "next_epoch_id": "3hmqJ7Stifr7D9MewDik5ct6iUZYDsSfENbP39bu4YW1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-04T14:10:57.001Z",
+        "balance": 1.0331852917242645e+26,
+        "block_height": 127281110,
+        "epoch_id": "6QKmvuZcPLLZXyyBJst68kz5ayyvKQA676KmxcuisB5f",
+        "next_epoch_id": "3hmqJ7Stifr7D9MewDik5ct6iUZYDsSfENbP39bu4YW1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2760205659735643e+22
+    },
+    {
+        "timestamp": "2024-09-04T00:44:33.755Z",
+        "balance": 1.0330576896676671e+26,
+        "block_height": 127237910,
+        "epoch_id": "F3MsVSNPZM3ph2STPN1sRxiYoR7G4eB3kE9DLDRUCoz2",
+        "next_epoch_id": "6QKmvuZcPLLZXyyBJst68kz5ayyvKQA676KmxcuisB5f",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-04T00:44:33.755Z",
+        "balance": 1.0330576896676671e+26,
+        "block_height": 127237910,
+        "epoch_id": "F3MsVSNPZM3ph2STPN1sRxiYoR7G4eB3kE9DLDRUCoz2",
+        "next_epoch_id": "6QKmvuZcPLLZXyyBJst68kz5ayyvKQA676KmxcuisB5f",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.537577824535557e+22
+    },
+    {
+        "timestamp": "2024-09-02T21:42:03.877Z",
+        "balance": 1.0328039318852136e+26,
+        "block_height": 127151510,
+        "epoch_id": "HKYto62ZJUT8cBX1rB43XLxSNRXrsebJrGPvTvKmjQej",
+        "next_epoch_id": "Ak7FX6fbJ32kwv9yonhMDPS316R7r1devPYEwZtfsdQg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-02T21:42:03.877Z",
+        "balance": 1.0328039318852136e+26,
+        "block_height": 127151510,
+        "epoch_id": "HKYto62ZJUT8cBX1rB43XLxSNRXrsebJrGPvTvKmjQej",
+        "next_epoch_id": "Ak7FX6fbJ32kwv9yonhMDPS316R7r1devPYEwZtfsdQg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2694431749567846e+22
+    },
+    {
+        "timestamp": "2024-09-02T08:11:37.775Z",
+        "balance": 1.0326769875677179e+26,
+        "block_height": 127108310,
+        "epoch_id": "CTpotscZooSwUpDzNfJMbDmwSZhqzzoQsQnd6SNTMhH6",
+        "next_epoch_id": "HKYto62ZJUT8cBX1rB43XLxSNRXrsebJrGPvTvKmjQej",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-02T08:11:37.775Z",
+        "balance": 1.0326769875677179e+26,
+        "block_height": 127108310,
+        "epoch_id": "CTpotscZooSwUpDzNfJMbDmwSZhqzzoQsQnd6SNTMhH6",
+        "next_epoch_id": "HKYto62ZJUT8cBX1rB43XLxSNRXrsebJrGPvTvKmjQej",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.55300375971675e+22
+    },
+    {
+        "timestamp": "2024-09-01T05:10:45.596Z",
+        "balance": 1.0324216871917462e+26,
+        "block_height": 127021910,
+        "epoch_id": "CLWbunbnu93k1TMdC9ifPmymJEJSR73soQdJF9znqBMy",
+        "next_epoch_id": "7w1ScKPsVS1hmjVd7eCwqtgWFUW9JbtLe2HdGivinoym",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-09-01T05:10:45.596Z",
+        "balance": 1.0324216871917462e+26,
+        "block_height": 127021910,
+        "epoch_id": "CLWbunbnu93k1TMdC9ifPmymJEJSR73soQdJF9znqBMy",
+        "next_epoch_id": "7w1ScKPsVS1hmjVd7eCwqtgWFUW9JbtLe2HdGivinoym",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3261123961337657e+22
+    },
+    {
+        "timestamp": "2024-08-31T15:42:13.095Z",
+        "balance": 1.0322890759521328e+26,
+        "block_height": 126978710,
+        "epoch_id": "5mdXXT7peakSchQ8QZwugFpMbLosDKEUh98dkAXdUdkx",
+        "next_epoch_id": "CLWbunbnu93k1TMdC9ifPmymJEJSR73soQdJF9znqBMy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-31T15:42:13.095Z",
+        "balance": 1.0322890759521328e+26,
+        "block_height": 126978710,
+        "epoch_id": "5mdXXT7peakSchQ8QZwugFpMbLosDKEUh98dkAXdUdkx",
+        "next_epoch_id": "CLWbunbnu93k1TMdC9ifPmymJEJSR73soQdJF9znqBMy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.5935631587881146e+22
+    },
+    {
+        "timestamp": "2024-08-30T11:23:53.876Z",
+        "balance": 1.032029719636254e+26,
+        "block_height": 126892310,
+        "epoch_id": "8m62bPdu4Wmh5EEyLWEJyXybTxhVzpTnvYVwg4Sxwcdn",
+        "next_epoch_id": "FqfESvDE4WBUvbChAZu4DrpHnDmjj6TM2GvLQC2Kx3hD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-30T11:23:53.876Z",
+        "balance": 1.032029719636254e+26,
+        "block_height": 126892310,
+        "epoch_id": "8m62bPdu4Wmh5EEyLWEJyXybTxhVzpTnvYVwg4Sxwcdn",
+        "next_epoch_id": "FqfESvDE4WBUvbChAZu4DrpHnDmjj6TM2GvLQC2Kx3hD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.29177252983212e+22
+    },
+    {
+        "timestamp": "2024-08-29T21:58:41.786Z",
+        "balance": 1.0319005423832708e+26,
+        "block_height": 126849110,
+        "epoch_id": "NBDCDHBwqzWwL7SV16yku4QTzcDdBeHMgcE1iedE6iV",
+        "next_epoch_id": "8m62bPdu4Wmh5EEyLWEJyXybTxhVzpTnvYVwg4Sxwcdn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-29T21:58:41.786Z",
+        "balance": 1.0319005423832708e+26,
+        "block_height": 126849110,
+        "epoch_id": "NBDCDHBwqzWwL7SV16yku4QTzcDdBeHMgcE1iedE6iV",
+        "next_epoch_id": "8m62bPdu4Wmh5EEyLWEJyXybTxhVzpTnvYVwg4Sxwcdn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.788455716883939e+22
+    },
+    {
+        "timestamp": "2024-08-28T17:42:43.974Z",
+        "balance": 1.0316216968115824e+26,
+        "block_height": 126762710,
+        "epoch_id": "8j2zNnZ4A14vBpzDWCADkqWkGETWDYv34gbe2qsxj3c2",
+        "next_epoch_id": "8KDSDTFcXC5yFu6MhhwRWAiVHkv5yPMMZX8BEUPPj53b",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-28T17:42:43.974Z",
+        "balance": 1.0316216968115824e+26,
+        "block_height": 126762710,
+        "epoch_id": "8j2zNnZ4A14vBpzDWCADkqWkGETWDYv34gbe2qsxj3c2",
+        "next_epoch_id": "8KDSDTFcXC5yFu6MhhwRWAiVHkv5yPMMZX8BEUPPj53b",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3417740638557387e+22
+    },
+    {
+        "timestamp": "2024-08-28T02:08:26.851Z",
+        "balance": 1.0314875194051968e+26,
+        "block_height": 126719510,
+        "epoch_id": "77hs6VzhsqCDnjQrwK43oVYs1CEL2rL5Ci8e22nT8PtG",
+        "next_epoch_id": "8j2zNnZ4A14vBpzDWCADkqWkGETWDYv34gbe2qsxj3c2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-28T02:08:26.851Z",
+        "balance": 1.0314875194051968e+26,
+        "block_height": 126719510,
+        "epoch_id": "77hs6VzhsqCDnjQrwK43oVYs1CEL2rL5Ci8e22nT8PtG",
+        "next_epoch_id": "8j2zNnZ4A14vBpzDWCADkqWkGETWDYv34gbe2qsxj3c2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.6411680104333194e+22
+    },
+    {
+        "timestamp": "2024-08-26T20:20:18.442Z",
+        "balance": 1.0312234026041535e+26,
+        "block_height": 126633110,
+        "epoch_id": "7TUMhAaJWjRSvCxQEeBpZHpDbsoLduKH3RKrJg3Wc94h",
+        "next_epoch_id": "BHdsRtTtnwYU6GiNpBbvQEwP84kg859ACfCDesoNtPsS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-26T20:20:18.442Z",
+        "balance": 1.0312234026041535e+26,
+        "block_height": 126633110,
+        "epoch_id": "7TUMhAaJWjRSvCxQEeBpZHpDbsoLduKH3RKrJg3Wc94h",
+        "next_epoch_id": "BHdsRtTtnwYU6GiNpBbvQEwP84kg859ACfCDesoNtPsS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3014516017765768e+22
+    },
+    {
+        "timestamp": "2024-08-26T06:22:40.593Z",
+        "balance": 1.0310932574439759e+26,
+        "block_height": 126589910,
+        "epoch_id": "6GeyMPzcvygT1TR1HZ57irtUyoQp653TsCmEsTr6FXWM",
+        "next_epoch_id": "7TUMhAaJWjRSvCxQEeBpZHpDbsoLduKH3RKrJg3Wc94h",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-26T06:22:40.593Z",
+        "balance": 1.0310932574439759e+26,
+        "block_height": 126589910,
+        "epoch_id": "6GeyMPzcvygT1TR1HZ57irtUyoQp653TsCmEsTr6FXWM",
+        "next_epoch_id": "7TUMhAaJWjRSvCxQEeBpZHpDbsoLduKH3RKrJg3Wc94h",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.6103530251624544e+22
+    },
+    {
+        "timestamp": "2024-08-25T02:39:49.633Z",
+        "balance": 1.0308322221414596e+26,
+        "block_height": 126503510,
+        "epoch_id": "22gPTjMx2nDY8uDD4JnHkPeAcC9RQisVT2CHzN7NeU46",
+        "next_epoch_id": "5N2LT1giyRHFbV7ig6wsRLho9E7WqnFGBAawoiHgk7Jv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-25T02:39:49.633Z",
+        "balance": 1.0308322221414596e+26,
+        "block_height": 126503510,
+        "epoch_id": "22gPTjMx2nDY8uDD4JnHkPeAcC9RQisVT2CHzN7NeU46",
+        "next_epoch_id": "5N2LT1giyRHFbV7ig6wsRLho9E7WqnFGBAawoiHgk7Jv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.333349064030904e+22
+    },
+    {
+        "timestamp": "2024-08-24T12:46:25.765Z",
+        "balance": 1.0306988872350565e+26,
+        "block_height": 126460310,
+        "epoch_id": "HHH1WrnbVqukcCoT8oA1qw8ESqTExKarTmK8KZy7VQoR",
+        "next_epoch_id": "22gPTjMx2nDY8uDD4JnHkPeAcC9RQisVT2CHzN7NeU46",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-24T12:46:25.765Z",
+        "balance": 1.0306988872350565e+26,
+        "block_height": 126460310,
+        "epoch_id": "HHH1WrnbVqukcCoT8oA1qw8ESqTExKarTmK8KZy7VQoR",
+        "next_epoch_id": "22gPTjMx2nDY8uDD4JnHkPeAcC9RQisVT2CHzN7NeU46",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.7231248113223284e+22
+    },
+    {
+        "timestamp": "2024-08-23T08:06:56.990Z",
+        "balance": 1.0304265747539243e+26,
+        "block_height": 126373910,
+        "epoch_id": "B4eU2bj2b9dsuuZbKby1CfSTp7TiuEPppE85rhuZbTfX",
+        "next_epoch_id": "BFi2K9pszHyDDDi3NAXjnFg47fVD7MRUtyC3xT35har7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-23T08:06:56.990Z",
+        "balance": 1.0304265747539243e+26,
+        "block_height": 126373910,
+        "epoch_id": "B4eU2bj2b9dsuuZbKby1CfSTp7TiuEPppE85rhuZbTfX",
+        "next_epoch_id": "BFi2K9pszHyDDDi3NAXjnFg47fVD7MRUtyC3xT35har7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3887070288697637e+22
+    },
+    {
+        "timestamp": "2024-08-22T17:44:43.190Z",
+        "balance": 1.0302877040510373e+26,
+        "block_height": 126330710,
+        "epoch_id": "5bH4JCVAnVFqKsf21cYGFDTBRAAAmzneofoqG68RUDZR",
+        "next_epoch_id": "B4eU2bj2b9dsuuZbKby1CfSTp7TiuEPppE85rhuZbTfX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-22T17:44:43.190Z",
+        "balance": 1.0302877040510373e+26,
+        "block_height": 126330710,
+        "epoch_id": "5bH4JCVAnVFqKsf21cYGFDTBRAAAmzneofoqG68RUDZR",
+        "next_epoch_id": "B4eU2bj2b9dsuuZbKby1CfSTp7TiuEPppE85rhuZbTfX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.774060855586461e+22
+    },
+    {
+        "timestamp": "2024-08-21T12:19:43.370Z",
+        "balance": 1.0300102979654787e+26,
+        "block_height": 126244310,
+        "epoch_id": "AmuwyKGsgEWcXU31ktyxy2uNWcWYGZydGpfpsVjhu8Ym",
+        "next_epoch_id": "FenaGUEYq82grSD1BVpXpi9Hn8YpPhUTG6qR69bczAfb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-21T12:19:43.370Z",
+        "balance": 1.0300102979654787e+26,
+        "block_height": 126244310,
+        "epoch_id": "AmuwyKGsgEWcXU31ktyxy2uNWcWYGZydGpfpsVjhu8Ym",
+        "next_epoch_id": "FenaGUEYq82grSD1BVpXpi9Hn8YpPhUTG6qR69bczAfb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3974273562946124e+22
+    },
+    {
+        "timestamp": "2024-08-20T21:31:03.342Z",
+        "balance": 1.0298705552298492e+26,
+        "block_height": 126201110,
+        "epoch_id": "6oFrtvnMRCnPxCg843aYKnexCfzuZuKhVfyfFTmGwkME",
+        "next_epoch_id": "AmuwyKGsgEWcXU31ktyxy2uNWcWYGZydGpfpsVjhu8Ym",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-20T21:31:03.342Z",
+        "balance": 1.0298705552298492e+26,
+        "block_height": 126201110,
+        "epoch_id": "6oFrtvnMRCnPxCg843aYKnexCfzuZuKhVfyfFTmGwkME",
+        "next_epoch_id": "AmuwyKGsgEWcXU31ktyxy2uNWcWYGZydGpfpsVjhu8Ym",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.8084724110117464e+22
+    },
+    {
+        "timestamp": "2024-08-19T15:35:45.081Z",
+        "balance": 1.029589707988748e+26,
+        "block_height": 126114710,
+        "epoch_id": "FLoyGVLT7sT4zCC83LBzGGjfKX6RMnyCXvvgWmKYj2y3",
+        "next_epoch_id": "AgWuQ63hT2NJaP1Whf6ps66KsSE3ZYrf8HVyU7L7ntK3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-19T15:35:45.081Z",
+        "balance": 1.029589707988748e+26,
+        "block_height": 126114710,
+        "epoch_id": "FLoyGVLT7sT4zCC83LBzGGjfKX6RMnyCXvvgWmKYj2y3",
+        "next_epoch_id": "AgWuQ63hT2NJaP1Whf6ps66KsSE3ZYrf8HVyU7L7ntK3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3951243882712231e+22
+    },
+    {
+        "timestamp": "2024-08-19T00:30:29.014Z",
+        "balance": 1.0294501955499209e+26,
+        "block_height": 126071510,
+        "epoch_id": "66TMxzpPg2kbsBrsHRmSwASBnZoSpnRu86M8M2s5VKMP",
+        "next_epoch_id": "FLoyGVLT7sT4zCC83LBzGGjfKX6RMnyCXvvgWmKYj2y3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-19T00:30:29.014Z",
+        "balance": 1.0294501955499209e+26,
+        "block_height": 126071510,
+        "epoch_id": "66TMxzpPg2kbsBrsHRmSwASBnZoSpnRu86M8M2s5VKMP",
+        "next_epoch_id": "FLoyGVLT7sT4zCC83LBzGGjfKX6RMnyCXvvgWmKYj2y3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.823585246324056e+22
+    },
+    {
+        "timestamp": "2024-08-17T18:24:50.765Z",
+        "balance": 1.0291678370252885e+26,
+        "block_height": 125985110,
+        "epoch_id": "24hCEVfhzw9DP5E9rgvvrRzWdQcwwHkMiff8wQUVev9z",
+        "next_epoch_id": "49ku2iqX7g743TxyDbQr3CQBVfuvkbEttXzprQUmXk8j",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-17T07:05:55.581Z",
+        "balance": 1.0291678370252885e+26,
+        "block_height": 125952740,
+        "epoch_id": "24hCEVfhzw9DP5E9rgvvrRzWdQcwwHkMiff8wQUVev9z",
+        "next_epoch_id": "49ku2iqX7g743TxyDbQr3CQBVfuvkbEttXzprQUmXk8j",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 25862712508547070
+    },
+    {
+        "timestamp": "2024-08-17T03:18:39.881Z",
+        "balance": 1.0291678367666614e+26,
+        "block_height": 125941910,
+        "epoch_id": "Bgn9RA3wW1S8b2ucsBXFDgT1hnRfg1QPKG2BhvqKk649",
+        "next_epoch_id": "24hCEVfhzw9DP5E9rgvvrRzWdQcwwHkMiff8wQUVev9z",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-08-17T03:18:39.881Z",
+        "balance": 1.0291678367666614e+26,
+        "block_height": 125941910,
+        "epoch_id": "Bgn9RA3wW1S8b2ucsBXFDgT1hnRfg1QPKG2BhvqKk649",
+        "next_epoch_id": "24hCEVfhzw9DP5E9rgvvrRzWdQcwwHkMiff8wQUVev9z",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 34356474192855040
+    },
+    {
+        "timestamp": "2024-08-16T12:12:57.023Z",
+        "balance": 1.0291678364230966e+26,
+        "block_height": 125898710,
+        "epoch_id": "GF4xWos1sr4cTAWtyowRGdrph39hWKGMuFp7C53zXm6F",
+        "next_epoch_id": "Bgn9RA3wW1S8b2ucsBXFDgT1hnRfg1QPKG2BhvqKk649",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 226171981374947330
+    },
+    {
+        "timestamp": "2024-08-15T20:34:57.704Z",
+        "balance": 1.0291678341613768e+26,
+        "block_height": 125855510,
+        "epoch_id": "6SkzTzMMLmxoHfRUEmS9pUtLRDJVJd2GevDj33TFwopc",
+        "next_epoch_id": "GF4xWos1sr4cTAWtyowRGdrph39hWKGMuFp7C53zXm6F",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2706002699395246e+22
+    },
+    {
+        "timestamp": "2024-08-15T04:25:02.573Z",
+        "balance": 1.0290407741343829e+26,
+        "block_height": 125812310,
+        "epoch_id": "8H5bxjKfyCBvPpsg9B7sU6MeftkGAzumxXcLvHbSzmAa",
+        "next_epoch_id": "6SkzTzMMLmxoHfRUEmS9pUtLRDJVJd2GevDj33TFwopc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3575174627334623e+22
+    },
+    {
+        "timestamp": "2024-08-14T15:14:31.257Z",
+        "balance": 1.0289050223881095e+26,
+        "block_height": 125769110,
+        "epoch_id": "EF37AN63EfwDrUvbwbwtZpUFSz358yUvRRLHyphi13UG",
+        "next_epoch_id": "8H5bxjKfyCBvPpsg9B7sU6MeftkGAzumxXcLvHbSzmAa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.384221434946171e+22
+    },
+    {
+        "timestamp": "2024-08-14T00:44:31.610Z",
+        "balance": 1.0287666002446149e+26,
+        "block_height": 125725910,
+        "epoch_id": "BqCBXdfMSbpYjkwCeZyFTehLuEEjUQp9tHXoPpfTNjaD",
+        "next_epoch_id": "EF37AN63EfwDrUvbwbwtZpUFSz358yUvRRLHyphi13UG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.25369304772417e+22
+    },
+    {
+        "timestamp": "2024-08-13T09:57:12.946Z",
+        "balance": 1.0286412309398425e+26,
+        "block_height": 125682710,
+        "epoch_id": "2BnhtYbEAPaDzj8X9rCWcNcUSF5SmXJVB3TbzFhjbVyi",
+        "next_epoch_id": "BqCBXdfMSbpYjkwCeZyFTehLuEEjUQp9tHXoPpfTNjaD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2817255303801167e+22
+    },
+    {
+        "timestamp": "2024-08-12T20:33:33.381Z",
+        "balance": 1.0285130583868045e+26,
+        "block_height": 125639510,
+        "epoch_id": "6akQNDLDrrmwKoPEnmhuKh2Rv277YyUepRkdkrKVJeEV",
+        "next_epoch_id": "2BnhtYbEAPaDzj8X9rCWcNcUSF5SmXJVB3TbzFhjbVyi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2400400048561284e+22
+    },
+    {
+        "timestamp": "2024-08-12T06:52:40.886Z",
+        "balance": 1.0283890543863189e+26,
+        "block_height": 125596310,
+        "epoch_id": "ArcjWerkFgALYBiS4d1gWckfU4oyX5NahNVv3TXatKf7",
+        "next_epoch_id": "6akQNDLDrrmwKoPEnmhuKh2Rv277YyUepRkdkrKVJeEV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2451370380119712e+22
+    },
+    {
+        "timestamp": "2024-08-11T17:39:01.319Z",
+        "balance": 1.0282645406825177e+26,
+        "block_height": 125553110,
+        "epoch_id": "3jWmJ8WTUkeEs4KcLMXWKL8Y5Jk9EsRmz9Vehn6f4fsr",
+        "next_epoch_id": "ArcjWerkFgALYBiS4d1gWckfU4oyX5NahNVv3TXatKf7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2424729849411817e+22
+    },
+    {
+        "timestamp": "2024-08-11T04:24:17.080Z",
+        "balance": 1.0281402933840235e+26,
+        "block_height": 125509910,
+        "epoch_id": "DBYpW1MUAuCU6SJUvwFP6qiVaTLTdWNaW7jiKpE4tT6p",
+        "next_epoch_id": "3jWmJ8WTUkeEs4KcLMXWKL8Y5Jk9EsRmz9Vehn6f4fsr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2504848119976457e+22
+    },
+    {
+        "timestamp": "2024-08-10T15:09:52.920Z",
+        "balance": 1.0280152449028238e+26,
+        "block_height": 125466710,
+        "epoch_id": "wWvS91hoGZNJBVyshMcNTwY7hsq7XFDUgdeDrhoTBwa",
+        "next_epoch_id": "DBYpW1MUAuCU6SJUvwFP6qiVaTLTdWNaW7jiKpE4tT6p",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2785006785418156e+22
+    },
+    {
+        "timestamp": "2024-08-09T16:58:57.800Z",
+        "balance": 1.0278873948349696e+26,
+        "block_height": 125395149,
+        "epoch_id": "8wJaQgywixTtmxEx51CYE8q1n6pFZDNv5ZYR7C4JN6sX",
+        "next_epoch_id": "wWvS91hoGZNJBVyshMcNTwY7hsq7XFDUgdeDrhoTBwa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2904688915736988e+22
+    },
+    {
+        "timestamp": "2024-08-09T04:51:24.093Z",
+        "balance": 1.0277583479458122e+26,
+        "block_height": 125357142,
+        "epoch_id": "27vHs9nGiSu9XQcWzp29ZZEPyZQw5ZAqj9jjqTaYjNNK",
+        "next_epoch_id": "8wJaQgywixTtmxEx51CYE8q1n6pFZDNv5ZYR7C4JN6sX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.278367180959572e+22
+    },
+    {
+        "timestamp": "2024-08-08T22:35:26.094Z",
+        "balance": 1.0276305112277163e+26,
+        "block_height": 125337110,
+        "epoch_id": "6ymA6mprFniKSjTi2HeTAQcCxnHtCrgpa2f1ifNApomS",
+        "next_epoch_id": "27vHs9nGiSu9XQcWzp29ZZEPyZQw5ZAqj9jjqTaYjNNK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2405423258932762e+22
+    },
+    {
+        "timestamp": "2024-08-08T09:04:32.260Z",
+        "balance": 1.027506456995127e+26,
+        "block_height": 125293910,
+        "epoch_id": "J18y4YESfnH5jqbBFj7qNcfpCFtSzmNzMZBR6LeD7QCE",
+        "next_epoch_id": "6ymA6mprFniKSjTi2HeTAQcCxnHtCrgpa2f1ifNApomS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2582591524521218e+22
+    },
+    {
+        "timestamp": "2024-08-07T19:57:25.491Z",
+        "balance": 1.0273806310798817e+26,
+        "block_height": 125250710,
+        "epoch_id": "ErjgoJKrtfYQ8Q8aUFY5UgroGxkARum1pVdkMJH6A44q",
+        "next_epoch_id": "J18y4YESfnH5jqbBFj7qNcfpCFtSzmNzMZBR6LeD7QCE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2617447534076665e+22
+    },
+    {
+        "timestamp": "2024-08-07T06:37:44.999Z",
+        "balance": 1.027254456604541e+26,
+        "block_height": 125207510,
+        "epoch_id": "FDsY5wvM5M7dBk596rHwujfUvrU5ozmfkaPj86VEU12G",
+        "next_epoch_id": "ErjgoJKrtfYQ8Q8aUFY5UgroGxkARum1pVdkMJH6A44q",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2528151219666659e+22
+    },
+    {
+        "timestamp": "2024-08-06T17:16:10.692Z",
+        "balance": 1.0271291750923443e+26,
+        "block_height": 125164310,
+        "epoch_id": "25PBZe3ToVw7kKbyjVBZV5NFKjBzpCHkqc7FVduCurQG",
+        "next_epoch_id": "FDsY5wvM5M7dBk596rHwujfUvrU5ozmfkaPj86VEU12G",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2648796332677466e+22
+    },
+    {
+        "timestamp": "2024-08-06T04:00:14.974Z",
+        "balance": 1.0270026871290175e+26,
+        "block_height": 125121110,
+        "epoch_id": "4XhzWVXB8yhuXPLarYej8YM4tKCTt839KDd1hPKfNZEP",
+        "next_epoch_id": "25PBZe3ToVw7kKbyjVBZV5NFKjBzpCHkqc7FVduCurQG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.259748296802534e+22
+    },
+    {
+        "timestamp": "2024-08-05T14:35:50.719Z",
+        "balance": 1.0268767122993373e+26,
+        "block_height": 125077910,
+        "epoch_id": "DnmfMmc8ae1hzLPG87oXDuY1oaxneuxvRy22DDbop7DA",
+        "next_epoch_id": "4XhzWVXB8yhuXPLarYej8YM4tKCTt839KDd1hPKfNZEP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2480808913864392e+22
+    },
+    {
+        "timestamp": "2024-08-05T01:13:59.898Z",
+        "balance": 1.0267519042101986e+26,
+        "block_height": 125034710,
+        "epoch_id": "GfkhzmEpck5oVveWihcUUw6QfMagBKDh3FwZi17yjFBN",
+        "next_epoch_id": "DnmfMmc8ae1hzLPG87oXDuY1oaxneuxvRy22DDbop7DA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2427464861891303e+22
+    },
+    {
+        "timestamp": "2024-08-04T11:59:50.929Z",
+        "balance": 1.0266276295615797e+26,
+        "block_height": 124991510,
+        "epoch_id": "G9sVdng2WXgmy7TiUooo5YzHzRZAHHhzyZfKrRQ2PXv6",
+        "next_epoch_id": "GfkhzmEpck5oVveWihcUUw6QfMagBKDh3FwZi17yjFBN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2451166500049396e+22
+    },
+    {
+        "timestamp": "2024-08-03T22:49:47.366Z",
+        "balance": 1.0265031178965792e+26,
+        "block_height": 124948310,
+        "epoch_id": "E77wafwyHHBahufucrRchZi9E1zKoEQdzu2FTBMec6xA",
+        "next_epoch_id": "G9sVdng2WXgmy7TiUooo5YzHzRZAHHhzyZfKrRQ2PXv6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.249588593182436e+22
+    },
+    {
+        "timestamp": "2024-08-03T09:37:21.358Z",
+        "balance": 1.026378159037261e+26,
+        "block_height": 124905110,
+        "epoch_id": "DGoip6WMHHcWsaNTax546Uq8gBRDhUuS1LDsqhrHWsJ8",
+        "next_epoch_id": "E77wafwyHHBahufucrRchZi9E1zKoEQdzu2FTBMec6xA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2613297886535268e+22
+    },
+    {
+        "timestamp": "2024-08-02T20:26:44.123Z",
+        "balance": 1.0262520260583956e+26,
+        "block_height": 124861910,
+        "epoch_id": "4vvigoYwpLV8cxBQNkv1Md23cXJ5fUZJFREpmb9fETgc",
+        "next_epoch_id": "DGoip6WMHHcWsaNTax546Uq8gBRDhUuS1LDsqhrHWsJ8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3318896536531826e+22
+    },
+    {
+        "timestamp": "2024-08-02T07:01:49.393Z",
+        "balance": 1.0261188370930303e+26,
+        "block_height": 124818710,
+        "epoch_id": "2w4ZkojyvQYXy51yunoqDpV4i6kt9zTAsVQm7D3uW7wK",
+        "next_epoch_id": "4vvigoYwpLV8cxBQNkv1Md23cXJ5fUZJFREpmb9fETgc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2498105297058637e+22
+    },
+    {
+        "timestamp": "2024-08-01T16:52:10.148Z",
+        "balance": 1.0259938560400597e+26,
+        "block_height": 124775510,
+        "epoch_id": "5YGxva1pYF1JCJBuhcPaFPL82iKAUmFif8d7f7YcXACS",
+        "next_epoch_id": "2w4ZkojyvQYXy51yunoqDpV4i6kt9zTAsVQm7D3uW7wK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2602636301354538e+22
+    },
+    {
+        "timestamp": "2024-08-01T03:33:46.127Z",
+        "balance": 1.0258678296770462e+26,
+        "block_height": 124732310,
+        "epoch_id": "GyvAjXEnnVA2GAYhbmbWquW9GDSZGbKMkpUhcYTDMfw1",
+        "next_epoch_id": "5YGxva1pYF1JCJBuhcPaFPL82iKAUmFif8d7f7YcXACS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.270679228113206e+22
+    },
+    {
+        "timestamp": "2024-07-31T14:07:43.639Z",
+        "balance": 1.0257407617542349e+26,
+        "block_height": 124689110,
+        "epoch_id": "AwTfBSDBNTp8zT3ggpGj5JnsQPukWXwA5UWKZcV2jGqB",
+        "next_epoch_id": "GyvAjXEnnVA2GAYhbmbWquW9GDSZGbKMkpUhcYTDMfw1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3024316875024886e+22
+    },
+    {
+        "timestamp": "2024-07-31T00:35:11.409Z",
+        "balance": 1.0256105185854846e+26,
+        "block_height": 124645910,
+        "epoch_id": "6TJmBcNDmD4uwiKjKtcYhQVBjYoYyE1peEJxz57Hnhku",
+        "next_epoch_id": "AwTfBSDBNTp8zT3ggpGj5JnsQPukWXwA5UWKZcV2jGqB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3134008474615048e+22
+    },
+    {
+        "timestamp": "2024-07-30T11:10:22.618Z",
+        "balance": 1.0254791785007385e+26,
+        "block_height": 124602710,
+        "epoch_id": "Hw6YadZrAZTjjSABubaMJwh1BkU1yZdh5RLhBRi314qB",
+        "next_epoch_id": "6TJmBcNDmD4uwiKjKtcYhQVBjYoYyE1peEJxz57Hnhku",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3238426116805404e+22
+    },
+    {
+        "timestamp": "2024-07-29T21:39:27.434Z",
+        "balance": 1.0253467942395704e+26,
+        "block_height": 124559510,
+        "epoch_id": "CX6h9877n94r3hWNFpUq6HuERjX6YyHiUeu3RBP3YLWk",
+        "next_epoch_id": "Hw6YadZrAZTjjSABubaMJwh1BkU1yZdh5RLhBRi314qB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.325444339816268e+22
+    },
+    {
+        "timestamp": "2024-07-29T07:58:43.163Z",
+        "balance": 1.0252142498055888e+26,
+        "block_height": 124516310,
+        "epoch_id": "CJPpAKnk6w45sw3n76qffvbGZNVNLkKxBmMZ2XW5ZKF1",
+        "next_epoch_id": "CX6h9877n94r3hWNFpUq6HuERjX6YyHiUeu3RBP3YLWk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2981190079761082e+22
+    },
+    {
+        "timestamp": "2024-07-28T18:16:55.666Z",
+        "balance": 1.0250844379047912e+26,
+        "block_height": 124473110,
+        "epoch_id": "ELX97jJp4ccE4Mcnjy4f6PWVy7X3R75k5Q8GhzALGv3n",
+        "next_epoch_id": "CJPpAKnk6w45sw3n76qffvbGZNVNLkKxBmMZ2XW5ZKF1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2608715668493617e+22
+    },
+    {
+        "timestamp": "2024-07-27T19:06:43.672Z",
+        "balance": 1.0249583507481062e+26,
+        "block_height": 124397414,
+        "epoch_id": "FYQGMEk6WLyNXmsXRhNaYmV5wRWvZL4TKdNBscHSn6vB",
+        "next_epoch_id": "ELX97jJp4ccE4Mcnjy4f6PWVy7X3R75k5Q8GhzALGv3n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2894498419491455e+22
+    },
+    {
+        "timestamp": "2024-07-27T15:51:04.897Z",
+        "balance": 1.0248294057639113e+26,
+        "block_height": 124386710,
+        "epoch_id": "H8CtLL6de86ThrkrBCt7a7rZ4xixhNbJrFNTUnpNJTcy",
+        "next_epoch_id": "FYQGMEk6WLyNXmsXRhNaYmV5wRWvZL4TKdNBscHSn6vB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2913146027348668e+22
+    },
+    {
+        "timestamp": "2024-07-27T02:32:22.211Z",
+        "balance": 1.0247002743036378e+26,
+        "block_height": 124343510,
+        "epoch_id": "H9rYcmLBGmf4UrQPkRvdMVPNgfMTgXDnaaSoU9xxTWqJ",
+        "next_epoch_id": "H8CtLL6de86ThrkrBCt7a7rZ4xixhNbJrFNTUnpNJTcy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2958750489499213e+22
+    },
+    {
+        "timestamp": "2024-07-26T13:12:29.968Z",
+        "balance": 1.0245706867987428e+26,
+        "block_height": 124300310,
+        "epoch_id": "DiV2qWKRuaeZZMbMLesuZ8R3JTdP8PJgRkRHqAPKzqon",
+        "next_epoch_id": "H9rYcmLBGmf4UrQPkRvdMVPNgfMTgXDnaaSoU9xxTWqJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.348601562175776e+22
+    },
+    {
+        "timestamp": "2024-07-25T23:47:26.205Z",
+        "balance": 1.0244358266425253e+26,
+        "block_height": 124257110,
+        "epoch_id": "7y98n8AHxwdvjYjmvrkC3c4nqdHdKDLQwwDjrgoHtTJT",
+        "next_epoch_id": "DiV2qWKRuaeZZMbMLesuZ8R3JTdP8PJgRkRHqAPKzqon",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3174103405993059e+22
+    },
+    {
+        "timestamp": "2024-07-25T09:49:29.954Z",
+        "balance": 1.0243040856084653e+26,
+        "block_height": 124213910,
+        "epoch_id": "8nKuZzHNCQiBn2uYn5UkAcRkPktupSFXRJbDgw9GvNNC",
+        "next_epoch_id": "7y98n8AHxwdvjYjmvrkC3c4nqdHdKDLQwwDjrgoHtTJT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3307791400217193e+22
+    },
+    {
+        "timestamp": "2024-07-24T20:08:43.955Z",
+        "balance": 1.0241710076944632e+26,
+        "block_height": 124170710,
+        "epoch_id": "89DpT7jJMwupggM4s5CFhuf5nmkKgr5eg19Udd8788cE",
+        "next_epoch_id": "8nKuZzHNCQiBn2uYn5UkAcRkPktupSFXRJbDgw9GvNNC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.293328422317383e+22
+    },
+    {
+        "timestamp": "2024-07-24T06:06:11.629Z",
+        "balance": 1.0240416748522314e+26,
+        "block_height": 124127162,
+        "epoch_id": "7Nc3oxbfqW8A76hKYTrWK8HJabfGxuQ5xFBfmEzVtmvU",
+        "next_epoch_id": "89DpT7jJMwupggM4s5CFhuf5nmkKgr5eg19Udd8788cE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3132852664470056e+22
+    },
+    {
+        "timestamp": "2024-07-23T16:43:44.305Z",
+        "balance": 1.0239103463255867e+26,
+        "block_height": 124084310,
+        "epoch_id": "CQmfUiSqUnmuL78U3h8nTSXqxL2A2LLmS6neQaRCd8WT",
+        "next_epoch_id": "7Nc3oxbfqW8A76hKYTrWK8HJabfGxuQ5xFBfmEzVtmvU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3025963651677576e+22
+    },
+    {
+        "timestamp": "2024-07-23T03:09:14.026Z",
+        "balance": 1.02378008668907e+26,
+        "block_height": 124041110,
+        "epoch_id": "Bh4RJBuS2ZiryP7wqbRXfVC338Bze2R3G82MRKRWwVW",
+        "next_epoch_id": "CQmfUiSqUnmuL78U3h8nTSXqxL2A2LLmS6neQaRCd8WT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3039333900675503e+22
+    },
+    {
+        "timestamp": "2024-07-22T13:40:37.054Z",
+        "balance": 1.0236496933500632e+26,
+        "block_height": 123997910,
+        "epoch_id": "3HbKdnznAEeJwVMqpuH8jWAYHMpruAFxM4jtXrSJyLHp",
+        "next_epoch_id": "Bh4RJBuS2ZiryP7wqbRXfVC338Bze2R3G82MRKRWwVW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2772754689150962e+22
+    },
+    {
+        "timestamp": "2024-07-22T00:11:00.694Z",
+        "balance": 1.0235219658031717e+26,
+        "block_height": 123954710,
+        "epoch_id": "BnbtSUN1EtgTF3RYoSpxwt6tvjSDYap41T92aGDP4eum",
+        "next_epoch_id": "3HbKdnznAEeJwVMqpuH8jWAYHMpruAFxM4jtXrSJyLHp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2805074100624938e+22
+    },
+    {
+        "timestamp": "2024-07-21T10:58:31.271Z",
+        "balance": 1.0233939150621654e+26,
+        "block_height": 123911510,
+        "epoch_id": "AqfLeSAcsFXjMhoFd1bGyTs3mAfLGZowsRnyCX4XZqDE",
+        "next_epoch_id": "BnbtSUN1EtgTF3RYoSpxwt6tvjSDYap41T92aGDP4eum",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.289534415187835e+22
+    },
+    {
+        "timestamp": "2024-07-20T21:44:22.446Z",
+        "balance": 1.0232649616206466e+26,
+        "block_height": 123868310,
+        "epoch_id": "ASnhPNxHUsnS4CCJkbKNYo7Qj3EoEj4KtGCAxjU8J4hh",
+        "next_epoch_id": "AqfLeSAcsFXjMhoFd1bGyTs3mAfLGZowsRnyCX4XZqDE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2958789288034742e+22
+    },
+    {
+        "timestamp": "2024-07-20T08:23:25.012Z",
+        "balance": 1.0231353737277663e+26,
+        "block_height": 123825110,
+        "epoch_id": "Hm4TkhjCr3TPHVVcbkEXg8RosU4WQHrGat1S8fyujZVe",
+        "next_epoch_id": "ASnhPNxHUsnS4CCJkbKNYo7Qj3EoEj4KtGCAxjU8J4hh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.277985672981902e+22
+    },
+    {
+        "timestamp": "2024-07-19T18:58:47.165Z",
+        "balance": 1.0230075751604681e+26,
+        "block_height": 123781910,
+        "epoch_id": "AAa2is8Z3PX81nemzCmcqvKAGhaxDKEQKfc6nv28DGMc",
+        "next_epoch_id": "Hm4TkhjCr3TPHVVcbkEXg8RosU4WQHrGat1S8fyujZVe",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.5776336878293276e+22
+    },
+    {
+        "timestamp": "2024-07-18T17:15:58.869Z",
+        "balance": 1.0227498117916852e+26,
+        "block_height": 123697402,
+        "epoch_id": "9eiNktgp5Be8L8iPD6J5VuvngD1Lx26GCdAPc5aBdjsD",
+        "next_epoch_id": "AAa2is8Z3PX81nemzCmcqvKAGhaxDKEQKfc6nv28DGMc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-07-18T16:40:43.929Z",
+        "balance": 1.0227498117916852e+26,
+        "block_height": 123695510,
+        "epoch_id": "FpsRxD4Ex19v4YbCfTxpcttSo251hrrgBajBcvVCWC95",
+        "next_epoch_id": "9eiNktgp5Be8L8iPD6J5VuvngD1Lx26GCdAPc5aBdjsD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.299199394794838e+22
+    },
+    {
+        "timestamp": "2024-07-17T15:34:26.516Z",
+        "balance": 1.0226198918522057e+26,
+        "block_height": 123615279,
+        "epoch_id": "sw9QwUkdwp4iAhHJUTRLQpviEQ1nVJvvK7p1QpNJMFL",
+        "next_epoch_id": "FpsRxD4Ex19v4YbCfTxpcttSo251hrrgBajBcvVCWC95",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2831836460674345e+22
+    },
+    {
+        "timestamp": "2024-07-17T13:36:47.919Z",
+        "balance": 1.022491573487599e+26,
+        "block_height": 123609110,
+        "epoch_id": "5M2ksbg8HuDf1CAY5wDPLJZMeSKd5iR2nmrZQFhbbhvT",
+        "next_epoch_id": "sw9QwUkdwp4iAhHJUTRLQpviEQ1nVJvvK7p1QpNJMFL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2962777709599133e+22
+    },
+    {
+        "timestamp": "2024-07-17T00:17:43.027Z",
+        "balance": 1.022361945710503e+26,
+        "block_height": 123565910,
+        "epoch_id": "zhVjqpCaa7SeZXSqYeDiSGF8C7MdNToxwrzQFQ6Bhoj",
+        "next_epoch_id": "5M2ksbg8HuDf1CAY5wDPLJZMeSKd5iR2nmrZQFhbbhvT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.29348805696262e+22
+    },
+    {
+        "timestamp": "2024-07-16T10:49:56.421Z",
+        "balance": 1.0222325969048067e+26,
+        "block_height": 123522710,
+        "epoch_id": "Fwt1kkMWqsHWk8TtEdzocVvQwzXmxYnJRV97Z4TJzBGP",
+        "next_epoch_id": "zhVjqpCaa7SeZXSqYeDiSGF8C7MdNToxwrzQFQ6Bhoj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2956032385876476e+22
+    },
+    {
+        "timestamp": "2024-07-15T21:23:55.222Z",
+        "balance": 1.022103036580948e+26,
+        "block_height": 123479510,
+        "epoch_id": "14VV8tTcNQ4srniNArAZ2nXphBS4w4K2nJ8eJomp2oTB",
+        "next_epoch_id": "Fwt1kkMWqsHWk8TtEdzocVvQwzXmxYnJRV97Z4TJzBGP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2878642788264973e+22
+    },
+    {
+        "timestamp": "2024-07-15T07:57:29.647Z",
+        "balance": 1.0219742501530653e+26,
+        "block_height": 123436310,
+        "epoch_id": "5tYmypQn9cjWzCJJtXN8ZcpTAjAuJqEbQpRoRpuFmetn",
+        "next_epoch_id": "14VV8tTcNQ4srniNArAZ2nXphBS4w4K2nJ8eJomp2oTB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2965780316769e+22
+    },
+    {
+        "timestamp": "2024-07-14T18:36:07.880Z",
+        "balance": 1.0218445923498976e+26,
+        "block_height": 123393110,
+        "epoch_id": "FWuR2nvfUXEEzPkY1upBPYSdjRAF2ETG24PQwPh9mqC1",
+        "next_epoch_id": "5tYmypQn9cjWzCJJtXN8ZcpTAjAuJqEbQpRoRpuFmetn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2699881316515255e+22
+    },
+    {
+        "timestamp": "2024-07-14T05:09:09.963Z",
+        "balance": 1.0217175935367324e+26,
+        "block_height": 123349910,
+        "epoch_id": "8E43ZnyUuNiQRQ8HjQKzTA41rbfmPmZaxjmXRqnyoVrh",
+        "next_epoch_id": "FWuR2nvfUXEEzPkY1upBPYSdjRAF2ETG24PQwPh9mqC1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2803351945956173e+22
+    },
+    {
+        "timestamp": "2024-07-13T15:57:29.231Z",
+        "balance": 1.0215895600172729e+26,
+        "block_height": 123306710,
+        "epoch_id": "GFm8Evj1U4b6sjpQ7WWok2dTvZc3FKo4J97dttwcQSNr",
+        "next_epoch_id": "8E43ZnyUuNiQRQ8HjQKzTA41rbfmPmZaxjmXRqnyoVrh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2899913512591804e+22
+    },
+    {
+        "timestamp": "2024-07-13T02:39:28.821Z",
+        "balance": 1.021460560882147e+26,
+        "block_height": 123263510,
+        "epoch_id": "DXrPVocrjN6RLsgHYDN6ArxVUFVec7FGtGjVQm5dYEoV",
+        "next_epoch_id": "GFm8Evj1U4b6sjpQ7WWok2dTvZc3FKo4J97dttwcQSNr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2528269871264947e+22
+    },
+    {
+        "timestamp": "2024-07-12T13:16:07.055Z",
+        "balance": 1.0213352781834343e+26,
+        "block_height": 123220310,
+        "epoch_id": "73JbXB5DhYTe6PybhRkWKuwPngYix2wzvfvTJJySQ5yA",
+        "next_epoch_id": "DXrPVocrjN6RLsgHYDN6ArxVUFVec7FGtGjVQm5dYEoV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3030869085455863e+22
+    },
+    {
+        "timestamp": "2024-07-12T00:15:47.176Z",
+        "balance": 1.0212049694925797e+26,
+        "block_height": 123177110,
+        "epoch_id": "DAngEAHnJYaMCx2YE6bf4C8rBfKVC8R7t7Q3LiqgK8dz",
+        "next_epoch_id": "73JbXB5DhYTe6PybhRkWKuwPngYix2wzvfvTJJySQ5yA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3033196876057197e+22
+    },
+    {
+        "timestamp": "2024-07-11T10:43:45.427Z",
+        "balance": 1.0210746375238192e+26,
+        "block_height": 123133910,
+        "epoch_id": "9amikt5nqGC8M8Ue5ZSMSbbhh286qUX88mcNrRxStuoA",
+        "next_epoch_id": "DAngEAHnJYaMCx2YE6bf4C8rBfKVC8R7t7Q3LiqgK8dz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3157328265888192e+22
+    },
+    {
+        "timestamp": "2024-07-10T21:12:08.824Z",
+        "balance": 1.0209430642411603e+26,
+        "block_height": 123090710,
+        "epoch_id": "7ZUgCaSbgKGuUJjyFTn8tVftfoyx2z8CRHSinbkLMSd1",
+        "next_epoch_id": "9amikt5nqGC8M8Ue5ZSMSbbhh286qUX88mcNrRxStuoA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2932678224058826e+22
+    },
+    {
+        "timestamp": "2024-07-10T04:32:36.306Z",
+        "balance": 1.0208137374589197e+26,
+        "block_height": 123038048,
+        "epoch_id": "rsDkgnB7kj8XdoEQAR1ebUuaZzx5jppDxeTXmoBscsu",
+        "next_epoch_id": "7ZUgCaSbgKGuUJjyFTn8tVftfoyx2z8CRHSinbkLMSd1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.330425904752043e+22
+    },
+    {
+        "timestamp": "2024-07-09T14:58:13.213Z",
+        "balance": 1.0206806948684445e+26,
+        "block_height": 122994848,
+        "epoch_id": "GYgRSHewRjKzcjzyycDYaJaDfyp63dn3aS35teCSVfeK",
+        "next_epoch_id": "rsDkgnB7kj8XdoEQAR1ebUuaZzx5jppDxeTXmoBscsu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2979865676378603e+22
+    },
+    {
+        "timestamp": "2024-07-09T01:03:06.839Z",
+        "balance": 1.0205508962116807e+26,
+        "block_height": 122951648,
+        "epoch_id": "4jNg5ZYuXD8Tcsf21bjJ4GsHySdgdsRopdsAPyFjgSq8",
+        "next_epoch_id": "GYgRSHewRjKzcjzyycDYaJaDfyp63dn3aS35teCSVfeK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2917842579189265e+22
+    },
+    {
+        "timestamp": "2024-07-08T11:27:55.948Z",
+        "balance": 1.0204217177858888e+26,
+        "block_height": 122908448,
+        "epoch_id": "8eR7QY523vQQsXdTgyppZaniE1mS9T913VMEZorCE5aj",
+        "next_epoch_id": "4jNg5ZYuXD8Tcsf21bjJ4GsHySdgdsRopdsAPyFjgSq8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.5695842069114027e+22
+    },
+    {
+        "timestamp": "2024-07-07T11:43:33.164Z",
+        "balance": 1.0201647593651977e+26,
+        "block_height": 122832534,
+        "epoch_id": "3rQPjBqVus3FkR1fzpg9r3kt125GfwxA4db5ZaDYLvjd",
+        "next_epoch_id": "8eR7QY523vQQsXdTgyppZaniE1mS9T913VMEZorCE5aj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-07-07T11:15:09.406Z",
+        "balance": 1.0201647593651977e+26,
+        "block_height": 122831000,
+        "epoch_id": "2FpZuEmUN7FSF3qwXxtHcJPCMF7bny9EssKA7a2NYxHC",
+        "next_epoch_id": "3rQPjBqVus3FkR1fzpg9r3kt125GfwxA4db5ZaDYLvjd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3031299512045882e+22
+    },
+    {
+        "timestamp": "2024-07-06T18:52:08.059Z",
+        "balance": 1.0200344463700772e+26,
+        "block_height": 122778363,
+        "epoch_id": "CBHotdR8qZ3wETymWPgQiPpPLKHpp1xSK14WqFuZYeA3",
+        "next_epoch_id": "2FpZuEmUN7FSF3qwXxtHcJPCMF7bny9EssKA7a2NYxHC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3051644451464776e+22
+    },
+    {
+        "timestamp": "2024-07-06T08:16:14.443Z",
+        "balance": 1.0199039299255626e+26,
+        "block_height": 122745110,
+        "epoch_id": "B1zaGYNzR5qgrPUtEQvkDr8rJPQJCHQbnbYK17df42Ss",
+        "next_epoch_id": "CBHotdR8qZ3wETymWPgQiPpPLKHpp1xSK14WqFuZYeA3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.347243709261578e+22
+    },
+    {
+        "timestamp": "2024-07-05T18:34:50.276Z",
+        "balance": 1.0197692055546364e+26,
+        "block_height": 122701910,
+        "epoch_id": "6GuA73dmMfwDN1Jcj4EZAXB1vx8rL6mP9Dxbe9qTb8NZ",
+        "next_epoch_id": "B1zaGYNzR5qgrPUtEQvkDr8rJPQJCHQbnbYK17df42Ss",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.354541727294488e+22
+    },
+    {
+        "timestamp": "2024-07-05T04:26:32.406Z",
+        "balance": 1.019633751381907e+26,
+        "block_height": 122658710,
+        "epoch_id": "77kKgrqGq8UMVTNH4dZ96voCQskSpWBqVgnES8tqMDrV",
+        "next_epoch_id": "6GuA73dmMfwDN1Jcj4EZAXB1vx8rL6mP9Dxbe9qTb8NZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3585361295767864e+22
+    },
+    {
+        "timestamp": "2024-07-04T14:13:11.878Z",
+        "balance": 1.0194978977689493e+26,
+        "block_height": 122615510,
+        "epoch_id": "F5qdfijmjt9DE9o38KbD5YDAm5qEo6f5XQzHwwYt91Bd",
+        "next_epoch_id": "77kKgrqGq8UMVTNH4dZ96voCQskSpWBqVgnES8tqMDrV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3553723135719863e+22
+    },
+    {
+        "timestamp": "2024-07-03T23:57:29.843Z",
+        "balance": 1.0193623605375921e+26,
+        "block_height": 122572310,
+        "epoch_id": "GCsZuCNZHYWcPBrjf9hEayxPQiwXqkChc9WgougRRsNM",
+        "next_epoch_id": "F5qdfijmjt9DE9o38KbD5YDAm5qEo6f5XQzHwwYt91Bd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3346187183365437e+22
+    },
+    {
+        "timestamp": "2024-07-03T09:44:26.606Z",
+        "balance": 1.0192288986657584e+26,
+        "block_height": 122529110,
+        "epoch_id": "69a4eYnr5Lv5HtVLNoNJF8bsWhj3MWVcb3sCtEzFXeXF",
+        "next_epoch_id": "GCsZuCNZHYWcPBrjf9hEayxPQiwXqkChc9WgougRRsNM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.364950817077373e+22
+    },
+    {
+        "timestamp": "2024-07-02T19:44:53.421Z",
+        "balance": 1.0190924035840507e+26,
+        "block_height": 122485910,
+        "epoch_id": "GTLonv7dwnG6VgfkvsrEv7Rr8ypqwpAuSBrPtBS4CFzN",
+        "next_epoch_id": "69a4eYnr5Lv5HtVLNoNJF8bsWhj3MWVcb3sCtEzFXeXF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3527996670277004e+22
+    },
+    {
+        "timestamp": "2024-07-02T05:27:48.735Z",
+        "balance": 1.018957123617348e+26,
+        "block_height": 122442710,
+        "epoch_id": "Bjc2wGxnMEZamGfkZbf9n6WatNMuHfKTyM9dGXMfcwXt",
+        "next_epoch_id": "GTLonv7dwnG6VgfkvsrEv7Rr8ypqwpAuSBrPtBS4CFzN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3958444059311374e+22
+    },
+    {
+        "timestamp": "2024-07-01T15:18:18.506Z",
+        "balance": 1.0188175391767548e+26,
+        "block_height": 122399510,
+        "epoch_id": "AtC6RSehPhYH8STuzERvA2UHnwpwDG6MCtMbfa2X7Xru",
+        "next_epoch_id": "Bjc2wGxnMEZamGfkZbf9n6WatNMuHfKTyM9dGXMfcwXt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3969108362862805e+22
+    },
+    {
+        "timestamp": "2024-07-01T00:38:45.363Z",
+        "balance": 1.0186778480931262e+26,
+        "block_height": 122356310,
+        "epoch_id": "2G2sJ89t2zpWRsEnx3bCByuF41n7MSMQBKb4VtxYRKTc",
+        "next_epoch_id": "AtC6RSehPhYH8STuzERvA2UHnwpwDG6MCtMbfa2X7Xru",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.341503782398743e+22
+    },
+    {
+        "timestamp": "2024-06-30T10:01:36.031Z",
+        "balance": 1.0185436977148863e+26,
+        "block_height": 122313110,
+        "epoch_id": "4mw9E5AbRg1AwoVpX8R7oPy96YPLmsaTxy7cnrdKwWTp",
+        "next_epoch_id": "2G2sJ89t2zpWRsEnx3bCByuF41n7MSMQBKb4VtxYRKTc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.383666836106544e+22
+    },
+    {
+        "timestamp": "2024-06-29T19:58:16.360Z",
+        "balance": 1.0184053310312757e+26,
+        "block_height": 122269910,
+        "epoch_id": "GzmmnwB2TyaTaRksZ9mkBQohj6pUURTBSfJhwcrTFmYc",
+        "next_epoch_id": "4mw9E5AbRg1AwoVpX8R7oPy96YPLmsaTxy7cnrdKwWTp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3672630293719037e+22
+    },
+    {
+        "timestamp": "2024-06-29T05:28:54.656Z",
+        "balance": 1.0182686047283385e+26,
+        "block_height": 122226710,
+        "epoch_id": "58othovZFom3wxfR4jYcE2bNBq5VszYmpayWCy1CfK2k",
+        "next_epoch_id": "GzmmnwB2TyaTaRksZ9mkBQohj6pUURTBSfJhwcrTFmYc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4175396302947713e+22
+    },
+    {
+        "timestamp": "2024-06-28T15:08:51.972Z",
+        "balance": 1.018126850765309e+26,
+        "block_height": 122183510,
+        "epoch_id": "67F8eXE4ceJvkCXSmWtJLHqePFNKj4Qe5guCzr1guKME",
+        "next_epoch_id": "58othovZFom3wxfR4jYcE2bNBq5VszYmpayWCy1CfK2k",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4044255054232222e+22
+    },
+    {
+        "timestamp": "2024-06-28T00:15:26.877Z",
+        "balance": 1.0179864082147667e+26,
+        "block_height": 122140310,
+        "epoch_id": "7NVd6URfod1f2oekts52MU8zMHcD5THq4tXVteU9pj4Y",
+        "next_epoch_id": "67F8eXE4ceJvkCXSmWtJLHqePFNKj4Qe5guCzr1guKME",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3666372643501113e+22
+    },
+    {
+        "timestamp": "2024-06-27T09:35:55.268Z",
+        "balance": 1.0178497444883317e+26,
+        "block_height": 122097110,
+        "epoch_id": "CMvg54ULBKJfAuA6hGfsfWRAGC4QPpQ2uCmAZvo5WTxq",
+        "next_epoch_id": "7NVd6URfod1f2oekts52MU8zMHcD5THq4tXVteU9pj4Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4352463252095903e+22
+    },
+    {
+        "timestamp": "2024-06-26T19:30:37.981Z",
+        "balance": 1.0177062198558107e+26,
+        "block_height": 122053910,
+        "epoch_id": "DtYdA7b82qJmAtyw9N2TsVTjyUhwcvtW2oHC1n4qKC1",
+        "next_epoch_id": "CMvg54ULBKJfAuA6hGfsfWRAGC4QPpQ2uCmAZvo5WTxq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4605794070438206e+22
+    },
+    {
+        "timestamp": "2024-06-26T04:25:46.743Z",
+        "balance": 1.0175601619151063e+26,
+        "block_height": 122010710,
+        "epoch_id": "GdbPiyTkgMJzhb26HVJ98mTM578Zm1hmw6drkZLaffZ2",
+        "next_epoch_id": "DtYdA7b82qJmAtyw9N2TsVTjyUhwcvtW2oHC1n4qKC1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3198515166982946e+22
+    },
+    {
+        "timestamp": "2024-06-25T13:05:25.132Z",
+        "balance": 1.0174281767634365e+26,
+        "block_height": 121967507,
+        "epoch_id": "A172PuHwBKtDNVsqSuxXYvQj4memHTDMnu5EKif74KnS",
+        "next_epoch_id": "GdbPiyTkgMJzhb26HVJ98mTM578Zm1hmw6drkZLaffZ2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.337013918215942e+22
+    },
+    {
+        "timestamp": "2024-06-24T23:13:45.650Z",
+        "balance": 1.0172944753716149e+26,
+        "block_height": 121924307,
+        "epoch_id": "4RjXBrNcu39wutFTuFpnRHgNqgHxLMcGBKNEQdtkSBhy",
+        "next_epoch_id": "A172PuHwBKtDNVsqSuxXYvQj4memHTDMnu5EKif74KnS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2925850458490461e+22
+    },
+    {
+        "timestamp": "2024-06-24T09:11:55.164Z",
+        "balance": 1.01716521686703e+26,
+        "block_height": 121881107,
+        "epoch_id": "CRTZ7cQd77rvfS57Y7M36P1vLhran9HyQFEpTLxHRf9t",
+        "next_epoch_id": "4RjXBrNcu39wutFTuFpnRHgNqgHxLMcGBKNEQdtkSBhy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3306003359375718e+22
+    },
+    {
+        "timestamp": "2024-06-23T19:37:45.931Z",
+        "balance": 1.0170321568334362e+26,
+        "block_height": 121837907,
+        "epoch_id": "HPi5yyZHZ91t5S4SPAAfEZwGYEqq5i6QjzXoVMi8ksae",
+        "next_epoch_id": "CRTZ7cQd77rvfS57Y7M36P1vLhran9HyQFEpTLxHRf9t",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.293939286587515e+22
+    },
+    {
+        "timestamp": "2024-06-23T05:39:38.407Z",
+        "balance": 1.0169027629047775e+26,
+        "block_height": 121794707,
+        "epoch_id": "3JMehuv86nBynJ33VBUGAvfd9Ts8EfvytGJ8i8e45XPi",
+        "next_epoch_id": "HPi5yyZHZ91t5S4SPAAfEZwGYEqq5i6QjzXoVMi8ksae",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3180525972956465e+22
+    },
+    {
+        "timestamp": "2024-06-22T16:04:05.555Z",
+        "balance": 1.0167709576450479e+26,
+        "block_height": 121751507,
+        "epoch_id": "89PT9SkLXB1FZHvW7EdQHxiSpm5ybuTCvjrGZWWhXMTz",
+        "next_epoch_id": "3JMehuv86nBynJ33VBUGAvfd9Ts8EfvytGJ8i8e45XPi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2970125090928126e+22
+    },
+    {
+        "timestamp": "2024-06-22T02:15:24.598Z",
+        "balance": 1.0166412563941386e+26,
+        "block_height": 121708307,
+        "epoch_id": "3TDMgDbDBZbzkjRT3CCw3RBQk5aLRrmmD9WiYbuZQV9d",
+        "next_epoch_id": "89PT9SkLXB1FZHvW7EdQHxiSpm5ybuTCvjrGZWWhXMTz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3398362738770676e+22
+    },
+    {
+        "timestamp": "2024-06-21T12:39:51.653Z",
+        "balance": 1.016507272766751e+26,
+        "block_height": 121665107,
+        "epoch_id": "9ASpcRrp7iJin1PAUCVhoD4r7MhcLi6tVtRGSfSfsv44",
+        "next_epoch_id": "3TDMgDbDBZbzkjRT3CCw3RBQk5aLRrmmD9WiYbuZQV9d",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3238446697326613e+22
+    },
+    {
+        "timestamp": "2024-06-20T22:37:25.437Z",
+        "balance": 1.0163748882997777e+26,
+        "block_height": 121621907,
+        "epoch_id": "97fDLBWDyKSwCH3MmeTY6VMe2o48bQ9ZNMyiRejuoBhT",
+        "next_epoch_id": "9ASpcRrp7iJin1PAUCVhoD4r7MhcLi6tVtRGSfSfsv44",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2753795290410638e+22
+    },
+    {
+        "timestamp": "2024-06-20T08:44:02.558Z",
+        "balance": 1.0162473503468736e+26,
+        "block_height": 121578707,
+        "epoch_id": "DvpH8HRqtYM77tkkMJiSPaEbR63VrAh2NJGjL39mYK8n",
+        "next_epoch_id": "97fDLBWDyKSwCH3MmeTY6VMe2o48bQ9ZNMyiRejuoBhT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2943584674138374e+22
+    },
+    {
+        "timestamp": "2024-06-19T19:19:37.085Z",
+        "balance": 1.0161179145001322e+26,
+        "block_height": 121535507,
+        "epoch_id": "6roR7NaJrsfxNeU2phRyWwPWAZdW7BpiXRjFuGu7RcY1",
+        "next_epoch_id": "DvpH8HRqtYM77tkkMJiSPaEbR63VrAh2NJGjL39mYK8n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2822396961777166e+22
+    },
+    {
+        "timestamp": "2024-06-19T05:45:59.483Z",
+        "balance": 1.0159896905305144e+26,
+        "block_height": 121492307,
+        "epoch_id": "5KxLdek84Ui7BS5wSWkLCbub2o8Jfo87jJVbUNFFyPK4",
+        "next_epoch_id": "6roR7NaJrsfxNeU2phRyWwPWAZdW7BpiXRjFuGu7RcY1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.339739060400161e+22
+    },
+    {
+        "timestamp": "2024-06-18T16:18:47.687Z",
+        "balance": 1.0158557166244744e+26,
+        "block_height": 121449107,
+        "epoch_id": "CQQbNc1XiVgiUxgQtkcYsmapwXgPjPmR1SCsKSVeSsJj",
+        "next_epoch_id": "5KxLdek84Ui7BS5wSWkLCbub2o8Jfo87jJVbUNFFyPK4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3159414501722003e+22
+    },
+    {
+        "timestamp": "2024-06-18T02:14:39.976Z",
+        "balance": 1.0157241224794572e+26,
+        "block_height": 121405907,
+        "epoch_id": "8vTCZDwGiw9D5DUnVJj29744Uo9TEs97WuKCwJ1t3eLg",
+        "next_epoch_id": "CQQbNc1XiVgiUxgQtkcYsmapwXgPjPmR1SCsKSVeSsJj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.306822883734888e+22
+    },
+    {
+        "timestamp": "2024-06-17T12:33:57.523Z",
+        "balance": 1.0155934401910837e+26,
+        "block_height": 121362707,
+        "epoch_id": "CLXk22wwFpiWZrq5WDJdkVScN2tQ9AVBbmDXi6x6wCih",
+        "next_epoch_id": "8vTCZDwGiw9D5DUnVJj29744Uo9TEs97WuKCwJ1t3eLg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.436634023734705e+22
+    },
+    {
+        "timestamp": "2024-06-16T22:59:03.934Z",
+        "balance": 1.0154497767887102e+26,
+        "block_height": 121319507,
+        "epoch_id": "8b2pLrk1msVgAChpFP7YauVUK3EzBhknwrbyTCQy9WGZ",
+        "next_epoch_id": "CLXk22wwFpiWZrq5WDJdkVScN2tQ9AVBbmDXi6x6wCih",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4382906554612978e+22
+    },
+    {
+        "timestamp": "2024-06-16T07:54:43.695Z",
+        "balance": 1.015305947723164e+26,
+        "block_height": 121276307,
+        "epoch_id": "2UD5MbcubvV3EBfwsVaNrL7zat6w6uGizBkfjmGG6VQ4",
+        "next_epoch_id": "8b2pLrk1msVgAChpFP7YauVUK3EzBhknwrbyTCQy9WGZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.355371371872919e+22
+    },
+    {
+        "timestamp": "2024-06-15T16:49:29.112Z",
+        "balance": 1.0151704105859768e+26,
+        "block_height": 121233107,
+        "epoch_id": "D4sHr7U4CFjPUJN7MPkW2cSULrtdwA4wdVXm8fWxBxXj",
+        "next_epoch_id": "2UD5MbcubvV3EBfwsVaNrL7zat6w6uGizBkfjmGG6VQ4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3360542113590896e+22
+    },
+    {
+        "timestamp": "2024-06-15T02:46:11.119Z",
+        "balance": 1.0150368051648409e+26,
+        "block_height": 121189907,
+        "epoch_id": "25HzMRNxuAfp21319oFQELh1V8sX63Fv6ekAeC1iGhbS",
+        "next_epoch_id": "D4sHr7U4CFjPUJN7MPkW2cSULrtdwA4wdVXm8fWxBxXj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4608799175457974e+22
+    },
+    {
+        "timestamp": "2024-06-14T12:54:42.469Z",
+        "balance": 1.0148907171730863e+26,
+        "block_height": 121146707,
+        "epoch_id": "FBiVruRirWiKyNZojZzkHMFQGmLRe5nZgnpq1pBKXHo6",
+        "next_epoch_id": "25HzMRNxuAfp21319oFQELh1V8sX63Fv6ekAeC1iGhbS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4150967075270725e+22
+    },
+    {
+        "timestamp": "2024-06-13T21:28:49.260Z",
+        "balance": 1.0147492075023336e+26,
+        "block_height": 121103068,
+        "epoch_id": "AEVPFToJXQ888CveYcZDKqaNF1m9gonXHsTG4vNDTRQL",
+        "next_epoch_id": "FBiVruRirWiKyNZojZzkHMFQGmLRe5nZgnpq1pBKXHo6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3088900415696423e+22
+    },
+    {
+        "timestamp": "2024-06-13T06:50:55.554Z",
+        "balance": 1.0146183184981766e+26,
+        "block_height": 121060307,
+        "epoch_id": "FY8vMqjwVXumHMm6UYjK3dNquoMhmMat5wQ3Hhw7sBHL",
+        "next_epoch_id": "AEVPFToJXQ888CveYcZDKqaNF1m9gonXHsTG4vNDTRQL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3631320282162746e+22
+    },
+    {
+        "timestamp": "2024-06-12T17:10:27.795Z",
+        "balance": 1.014482005295355e+26,
+        "block_height": 121017107,
+        "epoch_id": "6JkEvmXjH4Jn5HcRwaZCHCjrwyDki9BVLeFJgZTfYw3P",
+        "next_epoch_id": "FY8vMqjwVXumHMm6UYjK3dNquoMhmMat5wQ3Hhw7sBHL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.348140216440892e+22
+    },
+    {
+        "timestamp": "2024-06-12T02:57:46.769Z",
+        "balance": 1.0143471912737109e+26,
+        "block_height": 120973907,
+        "epoch_id": "2o7D2y57uXqErbFqx8JoFPeN1oYqaph6jYw93Ted9AEL",
+        "next_epoch_id": "6JkEvmXjH4Jn5HcRwaZCHCjrwyDki9BVLeFJgZTfYw3P",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3180946700891855e+22
+    },
+    {
+        "timestamp": "2024-06-11T12:58:10.666Z",
+        "balance": 1.014215381806702e+26,
+        "block_height": 120930707,
+        "epoch_id": "4NTfRJoC2BuQPecmNcqqmHkcUoHXWKHbgsjbFvoppizE",
+        "next_epoch_id": "2o7D2y57uXqErbFqx8JoFPeN1oYqaph6jYw93Ted9AEL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3969974165408538e+22
+    },
+    {
+        "timestamp": "2024-06-10T23:14:46.354Z",
+        "balance": 1.0140756820650479e+26,
+        "block_height": 120887507,
+        "epoch_id": "DmTiP5BkrfesBvWF8Ng78zvLRo61JHLcyKYo8DsieUA6",
+        "next_epoch_id": "4NTfRJoC2BuQPecmNcqqmHkcUoHXWKHbgsjbFvoppizE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3887787176154462e+22
+    },
+    {
+        "timestamp": "2024-06-10T08:54:18.752Z",
+        "balance": 1.0139368041932864e+26,
+        "block_height": 120844307,
+        "epoch_id": "3V5JxX6dZxjPaf6ekhPbZSyFxYXdLxLD42YUrjbGEKJ4",
+        "next_epoch_id": "DmTiP5BkrfesBvWF8Ng78zvLRo61JHLcyKYo8DsieUA6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4123839701653232e+22
+    },
+    {
+        "timestamp": "2024-06-09T18:38:13.387Z",
+        "balance": 1.0137955657962698e+26,
+        "block_height": 120801107,
+        "epoch_id": "ESNJJmSXw7xu4u1vrELuRFEr9NoNoZ9jppoyRNzwVvyY",
+        "next_epoch_id": "3V5JxX6dZxjPaf6ekhPbZSyFxYXdLxLD42YUrjbGEKJ4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3758987736177904e+22
+    },
+    {
+        "timestamp": "2024-06-09T04:18:24.705Z",
+        "balance": 1.013657975918908e+26,
+        "block_height": 120757907,
+        "epoch_id": "FjmF83DVRRessei2KQC6NAamemaShDxoHFteYsFJNF7M",
+        "next_epoch_id": "ESNJJmSXw7xu4u1vrELuRFEr9NoNoZ9jppoyRNzwVvyY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.404542372575986e+22
+    },
+    {
+        "timestamp": "2024-06-08T14:20:30.536Z",
+        "balance": 1.0135175216816504e+26,
+        "block_height": 120714707,
+        "epoch_id": "F13VkENA7rfsM2gWDPfeD3JvZnDe11W81VUeRnSU4QCj",
+        "next_epoch_id": "FjmF83DVRRessei2KQC6NAamemaShDxoHFteYsFJNF7M",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.414747227218454e+22
+    },
+    {
+        "timestamp": "2024-06-08T00:03:52.413Z",
+        "balance": 1.0133760469589286e+26,
+        "block_height": 120671507,
+        "epoch_id": "FH9orhez7ADwc3bPkiFo6B233RH4tBf9LdQwfs8xSnYx",
+        "next_epoch_id": "F13VkENA7rfsM2gWDPfeD3JvZnDe11W81VUeRnSU4QCj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4227718775062296e+22
+    },
+    {
+        "timestamp": "2024-06-07T09:39:42.814Z",
+        "balance": 1.013233769771178e+26,
+        "block_height": 120628307,
+        "epoch_id": "BANWz3867e9S4epMu936obvFoeuTv55jXvrDQBkGwjxZ",
+        "next_epoch_id": "FH9orhez7ADwc3bPkiFo6B233RH4tBf9LdQwfs8xSnYx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4059473496823772e+22
+    },
+    {
+        "timestamp": "2024-06-06T19:11:51.458Z",
+        "balance": 1.0130931750362097e+26,
+        "block_height": 120585107,
+        "epoch_id": "BRhrQEc5Cu75b1dcd6WXQCXU2BMWoZrZrGWDif5uyXD1",
+        "next_epoch_id": "BANWz3867e9S4epMu936obvFoeuTv55jXvrDQBkGwjxZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3668906115602307e+22
+    },
+    {
+        "timestamp": "2024-06-06T04:42:16.533Z",
+        "balance": 1.0129564859750537e+26,
+        "block_height": 120541907,
+        "epoch_id": "Db7EFLP7Q3ymECWH8j74GduM6koRX2PtCpu9Zav8XbXb",
+        "next_epoch_id": "BRhrQEc5Cu75b1dcd6WXQCXU2BMWoZrZrGWDif5uyXD1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3829092497200106e+22
+    },
+    {
+        "timestamp": "2024-06-05T14:38:15.095Z",
+        "balance": 1.0128181950500817e+26,
+        "block_height": 120498707,
+        "epoch_id": "EQpcBA3woXwG6e9WTCkNKDAc4oje649sc3dcCLvVLiy7",
+        "next_epoch_id": "Db7EFLP7Q3ymECWH8j74GduM6koRX2PtCpu9Zav8XbXb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4142384258435967e+22
+    },
+    {
+        "timestamp": "2024-06-05T00:22:41.993Z",
+        "balance": 1.0126767712074974e+26,
+        "block_height": 120455507,
+        "epoch_id": "4YBJXVzj6UU4DpVJ5gh4d7SxPQSTsTU9bUTsJTxBS8ob",
+        "next_epoch_id": "EQpcBA3woXwG6e9WTCkNKDAc4oje649sc3dcCLvVLiy7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.375395927876514e+22
+    },
+    {
+        "timestamp": "2024-06-04T09:46:57.413Z",
+        "balance": 1.0125392316147097e+26,
+        "block_height": 120412307,
+        "epoch_id": "Hc8rX5svN7gJts3duiAvqnCaGu3D6HGoKnmGcZwjJLqR",
+        "next_epoch_id": "4YBJXVzj6UU4DpVJ5gh4d7SxPQSTsTU9bUTsJTxBS8ob",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3805470723924522e+22
+    },
+    {
+        "timestamp": "2024-06-03T16:18:44.570Z",
+        "balance": 1.0124011769074705e+26,
+        "block_height": 120358320,
+        "epoch_id": "5Hc1KuMhcKTMLHGRVvMxXWK4Nbw2gwDNrHJ5gxR5b4yq",
+        "next_epoch_id": "Hc8rX5svN7gJts3duiAvqnCaGu3D6HGoKnmGcZwjJLqR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4281032011950707e+22
+    },
+    {
+        "timestamp": "2024-06-03T05:40:55.373Z",
+        "balance": 1.012258366587351e+26,
+        "block_height": 120325907,
+        "epoch_id": "BRDmgyrWnGefBFcYrKMgodFMvyb8Ga2CSeNzuW3GDR9c",
+        "next_epoch_id": "5Hc1KuMhcKTMLHGRVvMxXWK4Nbw2gwDNrHJ5gxR5b4yq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4413795476874824e+22
+    },
+    {
+        "timestamp": "2024-06-02T15:09:30.693Z",
+        "balance": 1.0121142286325822e+26,
+        "block_height": 120282707,
+        "epoch_id": "64P8hvFvgmDVfh39zPcoU55pvbkCAid6oBkv7jCBRx1M",
+        "next_epoch_id": "BRDmgyrWnGefBFcYrKMgodFMvyb8Ga2CSeNzuW3GDR9c",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.450626593410556e+22
+    },
+    {
+        "timestamp": "2024-06-02T00:26:37.315Z",
+        "balance": 1.0119691659732411e+26,
+        "block_height": 120239507,
+        "epoch_id": "5atv5Hr8hkLonGBjUzkR94FMya8y242Wz1vncWux2Pmu",
+        "next_epoch_id": "64P8hvFvgmDVfh39zPcoU55pvbkCAid6oBkv7jCBRx1M",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4326524373942999e+22
+    },
+    {
+        "timestamp": "2024-06-01T09:39:54.634Z",
+        "balance": 1.0118259007295017e+26,
+        "block_height": 120196307,
+        "epoch_id": "GhPbd6YUgXbnQPmG9TQG3LZeVjbZR1xAhsypgoCU3gd",
+        "next_epoch_id": "5atv5Hr8hkLonGBjUzkR94FMya8y242Wz1vncWux2Pmu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4796166218813545e+22
+    },
+    {
+        "timestamp": "2024-05-31T19:04:17.417Z",
+        "balance": 1.0116779390673136e+26,
+        "block_height": 120153107,
+        "epoch_id": "2NV5y1pbaQ5zwXuGtnCJFQu8zUj2Qz3cUjG4rmZc8d4o",
+        "next_epoch_id": "GhPbd6YUgXbnQPmG9TQG3LZeVjbZR1xAhsypgoCU3gd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4174540491097207e+22
+    },
+    {
+        "timestamp": "2024-05-31T03:52:13.405Z",
+        "balance": 1.0115361936624026e+26,
+        "block_height": 120109907,
+        "epoch_id": "EQzDX3HrhJSebo25yuWV7TaL8GumgaGfhSEbEqftZXS8",
+        "next_epoch_id": "2NV5y1pbaQ5zwXuGtnCJFQu8zUj2Qz3cUjG4rmZc8d4o",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4291678092471298e+22
+    },
+    {
+        "timestamp": "2024-05-30T13:18:26.497Z",
+        "balance": 1.0113932768814779e+26,
+        "block_height": 120066707,
+        "epoch_id": "5QRwCDE32hfakJDW4Mv6Kk4HSKcEgtJQoco6za6Cc5Nj",
+        "next_epoch_id": "EQzDX3HrhJSebo25yuWV7TaL8GumgaGfhSEbEqftZXS8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4299229442192316e+22
+    },
+    {
+        "timestamp": "2024-05-29T22:33:13.291Z",
+        "balance": 1.011250284587056e+26,
+        "block_height": 120023507,
+        "epoch_id": "8NRhYtxkVMNfkTCX5DuQccnXxe7shUukzzjnsa2UpBAd",
+        "next_epoch_id": "5QRwCDE32hfakJDW4Mv6Kk4HSKcEgtJQoco6za6Cc5Nj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3858484329858411e+22
+    },
+    {
+        "timestamp": "2024-05-29T07:35:25.058Z",
+        "balance": 1.0111116997437574e+26,
+        "block_height": 119980307,
+        "epoch_id": "4dsqvgNrXiCrBFLjpPouekHYbGzEHdb2B2UPrsddV8xV",
+        "next_epoch_id": "8NRhYtxkVMNfkTCX5DuQccnXxe7shUukzzjnsa2UpBAd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.401516759063328e+22
+    },
+    {
+        "timestamp": "2024-05-28T17:04:52.965Z",
+        "balance": 1.010971548067851e+26,
+        "block_height": 119937107,
+        "epoch_id": "taXLH5QiRoXW9G9VnG12rLuXGhG5EE5bBeGearrLAMW",
+        "next_epoch_id": "4dsqvgNrXiCrBFLjpPouekHYbGzEHdb2B2UPrsddV8xV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 9.813863994830837e+21
+    },
+    {
+        "timestamp": "2024-05-28T02:21:42.725Z",
+        "balance": 1.0108734094279027e+26,
+        "block_height": 119893907,
+        "epoch_id": "7MLjtN4MnQSa97voBuZhaseKuzWj5XcWkehi2s48bEt",
+        "next_epoch_id": "taXLH5QiRoXW9G9VnG12rLuXGhG5EE5bBeGearrLAMW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.288525726950225e+21
+    },
+    {
+        "timestamp": "2024-05-27T11:40:35.392Z",
+        "balance": 1.0108305241706332e+26,
+        "block_height": 119850707,
+        "epoch_id": "DSSJz73PcnnkMbmNNCvD1JNPT1WQs3GK5sKrCdEEPUqA",
+        "next_epoch_id": "7MLjtN4MnQSa97voBuZhaseKuzWj5XcWkehi2s48bEt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 213030137363431420
+    },
+    {
+        "timestamp": "2024-05-26T21:31:29.366Z",
+        "balance": 1.0108305220403319e+26,
+        "block_height": 119807507,
+        "epoch_id": "CXZifJPDuZsgtzvjCA4bs4cnjNBLqBi8o4dnPEnRyhZv",
+        "next_epoch_id": "DSSJz73PcnnkMbmNNCvD1JNPT1WQs3GK5sKrCdEEPUqA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 213829190259048450
+    },
+    {
+        "timestamp": "2024-05-26T07:04:27.256Z",
+        "balance": 1.01083051990204e+26,
+        "block_height": 119764307,
+        "epoch_id": "6b2s1bNHgu2876zR14c9qDMN2U5Sn9hDTwLjGo5Hsq4W",
+        "next_epoch_id": "CXZifJPDuZsgtzvjCA4bs4cnjNBLqBi8o4dnPEnRyhZv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3762512643394242e+22
+    },
+    {
+        "timestamp": "2024-05-25T16:59:34.224Z",
+        "balance": 1.010692894775606e+26,
+        "block_height": 119721107,
+        "epoch_id": "5tUvdaeSgN4Zq31m413wsQSuqATPb5ofFnANBDtBcRwC",
+        "next_epoch_id": "6b2s1bNHgu2876zR14c9qDMN2U5Sn9hDTwLjGo5Hsq4W",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3729418701020166e+22
+    },
+    {
+        "timestamp": "2024-05-25T02:35:50.921Z",
+        "balance": 1.0105556005885958e+26,
+        "block_height": 119677907,
+        "epoch_id": "2qygBKpC3D6PNC4L73J51Z8N6Bnx7KZednrcht7Jjvq4",
+        "next_epoch_id": "5tUvdaeSgN4Zq31m413wsQSuqATPb5ofFnANBDtBcRwC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3840211757463153e+22
+    },
+    {
+        "timestamp": "2024-05-24T12:13:33.771Z",
+        "balance": 1.0104171984710212e+26,
+        "block_height": 119634707,
+        "epoch_id": "A8uTrvNEwQuinJkcKfBUAEYQfQyHtYp8McvD3M8nevfr",
+        "next_epoch_id": "2qygBKpC3D6PNC4L73J51Z8N6Bnx7KZednrcht7Jjvq4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 3.5881473750936616e+21
+    },
+    {
+        "timestamp": "2024-05-23T21:58:22.139Z",
+        "balance": 1.0103813169972703e+26,
+        "block_height": 119591507,
+        "epoch_id": "DsngyQnqb63SxDmpww1L9P3ZasUGRd4FNTY4PKM9a5Yi",
+        "next_epoch_id": "A8uTrvNEwQuinJkcKfBUAEYQfQyHtYp8McvD3M8nevfr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3556016117552589e+22
+    },
+    {
+        "timestamp": "2024-05-23T07:32:48.312Z",
+        "balance": 1.0102457568360947e+26,
+        "block_height": 119548307,
+        "epoch_id": "B11oxTuFpcJS8hphsy1M6v17vWsWPGAtWQtZmVzGSGRB",
+        "next_epoch_id": "DsngyQnqb63SxDmpww1L9P3ZasUGRd4FNTY4PKM9a5Yi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 8.663199278178333e+21
+    },
+    {
+        "timestamp": "2024-05-22T17:33:15.488Z",
+        "balance": 1.010159124843313e+26,
+        "block_height": 119505107,
+        "epoch_id": "B2Gu4fHjBQFnHvRXCkd56u8BULWJ6SNxXsRNr4BCFEnm",
+        "next_epoch_id": "B11oxTuFpcJS8hphsy1M6v17vWsWPGAtWQtZmVzGSGRB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3826887208326004e+22
+    },
+    {
+        "timestamp": "2024-05-22T03:22:21.071Z",
+        "balance": 1.0100208559712297e+26,
+        "block_height": 119461907,
+        "epoch_id": "3HqumBZGdykrTbKGKfEEFZ2SQXGHeHWG2ckhsEGnDfdw",
+        "next_epoch_id": "B2Gu4fHjBQFnHvRXCkd56u8BULWJ6SNxXsRNr4BCFEnm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3571951520443609e+22
+    },
+    {
+        "timestamp": "2024-05-21T13:06:22.672Z",
+        "balance": 1.0098851364560253e+26,
+        "block_height": 119418707,
+        "epoch_id": "HcFvrge7XW56Eybnosw6LfQQM6hJ7jvCWbJN7fQXkBwA",
+        "next_epoch_id": "3HqumBZGdykrTbKGKfEEFZ2SQXGHeHWG2ckhsEGnDfdw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3555782054994736e+22
+    },
+    {
+        "timestamp": "2024-05-20T22:50:18.707Z",
+        "balance": 1.0097495786354753e+26,
+        "block_height": 119375507,
+        "epoch_id": "4dzkDcZfYrb81SPDhhfAfNA1WREzHXa1rPUZZEz3pHhc",
+        "next_epoch_id": "HcFvrge7XW56Eybnosw6LfQQM6hJ7jvCWbJN7fQXkBwA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3218831949936277e+22
+    },
+    {
+        "timestamp": "2024-05-20T08:36:16.733Z",
+        "balance": 1.009617390315976e+26,
+        "block_height": 119332307,
+        "epoch_id": "2H73RSgUR8tgwF36iMMBKxZHQZeL2x954iV53Uk1Z7v5",
+        "next_epoch_id": "4dzkDcZfYrb81SPDhhfAfNA1WREzHXa1rPUZZEz3pHhc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 8.615398329483e+21
+    },
+    {
+        "timestamp": "2024-05-19T18:43:13.730Z",
+        "balance": 1.0095312363326811e+26,
+        "block_height": 119289107,
+        "epoch_id": "BwA2Qok2wXzVh72Rq3y6KHjZtC9XHxYYvFj7Xzb1Q55E",
+        "next_epoch_id": "2H73RSgUR8tgwF36iMMBKxZHQZeL2x954iV53Uk1Z7v5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3136363671299618e+22
+    },
+    {
+        "timestamp": "2024-05-19T04:44:53.618Z",
+        "balance": 1.0093998726959681e+26,
+        "block_height": 119245907,
+        "epoch_id": "Hg9mD2RZpL5ANEWpPMMP2W3Tee88tZz8wYhyW1DfYWMZ",
+        "next_epoch_id": "BwA2Qok2wXzVh72Rq3y6KHjZtC9XHxYYvFj7Xzb1Q55E",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3070149836341886e+22
+    },
+    {
+        "timestamp": "2024-05-18T14:56:48.821Z",
+        "balance": 1.0092691711976047e+26,
+        "block_height": 119202707,
+        "epoch_id": "2H8P24YVXTyrZPqmerXMVWcs5fbabAizKR218xdUKpg3",
+        "next_epoch_id": "Hg9mD2RZpL5ANEWpPMMP2W3Tee88tZz8wYhyW1DfYWMZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 220168338649645060
+    },
+    {
+        "timestamp": "2024-05-18T01:14:30.408Z",
+        "balance": 1.0092691689959213e+26,
+        "block_height": 119159507,
+        "epoch_id": "8nU64P6zXYvreJKtUkACp9Qw9SEaVoMK9mrQMCaQQr4d",
+        "next_epoch_id": "2H8P24YVXTyrZPqmerXMVWcs5fbabAizKR218xdUKpg3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 227263504363552770
+    },
+    {
+        "timestamp": "2024-05-17T11:20:08.895Z",
+        "balance": 1.0092691667232863e+26,
+        "block_height": 119116307,
+        "epoch_id": "Bh16JHDALmr2K4hXwJ6fHqeQje3ZfqXqanEqrGypxkCH",
+        "next_epoch_id": "8nU64P6zXYvreJKtUkACp9Qw9SEaVoMK9mrQMCaQQr4d",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 232246199002857470
+    },
+    {
+        "timestamp": "2024-05-16T21:32:41.556Z",
+        "balance": 1.0092691644008243e+26,
+        "block_height": 119073107,
+        "epoch_id": "63yzLJbaWTFcSBorewcweK3bzzDFH59gKtikuZG1tQTA",
+        "next_epoch_id": "Bh16JHDALmr2K4hXwJ6fHqeQje3ZfqXqanEqrGypxkCH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 228756005498912770
+    },
+    {
+        "timestamp": "2024-05-16T07:35:15.960Z",
+        "balance": 1.0092691621132642e+26,
+        "block_height": 119029907,
+        "epoch_id": "F5dpqJSdk9h8b1cFm2mZuL7i8TyDT22fgmD4j9zpDiPB",
+        "next_epoch_id": "63yzLJbaWTFcSBorewcweK3bzzDFH59gKtikuZG1tQTA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 8.351017212109505e+21
+    },
+    {
+        "timestamp": "2024-05-15T17:34:29.765Z",
+        "balance": 1.0091856519411431e+26,
+        "block_height": 118986707,
+        "epoch_id": "9QLkmJFHznDVNdm5ZK5jiTwsWMEwZHGoUb3Wqfvvr9wh",
+        "next_epoch_id": "F5dpqJSdk9h8b1cFm2mZuL7i8TyDT22fgmD4j9zpDiPB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.452580525520439e+22
+    },
+    {
+        "timestamp": "2024-05-15T03:11:18.375Z",
+        "balance": 1.009040393888591e+26,
+        "block_height": 118943507,
+        "epoch_id": "HZ7WqvJhwk1EMCB5yvXuaCtJowuqUeYHkztNcpWrq1vx",
+        "next_epoch_id": "9QLkmJFHznDVNdm5ZK5jiTwsWMEwZHGoUb3Wqfvvr9wh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.1254009819477863e+22
+    },
+    {
+        "timestamp": "2024-05-14T12:00:03.791Z",
+        "balance": 1.0089278537903963e+26,
+        "block_height": 118900307,
+        "epoch_id": "GWCbeBuF9h96BJYLTtHLmcPASq5oaybUi4HqJ8H1Ry2G",
+        "next_epoch_id": "HZ7WqvJhwk1EMCB5yvXuaCtJowuqUeYHkztNcpWrq1vx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5408754791235461e+22
+    },
+    {
+        "timestamp": "2024-05-13T20:01:38.104Z",
+        "balance": 1.008773766242484e+26,
+        "block_height": 118857107,
+        "epoch_id": "7TwMSQBie87dfNZeB5qNo1UpUhjAr2jZZBwojKPyk6sX",
+        "next_epoch_id": "GWCbeBuF9h96BJYLTtHLmcPASq5oaybUi4HqJ8H1Ry2G",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5362350068633474e+22
+    },
+    {
+        "timestamp": "2024-05-13T04:03:05.591Z",
+        "balance": 1.0086201427417976e+26,
+        "block_height": 118813907,
+        "epoch_id": "W1hgpXkx9sRtb9WNfd3xTyfaUpRoEHoEEvDqpRfeADb",
+        "next_epoch_id": "7TwMSQBie87dfNZeB5qNo1UpUhjAr2jZZBwojKPyk6sX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.669897400595274e+21
+    },
+    {
+        "timestamp": "2024-05-12T12:01:46.020Z",
+        "balance": 1.0085634437677917e+26,
+        "block_height": 118770707,
+        "epoch_id": "EfYBodnDm9EUo7pEaMXN2oewypGweKtFJfhY3gphh8H8",
+        "next_epoch_id": "W1hgpXkx9sRtb9WNfd3xTyfaUpRoEHoEEvDqpRfeADb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5033382889116221e+22
+    },
+    {
+        "timestamp": "2024-05-11T20:03:50.055Z",
+        "balance": 1.0084131099389005e+26,
+        "block_height": 118727507,
+        "epoch_id": "FvqjY1oTvQHWYBNMmHjsgxbahXj9VXPUmLFXsWNvQ8zC",
+        "next_epoch_id": "EfYBodnDm9EUo7pEaMXN2oewypGweKtFJfhY3gphh8H8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5039016652762685e+22
+    },
+    {
+        "timestamp": "2024-05-11T04:22:39.550Z",
+        "balance": 1.0082627197723729e+26,
+        "block_height": 118684307,
+        "epoch_id": "GSpv4pLm63QUFXiHuf57JwscVSEhWd6br5kABfscvnBN",
+        "next_epoch_id": "FvqjY1oTvQHWYBNMmHjsgxbahXj9VXPUmLFXsWNvQ8zC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4787748395672903e+22
+    },
+    {
+        "timestamp": "2024-05-10T12:41:48.535Z",
+        "balance": 1.0081148422884161e+26,
+        "block_height": 118641107,
+        "epoch_id": "An7nz7unUyMLXgvttbjU3qbeufXTX93Z7wi9R6r8Xw3B",
+        "next_epoch_id": "GSpv4pLm63QUFXiHuf57JwscVSEhWd6br5kABfscvnBN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.1354730184529391e+22
+    },
+    {
+        "timestamp": "2024-05-09T21:14:45.517Z",
+        "balance": 1.0080012949865708e+26,
+        "block_height": 118597907,
+        "epoch_id": "6C9Jn1jrmk42PqetDWei9ibpiuRntJK6tu9Jmr9wWNyr",
+        "next_epoch_id": "An7nz7unUyMLXgvttbjU3qbeufXTX93Z7wi9R6r8Xw3B",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 7.427562740868874e+21
+    },
+    {
+        "timestamp": "2024-05-09T05:54:58.671Z",
+        "balance": 1.0079270193591622e+26,
+        "block_height": 118554707,
+        "epoch_id": "9x6ebXcP2sXvcpxZdjYH4jbPpqv9844in9w82Lsm3BmV",
+        "next_epoch_id": "6C9Jn1jrmk42PqetDWei9ibpiuRntJK6tu9Jmr9wWNyr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 9.694671345356156e+21
+    },
+    {
+        "timestamp": "2024-05-08T14:51:54.616Z",
+        "balance": 1.0078300726457086e+26,
+        "block_height": 118511507,
+        "epoch_id": "4fcBsoKs6DAyTYmCiqUxGvbBJzGRx1qKoBDkVABHgRvH",
+        "next_epoch_id": "9x6ebXcP2sXvcpxZdjYH4jbPpqv9844in9w82Lsm3BmV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4947048543204766e+22
+    },
+    {
+        "timestamp": "2024-05-07T23:54:14.529Z",
+        "balance": 1.0076806021602766e+26,
+        "block_height": 118468307,
+        "epoch_id": "7w9GQ2X5iSifDv6ENzpkBPoh1xbaaFBQPo7LW12wDcao",
+        "next_epoch_id": "4fcBsoKs6DAyTYmCiqUxGvbBJzGRx1qKoBDkVABHgRvH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.69588198614177e+21
+    },
+    {
+        "timestamp": "2024-05-07T08:57:34.451Z",
+        "balance": 1.0076336433404151e+26,
+        "block_height": 118425107,
+        "epoch_id": "54q3Pup7dA3mLq2jbS2KKcTEhAacSDp6RvYqQKyAZWV8",
+        "next_epoch_id": "7w9GQ2X5iSifDv6ENzpkBPoh1xbaaFBQPo7LW12wDcao",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 9.720844679932593e+21
+    },
+    {
+        "timestamp": "2024-05-06T18:10:10.209Z",
+        "balance": 1.0075364348936158e+26,
+        "block_height": 118381907,
+        "epoch_id": "BYs4JSztGfZBKSLz2YhUAtrHTzNBV49P84d15jaCmKhS",
+        "next_epoch_id": "54q3Pup7dA3mLq2jbS2KKcTEhAacSDp6RvYqQKyAZWV8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7400829097079487e+22
+    },
+    {
+        "timestamp": "2024-05-05T12:32:00.266Z",
+        "balance": 1.007362426602645e+26,
+        "block_height": 118296621,
+        "epoch_id": "JDjhbRayPzAcXpY4MPBKzrcnhcdw4cYngAnrh8P61WdE",
+        "next_epoch_id": "BYs4JSztGfZBKSLz2YhUAtrHTzNBV49P84d15jaCmKhS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-05-05T12:08:21.455Z",
+        "balance": 1.007362426602645e+26,
+        "block_height": 118295507,
+        "epoch_id": "8BJdHWNq69H4PE33wZqcoEV5dXJUpuXKotivLZFSXuV7",
+        "next_epoch_id": "JDjhbRayPzAcXpY4MPBKzrcnhcdw4cYngAnrh8P61WdE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.496542802030814e+22
+    },
+    {
+        "timestamp": "2024-05-04T21:09:07.843Z",
+        "balance": 1.007212772322442e+26,
+        "block_height": 118252307,
+        "epoch_id": "B4mvpNoK5jyy7PsYbCpCFNVgszLFvAHKEnUTXfTw6zrm",
+        "next_epoch_id": "8BJdHWNq69H4PE33wZqcoEV5dXJUpuXKotivLZFSXuV7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5016951987118256e+22
+    },
+    {
+        "timestamp": "2024-05-04T06:13:20.450Z",
+        "balance": 1.0070626028025707e+26,
+        "block_height": 118209107,
+        "epoch_id": "GB5AwvbLDRbAmDXVAAh9RyKeJvvEKdUoxWVK3Z3rMaGg",
+        "next_epoch_id": "B4mvpNoK5jyy7PsYbCpCFNVgszLFvAHKEnUTXfTw6zrm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.0404641952377036e+22
+    },
+    {
+        "timestamp": "2024-05-03T15:14:51.687Z",
+        "balance": 1.006958556383047e+26,
+        "block_height": 118165907,
+        "epoch_id": "qyLu2YwgZgHvDjCs6daGEuyempAQErgPMQHGVXC6uoG",
+        "next_epoch_id": "GB5AwvbLDRbAmDXVAAh9RyKeJvvEKdUoxWVK3Z3rMaGg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4909004360647902e+22
+    },
+    {
+        "timestamp": "2024-05-02T23:41:35.805Z",
+        "balance": 1.0068094663394405e+26,
+        "block_height": 118122707,
+        "epoch_id": "B1yhwgFsTaB8XvVcN7aVsdJQrHWxcxB7iwsimjUA3Vfs",
+        "next_epoch_id": "qyLu2YwgZgHvDjCs6daGEuyempAQErgPMQHGVXC6uoG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4091203624181848e+22
+    },
+    {
+        "timestamp": "2024-05-02T08:56:45.241Z",
+        "balance": 1.0066685543031987e+26,
+        "block_height": 118079507,
+        "epoch_id": "GY7CfT1SQDhuoAFNoVxZwiUNv6X8jS7NZmZQ7ZQYzpfh",
+        "next_epoch_id": "B1yhwgFsTaB8XvVcN7aVsdJQrHWxcxB7iwsimjUA3Vfs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5192449185316723e+22
+    },
+    {
+        "timestamp": "2024-05-01T11:31:42.849Z",
+        "balance": 1.0065166298113455e+26,
+        "block_height": 118014164,
+        "epoch_id": "A2MvNweQfALBhn4EERLMDAjAnWqUuNvAHP5vtJRxpJEk",
+        "next_epoch_id": "GY7CfT1SQDhuoAFNoVxZwiUNv6X8jS7NZmZQ7ZQYzpfh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.580769382289525e+22
+    },
+    {
+        "timestamp": "2024-05-01T03:56:07.498Z",
+        "balance": 1.0063585528731166e+26,
+        "block_height": 117993107,
+        "epoch_id": "E9cdXo1YaKXuK3u9agVYoRinJsaETYAzk1L2sVQXPxKf",
+        "next_epoch_id": "A2MvNweQfALBhn4EERLMDAjAnWqUuNvAHP5vtJRxpJEk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5314253446005708e+22
+    },
+    {
+        "timestamp": "2024-04-30T12:19:52.078Z",
+        "balance": 1.0062054103386565e+26,
+        "block_height": 117949907,
+        "epoch_id": "9iq6LXXBSJYBhBGyLJkW8fvAJsKC9EDMdfYvaStXpo2v",
+        "next_epoch_id": "E9cdXo1YaKXuK3u9agVYoRinJsaETYAzk1L2sVQXPxKf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5158728599998617e+22
+    },
+    {
+        "timestamp": "2024-04-29T21:00:23.329Z",
+        "balance": 1.0060538230526565e+26,
+        "block_height": 117906707,
+        "epoch_id": "2GDrQEJMhr5ZJwSWZeQBDwFbo8v6GGk7k9WuhAmzp9Fs",
+        "next_epoch_id": "9iq6LXXBSJYBhBGyLJkW8fvAJsKC9EDMdfYvaStXpo2v",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 9.65019738934462e+21
+    },
+    {
+        "timestamp": "2024-04-29T05:50:23.472Z",
+        "balance": 1.005957321078763e+26,
+        "block_height": 117863507,
+        "epoch_id": "FG32HXpSoCUvgXCRpQyDgKx2imsVq4nKL7C3YQdUfsjP",
+        "next_epoch_id": "2GDrQEJMhr5ZJwSWZeQBDwFbo8v6GGk7k9WuhAmzp9Fs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.423642534591649e+22
+    },
+    {
+        "timestamp": "2024-04-28T16:03:46.000Z",
+        "balance": 1.0058149568253039e+26,
+        "block_height": 117820307,
+        "epoch_id": "7qcaLcSLkFfYzRrLXzmqYYfNPHQAj7sNaQ3tE89mreU7",
+        "next_epoch_id": "FG32HXpSoCUvgXCRpQyDgKx2imsVq4nKL7C3YQdUfsjP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.453526066283223e+22
+    },
+    {
+        "timestamp": "2024-04-28T01:49:40.418Z",
+        "balance": 1.0056696042186756e+26,
+        "block_height": 117777107,
+        "epoch_id": "FEoH4ZhcdeKvWjLpUHxDYcBi2pYdxQf2rKtGgJDEiPj",
+        "next_epoch_id": "7qcaLcSLkFfYzRrLXzmqYYfNPHQAj7sNaQ3tE89mreU7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.421318581816754e+22
+    },
+    {
+        "timestamp": "2024-04-27T11:19:43.664Z",
+        "balance": 1.0055274723604939e+26,
+        "block_height": 117733907,
+        "epoch_id": "BzYNd3DYcSJN2S7keGPaHohWrteqKcUfQ7d1KkLLFBVe",
+        "next_epoch_id": "FEoH4ZhcdeKvWjLpUHxDYcBi2pYdxQf2rKtGgJDEiPj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.094745422554106e+22
+    },
+    {
+        "timestamp": "2024-04-26T21:08:43.266Z",
+        "balance": 1.0054179978182385e+26,
+        "block_height": 117690707,
+        "epoch_id": "3mGCairDJoN5Wwfq2GGw4HaQDp3VoGtq9FWrNbRRHqHs",
+        "next_epoch_id": "BzYNd3DYcSJN2S7keGPaHohWrteqKcUfQ7d1KkLLFBVe",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4368919707431293e+22
+    },
+    {
+        "timestamp": "2024-04-26T06:50:54.087Z",
+        "balance": 1.0052743086211642e+26,
+        "block_height": 117647507,
+        "epoch_id": "4jrdNNLyJRCDiDoLd2YgWgA1AZoiUnAZnYPpjEC7dVqF",
+        "next_epoch_id": "3mGCairDJoN5Wwfq2GGw4HaQDp3VoGtq9FWrNbRRHqHs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4459851161503439e+22
+    },
+    {
+        "timestamp": "2024-04-25T16:31:11.377Z",
+        "balance": 1.0051297101095492e+26,
+        "block_height": 117604307,
+        "epoch_id": "CjZETa66hPYdfesDrHXtzpVkL4Pq7NDUEsGpoKQkSqbQ",
+        "next_epoch_id": "4jrdNNLyJRCDiDoLd2YgWgA1AZoiUnAZnYPpjEC7dVqF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4774242736200198e+22
+    },
+    {
+        "timestamp": "2024-04-24T19:01:14.109Z",
+        "balance": 1.0049819676821871e+26,
+        "block_height": 117539541,
+        "epoch_id": "CX9sQUHY1DBwc23TQS3iriXPCjDXm2FYwBEcysq1innX",
+        "next_epoch_id": "CjZETa66hPYdfesDrHXtzpVkL4Pq7NDUEsGpoKQkSqbQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.44981309686634e+22
+    },
+    {
+        "timestamp": "2024-04-24T11:22:57.554Z",
+        "balance": 1.0048369863725005e+26,
+        "block_height": 117517907,
+        "epoch_id": "C589TPFXn4SMogMpJy65CFBDzWi2gvkbj1jAh6SKYs6c",
+        "next_epoch_id": "CX9sQUHY1DBwc23TQS3iriXPCjDXm2FYwBEcysq1innX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.261789752577694e+21
+    },
+    {
+        "timestamp": "2024-04-23T20:58:26.006Z",
+        "balance": 1.0047843684749747e+26,
+        "block_height": 117474707,
+        "epoch_id": "65RDCwsUEK2pvgNrqbovrP8cJPufxikzGkU95wMKxhRk",
+        "next_epoch_id": "C589TPFXn4SMogMpJy65CFBDzWi2gvkbj1jAh6SKYs6c",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5039346048321605e+22
+    },
+    {
+        "timestamp": "2024-04-23T05:44:12.755Z",
+        "balance": 1.0046339750144915e+26,
+        "block_height": 117431507,
+        "epoch_id": "HbD2aDcntfHDt7wbUwYEG6xt3TUDwBNtKJW71L8RC1s3",
+        "next_epoch_id": "65RDCwsUEK2pvgNrqbovrP8cJPufxikzGkU95wMKxhRk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4615244224840008e+22
+    },
+    {
+        "timestamp": "2024-04-22T14:52:11.481Z",
+        "balance": 1.0044878225722431e+26,
+        "block_height": 117388307,
+        "epoch_id": "CjzyboFhTbJvcA3wma7VBcA9yaWLfyy7tWXYV1WrYdWr",
+        "next_epoch_id": "HbD2aDcntfHDt7wbUwYEG6xt3TUDwBNtKJW71L8RC1s3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5141507313757787e+22
+    },
+    {
+        "timestamp": "2024-04-22T00:26:42.557Z",
+        "balance": 1.0043364074991055e+26,
+        "block_height": 117345107,
+        "epoch_id": "3CYpF9xcVMXaj4gvcMBmBweQ6bMojTeqxiwhTZ9wUkcJ",
+        "next_epoch_id": "CjzyboFhTbJvcA3wma7VBcA9yaWLfyy7tWXYV1WrYdWr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 6.28644874495099e+21
+    },
+    {
+        "timestamp": "2024-04-21T09:26:55.866Z",
+        "balance": 1.004273543011656e+26,
+        "block_height": 117301907,
+        "epoch_id": "G85kZnKLt45Ztf2YByQV4i2F8yxM1b79VTrqffMX5yyM",
+        "next_epoch_id": "3CYpF9xcVMXaj4gvcMBmBweQ6bMojTeqxiwhTZ9wUkcJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.0307681905272752e+22
+    },
+    {
+        "timestamp": "2024-04-20T18:39:19.660Z",
+        "balance": 1.0041704661926033e+26,
+        "block_height": 117258707,
+        "epoch_id": "8asHVcDzJ5WVoBQZC71uxUipmWC275AL6bpYewMhSLep",
+        "next_epoch_id": "G85kZnKLt45Ztf2YByQV4i2F8yxM1b79VTrqffMX5yyM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.0315538814583708e+22
+    },
+    {
+        "timestamp": "2024-04-20T03:58:44.659Z",
+        "balance": 1.0040673108044575e+26,
+        "block_height": 117215507,
+        "epoch_id": "BwSu5qRbRuAKSij8jzZrpfrqmHbFLhfv6xxQHF6FFP7q",
+        "next_epoch_id": "8asHVcDzJ5WVoBQZC71uxUipmWC275AL6bpYewMhSLep",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 9.949473074067582e+21
+    },
+    {
+        "timestamp": "2024-04-19T12:45:53.257Z",
+        "balance": 1.0039678160737168e+26,
+        "block_height": 117172307,
+        "epoch_id": "DmwqNvGvWpyPYgy5NNBXnn1bmRtnEiTKkNMnVDXoVrEA",
+        "next_epoch_id": "BwSu5qRbRuAKSij8jzZrpfrqmHbFLhfv6xxQHF6FFP7q",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5513461267485392e+22
+    },
+    {
+        "timestamp": "2024-04-18T20:08:32.232Z",
+        "balance": 1.003812681461042e+26,
+        "block_height": 117126468,
+        "epoch_id": "AFBz3fZPkMPQxk3kHhZXN9uVCoGNphLwv8YvxvM62bTt",
+        "next_epoch_id": "DmwqNvGvWpyPYgy5NNBXnn1bmRtnEiTKkNMnVDXoVrEA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5484875078487459e+22
+    },
+    {
+        "timestamp": "2024-04-18T05:48:03.794Z",
+        "balance": 1.003657832710257e+26,
+        "block_height": 117085907,
+        "epoch_id": "GAxxe3Nr1HJNQJy5dRXFBZ8koprdT6KWYgZaQpQWecjd",
+        "next_epoch_id": "AFBz3fZPkMPQxk3kHhZXN9uVCoGNphLwv8YvxvM62bTt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5025716991758426e+22
+    },
+    {
+        "timestamp": "2024-04-17T14:36:50.026Z",
+        "balance": 1.0035075755403395e+26,
+        "block_height": 117042707,
+        "epoch_id": "25cDwcPmuiazBivtWjLRWV3KLmiXPHZXjsquu4b2Sd1B",
+        "next_epoch_id": "GAxxe3Nr1HJNQJy5dRXFBZ8koprdT6KWYgZaQpQWecjd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 225273319597801470
+    },
+    {
+        "timestamp": "2024-04-16T23:46:45.098Z",
+        "balance": 1.0035075732876063e+26,
+        "block_height": 116999507,
+        "epoch_id": "7s3GUtrjMBTNMtvKmKScLzPz5ESwGiPTAQgkzCPU313f",
+        "next_epoch_id": "25cDwcPmuiazBivtWjLRWV3KLmiXPHZXjsquu4b2Sd1B",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 227413192563752960
+    },
+    {
+        "timestamp": "2024-04-16T08:34:44.071Z",
+        "balance": 1.0035075710134744e+26,
+        "block_height": 116956307,
+        "epoch_id": "ATaGK7y1iDRCLrWuH1PU9eW5rf8rnrhCXqkFGzmc7gtw",
+        "next_epoch_id": "7s3GUtrjMBTNMtvKmKScLzPz5ESwGiPTAQgkzCPU313f",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 256721482455973900
+    },
+    {
+        "timestamp": "2024-04-15T04:24:24.580Z",
+        "balance": 1.0035075684462595e+26,
+        "block_height": 116873662,
+        "epoch_id": "Bag1Nc3jtMwXDa2dSAZcSSwBtx5JtSqZbQwtXFxDJbm9",
+        "next_epoch_id": "ATaGK7y1iDRCLrWuH1PU9eW5rf8rnrhCXqkFGzmc7gtw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 230244211666976770
+    },
+    {
+        "timestamp": "2024-04-15T03:03:49.700Z",
+        "balance": 1.0035075661438174e+26,
+        "block_height": 116869907,
+        "epoch_id": "A1qjJXMmRESTMfWu9pZZ6aFPvbtqU9wsBZm12ENjT9pB",
+        "next_epoch_id": "Bag1Nc3jtMwXDa2dSAZcSSwBtx5JtSqZbQwtXFxDJbm9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 222431064860131330
+    },
+    {
+        "timestamp": "2024-04-14T12:27:28.051Z",
+        "balance": 1.0035075639195068e+26,
+        "block_height": 116826707,
+        "epoch_id": "qb87bxXix6hBogt46zdihHJZczS7Y8VLx8Zbe2sWLVz",
+        "next_epoch_id": "A1qjJXMmRESTMfWu9pZZ6aFPvbtqU9wsBZm12ENjT9pB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 212482597752668160
+    },
+    {
+        "timestamp": "2024-04-13T12:06:37.380Z",
+        "balance": 1.0035075617946808e+26,
+        "block_height": 116755251,
+        "epoch_id": "G5LYA2Wtqkvb4QJkQgkM4zAxPeNkDGYBrWhGmk8yzLf7",
+        "next_epoch_id": "qb87bxXix6hBogt46zdihHJZczS7Y8VLx8Zbe2sWLVz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 252479377617453060
+    },
+    {
+        "timestamp": "2024-04-13T06:39:09.567Z",
+        "balance": 1.003507559269887e+26,
+        "block_height": 116740307,
+        "epoch_id": "4eGxYzrNFZ87hLFz2hqW1n4eM1oGZQmLSb42BqnEGAeb",
+        "next_epoch_id": "G5LYA2Wtqkvb4QJkQgkM4zAxPeNkDGYBrWhGmk8yzLf7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 229531281455579140
+    },
+    {
+        "timestamp": "2024-04-12T16:42:01.060Z",
+        "balance": 1.0035075569745742e+26,
+        "block_height": 116697107,
+        "epoch_id": "8h3AB2R4rYtv9uJXVvsqqYNzWzmkGVimAgRcd7SCr2Uo",
+        "next_epoch_id": "4eGxYzrNFZ87hLFz2hqW1n4eM1oGZQmLSb42BqnEGAeb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 208929749265809400
+    },
+    {
+        "timestamp": "2024-04-12T03:04:33.170Z",
+        "balance": 1.0035075548852767e+26,
+        "block_height": 116653907,
+        "epoch_id": "FJuvy46XvyaqbHsXK7ZPmVH6ersLEnxgYV9H9YxiGCcr",
+        "next_epoch_id": "8h3AB2R4rYtv9uJXVvsqqYNzWzmkGVimAgRcd7SCr2Uo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 245362152951513100
+    },
+    {
+        "timestamp": "2024-04-11T12:55:03.137Z",
+        "balance": 1.0035075524316552e+26,
+        "block_height": 116610707,
+        "epoch_id": "HLfSctMMdDZbetVv1jLeZxUCwURYYTxfu2Vzdcddbhxx",
+        "next_epoch_id": "FJuvy46XvyaqbHsXK7ZPmVH6ersLEnxgYV9H9YxiGCcr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 287918578705891330
+    },
+    {
+        "timestamp": "2024-04-10T21:31:46.584Z",
+        "balance": 1.0035075495524694e+26,
+        "block_height": 116567507,
+        "epoch_id": "5frqB5yTGSP1vaYgRbSPNdMBcuMv9vdMTe29wizwmwnA",
+        "next_epoch_id": "HLfSctMMdDZbetVv1jLeZxUCwURYYTxfu2Vzdcddbhxx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 288719538566987800
+    },
+    {
+        "timestamp": "2024-04-10T07:22:42.329Z",
+        "balance": 1.003507546665274e+26,
+        "block_height": 116524307,
+        "epoch_id": "3H7sGYLLVjChNXDAEWjZcwRErXGCPE5D8t1qxFTr6r29",
+        "next_epoch_id": "5frqB5yTGSP1vaYgRbSPNdMBcuMv9vdMTe29wizwmwnA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3660084847491854e+22
+    },
+    {
+        "timestamp": "2024-04-09T17:16:55.699Z",
+        "balance": 1.0033709458167991e+26,
+        "block_height": 116481107,
+        "epoch_id": "BKx9ihnnXimUA7CmFiyrX8YtQVtik9cr71cNQMwWUUFk",
+        "next_epoch_id": "3H7sGYLLVjChNXDAEWjZcwRErXGCPE5D8t1qxFTr6r29",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3869628863306755e+22
+    },
+    {
+        "timestamp": "2024-04-08T16:49:36.985Z",
+        "balance": 1.003232249528166e+26,
+        "block_height": 116406126,
+        "epoch_id": "DmPikjtApR58Qt33oE5tXhkpwtcDWhAFnV8GSbTkdCJL",
+        "next_epoch_id": "BKx9ihnnXimUA7CmFiyrX8YtQVtik9cr71cNQMwWUUFk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 8.7123738502034e+21
+    },
+    {
+        "timestamp": "2024-04-08T12:53:47.159Z",
+        "balance": 1.003145125789664e+26,
+        "block_height": 116394707,
+        "epoch_id": "Mn9K8ymKGF1gGeQTFaBCJ6XrkSGY3CSzsBdqejRTeY9",
+        "next_epoch_id": "DmPikjtApR58Qt33oE5tXhkpwtcDWhAFnV8GSbTkdCJL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 287311957525004300
+    },
+    {
+        "timestamp": "2024-04-07T23:02:41.812Z",
+        "balance": 1.0031451229165444e+26,
+        "block_height": 116351507,
+        "epoch_id": "B7gGUj1aNSLMCsDA82vsM2sfwVSvB4VS1fXXmqSt7cqL",
+        "next_epoch_id": "Mn9K8ymKGF1gGeQTFaBCJ6XrkSGY3CSzsBdqejRTeY9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3507749013516632e+22
+    },
+    {
+        "timestamp": "2024-04-07T09:00:14.113Z",
+        "balance": 1.0030100454264092e+26,
+        "block_height": 116308307,
+        "epoch_id": "7vmnNQfyqYCPkqnTuHy5Eutw3jQdfjjWKDeZE2E8gmYN",
+        "next_epoch_id": "B7gGUj1aNSLMCsDA82vsM2sfwVSvB4VS1fXXmqSt7cqL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 304869319974584300
+    },
+    {
+        "timestamp": "2024-04-06T19:16:01.195Z",
+        "balance": 1.003010042377716e+26,
+        "block_height": 116265107,
+        "epoch_id": "He7VjZpL2VNnjKdu2KHc7ER7frKprjVmU8vXNNBJKwrt",
+        "next_epoch_id": "7vmnNQfyqYCPkqnTuHy5Eutw3jQdfjjWKDeZE2E8gmYN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5445615373301964e+22
+    },
+    {
+        "timestamp": "2024-04-06T04:03:50.740Z",
+        "balance": 1.002855586223983e+26,
+        "block_height": 116221907,
+        "epoch_id": "3FYi4s79NFAJf14SEzwTjs6WowCMnK2pWgaJk7oXrU5K",
+        "next_epoch_id": "He7VjZpL2VNnjKdu2KHc7ER7frKprjVmU8vXNNBJKwrt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.530121190708992e+22
+    },
+    {
+        "timestamp": "2024-04-05T12:10:43.185Z",
+        "balance": 1.0027025741049121e+26,
+        "block_height": 116178707,
+        "epoch_id": "CBpjd66pS1UsZLyH4mHRV8EDG2krV6tzbDPC9BeeNSy9",
+        "next_epoch_id": "3FYi4s79NFAJf14SEzwTjs6WowCMnK2pWgaJk7oXrU5K",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5450690587034382e+22
+    },
+    {
+        "timestamp": "2024-04-04T20:33:23.098Z",
+        "balance": 1.0025480671990418e+26,
+        "block_height": 116135507,
+        "epoch_id": "DEiokvsj2jJHBGiKNHzKmQSaC7kdBQZVgZAE6jD2NAhn",
+        "next_epoch_id": "CBpjd66pS1UsZLyH4mHRV8EDG2krV6tzbDPC9BeeNSy9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.551142087865794e+22
+    },
+    {
+        "timestamp": "2024-04-04T04:50:09.634Z",
+        "balance": 1.0023929529902552e+26,
+        "block_height": 116092307,
+        "epoch_id": "CcGs4B7N4RKnwX7S3aEMzVWpv46Nmdtjb5jBnJkfaGsB",
+        "next_epoch_id": "DEiokvsj2jJHBGiKNHzKmQSaC7kdBQZVgZAE6jD2NAhn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5449748396193188e+22
+    },
+    {
+        "timestamp": "2024-04-03T12:57:44.741Z",
+        "balance": 1.0022384555062933e+26,
+        "block_height": 116049107,
+        "epoch_id": "FcXMkELZvaCi6L5YUL6PWfW462NCwv7mrVZPBQMtQQB4",
+        "next_epoch_id": "CcGs4B7N4RKnwX7S3aEMzVWpv46Nmdtjb5jBnJkfaGsB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5675168054638253e+22
+    },
+    {
+        "timestamp": "2024-04-02T15:41:20.367Z",
+        "balance": 1.0020817038257469e+26,
+        "block_height": 115990974,
+        "epoch_id": "EVcdmjn9GWdDusCGjCJ27waXFwtBNdSMaRHvZoXt1VAG",
+        "next_epoch_id": "FcXMkELZvaCi6L5YUL6PWfW462NCwv7mrVZPBQMtQQB4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 229066548814282750
+    },
+    {
+        "timestamp": "2024-04-01T19:35:49.695Z",
+        "balance": 1.0020817015350814e+26,
+        "block_height": 115936458,
+        "epoch_id": "DZzuNu9c2AVKHku3bimHfvfWmeoYWH2rvAv9KfJSVWxZ",
+        "next_epoch_id": "EVcdmjn9GWdDusCGjCJ27waXFwtBNdSMaRHvZoXt1VAG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 9.668058697318248e+21
+    },
+    {
+        "timestamp": "2024-04-01T13:11:02.474Z",
+        "balance": 1.0019850209481082e+26,
+        "block_height": 115919507,
+        "epoch_id": "7MjypaqsGBaca6osmLfjLBtiskb2wgUfCwBEWySMUJpH",
+        "next_epoch_id": "DZzuNu9c2AVKHku3bimHfvfWmeoYWH2rvAv9KfJSVWxZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 299863844828741600
+    },
+    {
+        "timestamp": "2024-03-31T21:34:03.647Z",
+        "balance": 1.0019850179494698e+26,
+        "block_height": 115876307,
+        "epoch_id": "J9h8BCb7BKLZjoJZt883sFqMDMGJHGBTHvEMf26Qp3co",
+        "next_epoch_id": "7MjypaqsGBaca6osmLfjLBtiskb2wgUfCwBEWySMUJpH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 291537810207277060
+    },
+    {
+        "timestamp": "2024-03-30T19:34:07.321Z",
+        "balance": 1.0019850150340917e+26,
+        "block_height": 115804680,
+        "epoch_id": "8DnB8RqdFM2A8GRbfZ1btymgZGNbhcNSypmNstiRGGqt",
+        "next_epoch_id": "J9h8BCb7BKLZjoJZt883sFqMDMGJHGBTHvEMf26Qp3co",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 342691712516227100
+    },
+    {
+        "timestamp": "2024-03-30T14:04:34.180Z",
+        "balance": 1.0019850116071745e+26,
+        "block_height": 115789907,
+        "epoch_id": "BnRpa5EZToPa98ztpc1y99a2upVuY4REcU9J9ktJqAha",
+        "next_epoch_id": "8DnB8RqdFM2A8GRbfZ1btymgZGNbhcNSypmNstiRGGqt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 295163501339476000
+    },
+    {
+        "timestamp": "2024-03-29T22:52:53.570Z",
+        "balance": 1.0019850086555395e+26,
+        "block_height": 115746707,
+        "epoch_id": "5xrPgcywVfUzek7SYvPDZpk8xzhBNfHDhXD5gEjig4xS",
+        "next_epoch_id": "BnRpa5EZToPa98ztpc1y99a2upVuY4REcU9J9ktJqAha",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5265665223774884e+22
+    },
+    {
+        "timestamp": "2024-03-29T07:24:35.155Z",
+        "balance": 1.0018323520033018e+26,
+        "block_height": 115703507,
+        "epoch_id": "JEFvVg78FLaeLaPDQnrqkmzai38ZdnwJZ1Gjb7f4sxNZ",
+        "next_epoch_id": "5xrPgcywVfUzek7SYvPDZpk8xzhBNfHDhXD5gEjig4xS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.463917378133036e+22
+    },
+    {
+        "timestamp": "2024-03-28T15:53:54.736Z",
+        "balance": 1.0016859602654885e+26,
+        "block_height": 115660307,
+        "epoch_id": "AApgVxaJHaD9SRuGsMmaq8UAvRf4u2CAvVWkEGDEPALn",
+        "next_epoch_id": "JEFvVg78FLaeLaPDQnrqkmzai38ZdnwJZ1Gjb7f4sxNZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4843655481010652e+22
+    },
+    {
+        "timestamp": "2024-03-28T01:07:46.164Z",
+        "balance": 1.0015375237106784e+26,
+        "block_height": 115617107,
+        "epoch_id": "2nQnyVAx9jeCWidMaDhaoeThRp8uGs3uUnxNQzwY9hxK",
+        "next_epoch_id": "AApgVxaJHaD9SRuGsMmaq8UAvRf4u2CAvVWkEGDEPALn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5023523390503948e+22
+    },
+    {
+        "timestamp": "2024-03-27T10:11:39.793Z",
+        "balance": 1.0013872884767733e+26,
+        "block_height": 115573907,
+        "epoch_id": "8iPgJijC4Bu1xVGDGJNtAmuuixgxpTk89HCA6jMxC1Pe",
+        "next_epoch_id": "2nQnyVAx9jeCWidMaDhaoeThRp8uGs3uUnxNQzwY9hxK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 292261082699923460
+    },
+    {
+        "timestamp": "2024-03-26T19:16:08.059Z",
+        "balance": 1.0013872855541625e+26,
+        "block_height": 115530707,
+        "epoch_id": "FhbxXXtGcfjv68eptEVD59P6TjNLEmXP5tuMGaTv9XZY",
+        "next_epoch_id": "8iPgJijC4Bu1xVGDGJNtAmuuixgxpTk89HCA6jMxC1Pe",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 339873526775283700
+    },
+    {
+        "timestamp": "2024-03-26T04:08:20.510Z",
+        "balance": 1.0013872821554272e+26,
+        "block_height": 115487507,
+        "epoch_id": "2HweRkPA4kQzxMDyauLwkyuqMczpbMBLAX8jdDiFnFPM",
+        "next_epoch_id": "FhbxXXtGcfjv68eptEVD59P6TjNLEmXP5tuMGaTv9XZY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 254403522966061060
+    },
+    {
+        "timestamp": "2024-03-25T12:58:29.571Z",
+        "balance": 1.001387279611392e+26,
+        "block_height": 115444307,
+        "epoch_id": "GZaubCVir9sH5eP23KmAFG1y2ZsxqdBcjg8EC6AbL86M",
+        "next_epoch_id": "2HweRkPA4kQzxMDyauLwkyuqMczpbMBLAX8jdDiFnFPM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 255186547043729400
+    },
+    {
+        "timestamp": "2024-03-24T22:37:41.696Z",
+        "balance": 1.0013872770595265e+26,
+        "block_height": 115401107,
+        "epoch_id": "8cynyRyKCJ35ZPAG9x61KYDFZxaeFrJotpcBhgDa7tg9",
+        "next_epoch_id": "GZaubCVir9sH5eP23KmAFG1y2ZsxqdBcjg8EC6AbL86M",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5273413870583944e+22
+    },
+    {
+        "timestamp": "2024-03-24T07:34:52.706Z",
+        "balance": 1.0012345429208207e+26,
+        "block_height": 115357907,
+        "epoch_id": "DQoDeyuBy5CLT1EbuG2ZwNAcHGBzUWz14VKcWeaDHCGH",
+        "next_epoch_id": "8cynyRyKCJ35ZPAG9x61KYDFZxaeFrJotpcBhgDa7tg9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 246589087669026800
+    },
+    {
+        "timestamp": "2024-03-23T16:21:12.061Z",
+        "balance": 1.0012345404549298e+26,
+        "block_height": 115314707,
+        "epoch_id": "5sbGVdziMpAkxKC2NzvhWF3XBiAg3LkxFbzNfx8jB6xX",
+        "next_epoch_id": "DQoDeyuBy5CLT1EbuG2ZwNAcHGBzUWz14VKcWeaDHCGH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 289419686955712500
+    },
+    {
+        "timestamp": "2024-03-23T02:11:35.398Z",
+        "balance": 1.001234537560733e+26,
+        "block_height": 115271507,
+        "epoch_id": "7vzGJjov138MQXSXkXkU2iQg7XogenFQVWuh3VCRmwKX",
+        "next_epoch_id": "5sbGVdziMpAkxKC2NzvhWF3XBiAg3LkxFbzNfx8jB6xX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 342004552108605440
+    },
+    {
+        "timestamp": "2024-03-22T13:30:49.671Z",
+        "balance": 1.0012345341406874e+26,
+        "block_height": 115228307,
+        "epoch_id": "BSphFzth4QR9W3i75AaVeKAypHguWJGWQzrZQDS1hov6",
+        "next_epoch_id": "7vzGJjov138MQXSXkXkU2iQg7XogenFQVWuh3VCRmwKX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 255200771975413760
+    },
+    {
+        "timestamp": "2024-03-21T22:34:02.031Z",
+        "balance": 1.0012345315886797e+26,
+        "block_height": 115185107,
+        "epoch_id": "68NrNfXTK8UE5DaWaUXaeZyZ74jBWrfGQdDKUwQBvwK9",
+        "next_epoch_id": "BSphFzth4QR9W3i75AaVeKAypHguWJGWQzrZQDS1hov6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4727394262645249e+22
+    },
+    {
+        "timestamp": "2024-03-21T03:52:43.044Z",
+        "balance": 1.0010872576460533e+26,
+        "block_height": 115141907,
+        "epoch_id": "AWM4QhMPpkAkJv9Bu4zaiuYCHNV5pZg1gAsRVxuMF9kg",
+        "next_epoch_id": "68NrNfXTK8UE5DaWaUXaeZyZ74jBWrfGQdDKUwQBvwK9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3441223553427167e+22
+    },
+    {
+        "timestamp": "2024-03-20T13:37:20.693Z",
+        "balance": 1.000952845410519e+26,
+        "block_height": 115098707,
+        "epoch_id": "XmJV4yW58eiA922uZb3HBc8qr6eZttLawZq7Htysvrd",
+        "next_epoch_id": "AWM4QhMPpkAkJv9Bu4zaiuYCHNV5pZg1gAsRVxuMF9kg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5760069169859954e+22
+    },
+    {
+        "timestamp": "2024-03-20T00:21:07.208Z",
+        "balance": 1.0007952447188204e+26,
+        "block_height": 115055507,
+        "epoch_id": "4BfXvNUqBQZ8Mx7M9RWP9iccs2JTsy34cT1RSGKxDJmU",
+        "next_epoch_id": "XmJV4yW58eiA922uZb3HBc8qr6eZttLawZq7Htysvrd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5507008588574993e+22
+    },
+    {
+        "timestamp": "2024-03-19T08:51:03.031Z",
+        "balance": 1.0006401746329346e+26,
+        "block_height": 115012307,
+        "epoch_id": "JC1G7vFR4TF1T5WT21ms1XJ83pXsJAvHZCqVBQu6F3ep",
+        "next_epoch_id": "4BfXvNUqBQZ8Mx7M9RWP9iccs2JTsy34cT1RSGKxDJmU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6207458152363713e+22
+    },
+    {
+        "timestamp": "2024-03-18T17:49:24.595Z",
+        "balance": 1.000478100051411e+26,
+        "block_height": 114969107,
+        "epoch_id": "A3VmH3LcYppST4fPzpwbrGBD3gVscnVRqjQcVLWdnXAL",
+        "next_epoch_id": "JC1G7vFR4TF1T5WT21ms1XJ83pXsJAvHZCqVBQu6F3ep",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.646270575176626e+22
+    },
+    {
+        "timestamp": "2024-03-18T02:05:16.005Z",
+        "balance": 1.0003134729938933e+26,
+        "block_height": 114925907,
+        "epoch_id": "AUZrixdSVaRJrCmPkv9nA1idhKyRPZ9Gq7MfvBANq8x4",
+        "next_epoch_id": "A3VmH3LcYppST4fPzpwbrGBD3gVscnVRqjQcVLWdnXAL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6168672666560458e+22
+    },
+    {
+        "timestamp": "2024-03-17T09:46:06.533Z",
+        "balance": 1.0001517862672277e+26,
+        "block_height": 114882707,
+        "epoch_id": "7agTuuPrVZESojoxwCwk543KJkuKjXFNeu4afKeeKbai",
+        "next_epoch_id": "AUZrixdSVaRJrCmPkv9nA1idhKyRPZ9Gq7MfvBANq8x4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5178626722768433e+22
+    },
+    {
+        "timestamp": "2024-03-15T11:28:33.856Z",
+        "balance": 3.7688536683997414e+26,
+        "block_height": 114753107,
+        "epoch_id": "GHc8yf9W4gGaFp8Czmkump1vaM6gTngQXkwFYo7dnHyj",
+        "next_epoch_id": "C1tJi9GW9uBsjTqmNG7jUaDUVzDTef2LcZtyM3tHvia8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-03-14T19:08:26.913Z",
+        "balance": 3.7688536683997414e+26,
+        "block_height": 114709907,
+        "epoch_id": "7MfKnQGNK5gdUD1koG9ewsP64GYdFm2dYBQ7sndQ5R1p",
+        "next_epoch_id": "GHc8yf9W4gGaFp8Czmkump1vaM6gTngQXkwFYo7dnHyj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2024-03-14T02:44:40.404Z",
+        "balance": 3.7688536683997414e+26,
+        "block_height": 114666707,
+        "epoch_id": "E2GyPCcriuEBTwPFkNpw21fdKjM4jtXTB9X7qa2NuZoP",
+        "next_epoch_id": "7MfKnQGNK5gdUD1koG9ewsP64GYdFm2dYBQ7sndQ5R1p",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2844795228005597000
+    },
+    {
+        "timestamp": "2024-03-13T14:58:15.673Z",
+        "balance": 3.768853639951789e+26,
+        "hash": "8L9herYruWMnDBpsQLmZUWdnpHp529289dtrbmFUCpo7",
+        "block_height": 114634819,
+        "epoch_id": "E2GyPCcriuEBTwPFkNpw21fdKjM4jtXTB9X7qa2NuZoP",
+        "next_epoch_id": "7MfKnQGNK5gdUD1koG9ewsP64GYdFm2dYBQ7sndQ5R1p",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": -1834651218140463000
+    },
+    {
+        "timestamp": "2024-03-13T10:45:05.469Z",
+        "balance": 3.768853658298301e+26,
+        "block_height": 114623507,
+        "epoch_id": "C6mc6SyC1Tweuh8WnnCXAE13XUCPb5P4vAqNJ84vWvaJ",
+        "next_epoch_id": "E2GyPCcriuEBTwPFkNpw21fdKjM4jtXTB9X7qa2NuZoP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1834651218140463000
+    },
+    {
+        "timestamp": "2024-03-12T18:12:42.212Z",
+        "balance": 3.768853639951789e+26,
+        "block_height": 114580307,
+        "epoch_id": "GK6rGGJyTbMf3KdqG2499VuduiFvqHknmLQzRceDC9FP",
+        "next_epoch_id": "C6mc6SyC1Tweuh8WnnCXAE13XUCPb5P4vAqNJ84vWvaJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.997559329652232e+22
+    },
+    {
+        "timestamp": "2024-03-11T19:28:31.173Z",
+        "balance": 3.768253884018824e+26,
+        "block_height": 114537107,
+        "epoch_id": "A8KmCFGzbsUyABEvAzTWVmU9YmipSSjog74crW4CdbsL",
+        "next_epoch_id": "GK6rGGJyTbMf3KdqG2499VuduiFvqHknmLQzRceDC9FP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.908272527529635e+22
+    },
+    {
+        "timestamp": "2024-03-11T02:36:28.778Z",
+        "balance": 3.767663056766071e+26,
+        "block_height": 114493907,
+        "epoch_id": "9UYQhdzNMauQmfua644BB1UC2C92wBGq3Km59mTbEPNp",
+        "next_epoch_id": "A8KmCFGzbsUyABEvAzTWVmU9YmipSSjog74crW4CdbsL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 197370514803523600
+    },
+    {
+        "timestamp": "2024-03-10T10:23:21.204Z",
+        "balance": 3.767663054792366e+26,
+        "block_height": 114450707,
+        "epoch_id": "4K6m4GtvmM3wpZZzeZNW1G3dt2YWS62WLNNsE72L3U5E",
+        "next_epoch_id": "9UYQhdzNMauQmfua644BB1UC2C92wBGq3Km59mTbEPNp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.8225457408336676e+22
+    },
+    {
+        "timestamp": "2024-03-09T18:12:46.963Z",
+        "balance": 3.7670808002182824e+26,
+        "block_height": 114407507,
+        "epoch_id": "BFhRUGQZwGNzSQ3i9u7Nu2CkjvE3vNXu2Kmt6fGFVexC",
+        "next_epoch_id": "4K6m4GtvmM3wpZZzeZNW1G3dt2YWS62WLNNsE72L3U5E",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 197800767447367680
+    },
+    {
+        "timestamp": "2024-03-09T01:59:45.229Z",
+        "balance": 3.767080798240275e+26,
+        "block_height": 114364307,
+        "epoch_id": "4QadJ5imr6w3Ygcn4iw8dEmntFfW7aMerCSceo13XgWG",
+        "next_epoch_id": "BFhRUGQZwGNzSQ3i9u7Nu2CkjvE3vNXu2Kmt6fGFVexC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6697912339767293e+21
+    },
+    {
+        "timestamp": "2024-03-08T09:25:03.597Z",
+        "balance": 3.767034100327935e+26,
+        "block_height": 114321107,
+        "epoch_id": "4iyeUnp1LpqyRXYXV1XX3tRhVhPPdTwBAiMVhNb6ZBMo",
+        "next_epoch_id": "4QadJ5imr6w3Ygcn4iw8dEmntFfW7aMerCSceo13XgWG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.893826526023921e+22
+    },
+    {
+        "timestamp": "2024-03-07T17:09:33.808Z",
+        "balance": 3.7664447176753326e+26,
+        "block_height": 114277907,
+        "epoch_id": "8qabxnA6BMPC1XoqY3rCtj9MZQ9VhFuWZ4yV4DLVWzLE",
+        "next_epoch_id": "4iyeUnp1LpqyRXYXV1XX3tRhVhPPdTwBAiMVhNb6ZBMo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.954285890986752e+22
+    },
+    {
+        "timestamp": "2024-03-07T00:38:30.397Z",
+        "balance": 3.765849289086234e+26,
+        "block_height": 114234706,
+        "epoch_id": "FJeAeCRG2RrNGusrpAhtebYnjQXsZ7qrrHr6dVjfUU9j",
+        "next_epoch_id": "8qabxnA6BMPC1XoqY3rCtj9MZQ9VhFuWZ4yV4DLVWzLE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.815882937643954e+22
+    },
+    {
+        "timestamp": "2024-03-06T07:46:46.309Z",
+        "balance": 3.7652677007924695e+26,
+        "block_height": 114191506,
+        "epoch_id": "6XsUTzDjPJ681qsTy7P4XHqh9wV8DsLgLei6ExUARW4F",
+        "next_epoch_id": "FJeAeCRG2RrNGusrpAhtebYnjQXsZ7qrrHr6dVjfUU9j",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.320102229181864e+22
+    },
+    {
+        "timestamp": "2024-03-05T15:02:24.032Z",
+        "balance": 3.764735690569551e+26,
+        "block_height": 114148306,
+        "epoch_id": "9WGjrCT8QqCTdZ1Qh6NfRFzMRPaV51hnLXKgvWr8XFp5",
+        "next_epoch_id": "6XsUTzDjPJ681qsTy7P4XHqh9wV8DsLgLei6ExUARW4F",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.631035764424001e+22
+    },
+    {
+        "timestamp": "2024-03-04T22:50:23.411Z",
+        "balance": 3.764172586993109e+26,
+        "block_height": 114105106,
+        "epoch_id": "7bQYGs3QhiPpWSuNKXVKAZ58PCJL3qR7wGYwA85RSJwa",
+        "next_epoch_id": "9WGjrCT8QqCTdZ1Qh6NfRFzMRPaV51hnLXKgvWr8XFp5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.598898517734413e+22
+    },
+    {
+        "timestamp": "2024-03-04T06:42:55.171Z",
+        "balance": 3.7636126971413355e+26,
+        "block_height": 114061906,
+        "epoch_id": "9bnmKNcuusKRquGxguR2ZwbxA4TbFMMD2pzfq9BNgMZU",
+        "next_epoch_id": "7bQYGs3QhiPpWSuNKXVKAZ58PCJL3qR7wGYwA85RSJwa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.611833610321612e+22
+    },
+    {
+        "timestamp": "2024-03-03T14:41:28.848Z",
+        "balance": 3.763051513780303e+26,
+        "block_height": 114018706,
+        "epoch_id": "4u6bQt8dvLR96Z6MV6At9VdKUd7SwDNpo9gPU1u1CNeu",
+        "next_epoch_id": "9bnmKNcuusKRquGxguR2ZwbxA4TbFMMD2pzfq9BNgMZU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.601249799497882e+22
+    },
+    {
+        "timestamp": "2024-03-02T22:35:46.091Z",
+        "balance": 3.7624913888003535e+26,
+        "block_height": 113975506,
+        "epoch_id": "9MvW1c4GSzZpnU4rFd6g1RMyp7EMYTHbjyaHzH6inhVo",
+        "next_epoch_id": "4u6bQt8dvLR96Z6MV6At9VdKUd7SwDNpo9gPU1u1CNeu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.486416970809974e+22
+    },
+    {
+        "timestamp": "2024-03-02T06:42:17.877Z",
+        "balance": 3.7619427471032725e+26,
+        "block_height": 113932306,
+        "epoch_id": "J8C8MkeKKh7CMj3sVMso7aNeDmxEjT2bv3tPK9E6sZK1",
+        "next_epoch_id": "9MvW1c4GSzZpnU4rFd6g1RMyp7EMYTHbjyaHzH6inhVo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.483270435630142e+22
+    },
+    {
+        "timestamp": "2024-03-01T14:57:16.718Z",
+        "balance": 3.7613944200597095e+26,
+        "block_height": 113889106,
+        "epoch_id": "6qTsmMXjWnoRtZrnHuWAZfo5mda9YpuLtHPaUsjHbwXe",
+        "next_epoch_id": "J8C8MkeKKh7CMj3sVMso7aNeDmxEjT2bv3tPK9E6sZK1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.629024894085576e+22
+    },
+    {
+        "timestamp": "2024-02-29T23:04:55.254Z",
+        "balance": 3.760831517570301e+26,
+        "block_height": 113845906,
+        "epoch_id": "2CA3XqwkEpR1CZHiigJiSPEzrpU6ucrJsxuTiBAKBR5Y",
+        "next_epoch_id": "6qTsmMXjWnoRtZrnHuWAZfo5mda9YpuLtHPaUsjHbwXe",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.271682986673737e+22
+    },
+    {
+        "timestamp": "2024-02-29T06:50:59.897Z",
+        "balance": 3.7603043492716336e+26,
+        "block_height": 113802706,
+        "epoch_id": "5eCLxJf5wojyReVMNbEZmjtieUGGiLi9WBpBWnvov4ke",
+        "next_epoch_id": "2CA3XqwkEpR1CZHiigJiSPEzrpU6ucrJsxuTiBAKBR5Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.262306618315432e+22
+    },
+    {
+        "timestamp": "2024-02-28T15:37:18.823Z",
+        "balance": 3.759778118609802e+26,
+        "block_height": 113759506,
+        "epoch_id": "HLz5ymMfivSPBtfECfhaYByWTLAY1b375oBo4sDv7bUG",
+        "next_epoch_id": "5eCLxJf5wojyReVMNbEZmjtieUGGiLi9WBpBWnvov4ke",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.371340337300205e+22
+    },
+    {
+        "timestamp": "2024-02-27T23:55:03.093Z",
+        "balance": 3.759240984576072e+26,
+        "block_height": 113716306,
+        "epoch_id": "APmuq9tsiNgCxsZeNwvaC4HyYMzXmSsNbUVQ5D8J3Z4f",
+        "next_epoch_id": "HLz5ymMfivSPBtfECfhaYByWTLAY1b375oBo4sDv7bUG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6825957437663944e+22
+    },
+    {
+        "timestamp": "2024-02-27T08:06:22.144Z",
+        "balance": 3.7587727250016954e+26,
+        "block_height": 113673106,
+        "epoch_id": "AkMMN43v7Qdyq1dUXzNHpFd6WjgZPNZvYSRYFTo6ATvr",
+        "next_epoch_id": "APmuq9tsiNgCxsZeNwvaC4HyYMzXmSsNbUVQ5D8J3Z4f",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.5520997394078e+22
+    },
+    {
+        "timestamp": "2024-02-26T16:39:47.406Z",
+        "balance": 3.7582175150277546e+26,
+        "block_height": 113629906,
+        "epoch_id": "3WdPshfQtNKCd13hCZ2X3XupoXgY4ELBQkSVwREAKGeg",
+        "next_epoch_id": "AkMMN43v7Qdyq1dUXzNHpFd6WjgZPNZvYSRYFTo6ATvr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.4244265404340795e+22
+    },
+    {
+        "timestamp": "2024-02-26T00:53:49.211Z",
+        "balance": 3.757675072373711e+26,
+        "block_height": 113586706,
+        "epoch_id": "22AZ4pLy84znaEGCW7ZRpUWQdZsRLyqWdWfmcqhYKyd9",
+        "next_epoch_id": "3WdPshfQtNKCd13hCZ2X3XupoXgY4ELBQkSVwREAKGeg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.301520588280541e+22
+    },
+    {
+        "timestamp": "2024-02-25T08:58:00.941Z",
+        "balance": 3.757144920314883e+26,
+        "block_height": 113543506,
+        "epoch_id": "2aZoAiRPcqF9XBEfPih5zgB2DM4b7FgFgdtYvrdDp3jp",
+        "next_epoch_id": "22AZ4pLy84znaEGCW7ZRpUWQdZsRLyqWdWfmcqhYKyd9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.378097628945797e+22
+    },
+    {
+        "timestamp": "2024-02-24T17:25:04.318Z",
+        "balance": 3.7566071105519886e+26,
+        "block_height": 113500306,
+        "epoch_id": "3dD9ExUJDGYfiSjBaUDjruQUkmRngjkyvqRx5SxbcQqZ",
+        "next_epoch_id": "2aZoAiRPcqF9XBEfPih5zgB2DM4b7FgFgdtYvrdDp3jp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.573502175637836e+22
+    },
+    {
+        "timestamp": "2024-02-24T01:57:23.691Z",
+        "balance": 3.756049760334425e+26,
+        "block_height": 113457106,
+        "epoch_id": "apqcZZKHDAaKvEfoX7wyovCoodv4nPFJcvfWTmjMjMV",
+        "next_epoch_id": "3dD9ExUJDGYfiSjBaUDjruQUkmRngjkyvqRx5SxbcQqZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 3.995171374979533e+22
+    },
+    {
+        "timestamp": "2024-02-23T10:12:45.909Z",
+        "balance": 3.755650243196927e+26,
+        "block_height": 113413906,
+        "epoch_id": "6zM95aQcH7ER3KSNuHhRDtPpyf6M4UbWgat4eU8xGjEH",
+        "next_epoch_id": "apqcZZKHDAaKvEfoX7wyovCoodv4nPFJcvfWTmjMjMV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.551251926071453e+22
+    },
+    {
+        "timestamp": "2024-02-22T18:33:45.842Z",
+        "balance": 3.75509511800432e+26,
+        "block_height": 113370706,
+        "epoch_id": "E4XC3pg4fR4crpyhVxkUrYKn5rKeLVKWd7ZeRpwLcw5V",
+        "next_epoch_id": "6zM95aQcH7ER3KSNuHhRDtPpyf6M4UbWgat4eU8xGjEH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.494990926618677e+22
+    },
+    {
+        "timestamp": "2024-02-22T02:45:20.296Z",
+        "balance": 3.754545618911658e+26,
+        "block_height": 113327506,
+        "epoch_id": "9DnEhuYat4zsz1JamxWDgw8pQoeJyPhjimgayRix5aVp",
+        "next_epoch_id": "E4XC3pg4fR4crpyhVxkUrYKn5rKeLVKWd7ZeRpwLcw5V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.296760579943977e+22
+    },
+    {
+        "timestamp": "2024-02-21T11:26:30.662Z",
+        "balance": 3.7540159428536634e+26,
+        "block_height": 113284306,
+        "epoch_id": "A1NZHmDm8CmYNevmLrVVhVPDSCoPJmKuNhrwiWUW41ea",
+        "next_epoch_id": "9DnEhuYat4zsz1JamxWDgw8pQoeJyPhjimgayRix5aVp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.467887344079166e+22
+    },
+    {
+        "timestamp": "2024-02-20T20:13:02.643Z",
+        "balance": 3.7534691541192555e+26,
+        "block_height": 113241106,
+        "epoch_id": "8RmPjuQFVMqwBDWNMmkTiXPPAujS5rQoPFzzmGstPMhX",
+        "next_epoch_id": "A1NZHmDm8CmYNevmLrVVhVPDSCoPJmKuNhrwiWUW41ea",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.389939392156737e+22
+    },
+    {
+        "timestamp": "2024-02-20T04:14:44.060Z",
+        "balance": 3.75293016018004e+26,
+        "block_height": 113197906,
+        "epoch_id": "F7xxVBdLDZyDuNhL7esUud47BAqxhbYydNNSTccB3riB",
+        "next_epoch_id": "8RmPjuQFVMqwBDWNMmkTiXPPAujS5rQoPFzzmGstPMhX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.2339686416004395e+22
+    },
+    {
+        "timestamp": "2024-02-19T12:59:28.985Z",
+        "balance": 3.75240676331588e+26,
+        "block_height": 113154706,
+        "epoch_id": "7rHPHgsuCpqXYdGGHiDSCEtpcMSFAgBYHPkFowcGH6cN",
+        "next_epoch_id": "F7xxVBdLDZyDuNhL7esUud47BAqxhbYydNNSTccB3riB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.550592689273448e+22
+    },
+    {
+        "timestamp": "2024-02-18T22:09:51.926Z",
+        "balance": 3.7518517040469524e+26,
+        "block_height": 113111506,
+        "epoch_id": "83vvsELB8T4pacVPsUwD88RfXtmfTebeKTvEyzu6oAkV",
+        "next_epoch_id": "7rHPHgsuCpqXYdGGHiDSCEtpcMSFAgBYHPkFowcGH6cN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.250518893544632e+22
+    },
+    {
+        "timestamp": "2024-02-18T06:30:22.397Z",
+        "balance": 3.751326652157598e+26,
+        "block_height": 113068306,
+        "epoch_id": "A14b8tmrBwpRAAvY9k5Ex58XQZdCU5xXZwyWx25tsLRW",
+        "next_epoch_id": "83vvsELB8T4pacVPsUwD88RfXtmfTebeKTvEyzu6oAkV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.274007560763755e+22
+    },
+    {
+        "timestamp": "2024-02-17T15:16:29.719Z",
+        "balance": 3.7507992514015216e+26,
+        "block_height": 113025106,
+        "epoch_id": "BPHo3U39eeoUav2Wzxc7gaB9hYPuNktmEpnBgb46R8PJ",
+        "next_epoch_id": "A14b8tmrBwpRAAvY9k5Ex58XQZdCU5xXZwyWx25tsLRW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.434862547984753e+22
+    },
+    {
+        "timestamp": "2024-02-16T23:58:33.129Z",
+        "balance": 3.750255765146723e+26,
+        "block_height": 112981906,
+        "epoch_id": "G2DPBP6SiM3eZ5TWjAyCrEf2YPNCNevfBRQfQMQCmXKF",
+        "next_epoch_id": "BPHo3U39eeoUav2Wzxc7gaB9hYPuNktmEpnBgb46R8PJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.239214092601364e+22
+    },
+    {
+        "timestamp": "2024-02-16T08:34:50.451Z",
+        "balance": 3.749731843737463e+26,
+        "block_height": 112938706,
+        "epoch_id": "Fv7GMVzA64ym1JCdiqetQahiXDxLwbQcbzRAdjnYtPSs",
+        "next_epoch_id": "G2DPBP6SiM3eZ5TWjAyCrEf2YPNCNevfBRQfQMQCmXKF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 3.5393956221995088e+22
+    },
+    {
+        "timestamp": "2024-02-15T17:41:11.203Z",
+        "balance": 3.749377904175243e+26,
+        "block_height": 112895506,
+        "epoch_id": "A6aNQbcvuF9ocXh7zYbP5LYWKZZadhokW5vpVLu3jmaA",
+        "next_epoch_id": "Fv7GMVzA64ym1JCdiqetQahiXDxLwbQcbzRAdjnYtPSs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.384709865149072e+22
+    },
+    {
+        "timestamp": "2024-02-15T02:04:00.967Z",
+        "balance": 3.748839433188728e+26,
+        "block_height": 112852306,
+        "epoch_id": "7xvGjLfi6bV1nSHvtzaiVHgDckA4cQ11MS66UX1i6Uhw",
+        "next_epoch_id": "A6aNQbcvuF9ocXh7zYbP5LYWKZZadhokW5vpVLu3jmaA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.237317790790437e+22
+    },
+    {
+        "timestamp": "2024-02-14T10:42:59.397Z",
+        "balance": 3.748315701409649e+26,
+        "block_height": 112809101,
+        "epoch_id": "3kkWfavpUpX8bEEuak2g6DKfYNwGajogwEgvzmL61zZ3",
+        "next_epoch_id": "7xvGjLfi6bV1nSHvtzaiVHgDckA4cQ11MS66UX1i6Uhw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.18811759212488e+22
+    },
+    {
+        "timestamp": "2024-02-13T19:40:44.419Z",
+        "balance": 3.7477968896504366e+26,
+        "block_height": 112765901,
+        "epoch_id": "AMFj6gnUbbBurHUnLrCBUypVidA6N2aXMsxPdHwkMim6",
+        "next_epoch_id": "3kkWfavpUpX8bEEuak2g6DKfYNwGajogwEgvzmL61zZ3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.281267450856714e+22
+    },
+    {
+        "timestamp": "2024-02-13T04:06:03.106Z",
+        "balance": 3.747268762905351e+26,
+        "block_height": 112722701,
+        "epoch_id": "5jVgBqNm1aTopuFzVEFU4NL1BYmq6Mrh4h3Wzo2ecZuR",
+        "next_epoch_id": "AMFj6gnUbbBurHUnLrCBUypVidA6N2aXMsxPdHwkMim6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.2365023414757745e+22
+    },
+    {
+        "timestamp": "2024-02-12T12:48:36.683Z",
+        "balance": 3.7467451126712034e+26,
+        "block_height": 112679501,
+        "epoch_id": "GkDFKsytxVbmTBAJ29ESp4T4DnMJZCKWgpW9K5aaJehs",
+        "next_epoch_id": "5jVgBqNm1aTopuFzVEFU4NL1BYmq6Mrh4h3Wzo2ecZuR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.056897338472103e+22
+    },
+    {
+        "timestamp": "2024-02-11T21:39:49.854Z",
+        "balance": 3.746239422937356e+26,
+        "block_height": 112636301,
+        "epoch_id": "6WzeLq9dKtsxT9EFBxKutanoqvVWWxb8qNaw5uwV5AnE",
+        "next_epoch_id": "GkDFKsytxVbmTBAJ29ESp4T4DnMJZCKWgpW9K5aaJehs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.926880227149751e+22
+    },
+    {
+        "timestamp": "2024-02-11T07:02:17.785Z",
+        "balance": 3.745746734914641e+26,
+        "block_height": 112593101,
+        "epoch_id": "4TTmH7iTjjB4pLtU4L6YSwCtmnSp2dK35RrNa8bBXUEr",
+        "next_epoch_id": "6WzeLq9dKtsxT9EFBxKutanoqvVWWxb8qNaw5uwV5AnE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.079599853145636e+22
+    },
+    {
+        "timestamp": "2024-02-10T16:44:58.078Z",
+        "balance": 3.7452387749293266e+26,
+        "block_height": 112549901,
+        "epoch_id": "Eeh823C5Q4d2ZVUybJiEPPyehVRSuFNZ3Qav6MMvq4TX",
+        "next_epoch_id": "4TTmH7iTjjB4pLtU4L6YSwCtmnSp2dK35RrNa8bBXUEr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.597055176963649e+22
+    },
+    {
+        "timestamp": "2024-02-10T02:00:08.412Z",
+        "balance": 3.74477906941163e+26,
+        "block_height": 112506701,
+        "epoch_id": "Dk35VdjDhGV5ewoM7eKBtCYVuLsCjVqfki5H2CksyhrZ",
+        "next_epoch_id": "Eeh823C5Q4d2ZVUybJiEPPyehVRSuFNZ3Qav6MMvq4TX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.583790491245599e+22
+    },
+    {
+        "timestamp": "2024-02-09T12:39:03.139Z",
+        "balance": 3.744320690362506e+26,
+        "block_height": 112463501,
+        "epoch_id": "CmAoWQSRkLeDUxsT94gPujHtpC7pmk1ZykuR2GeyAzBC",
+        "next_epoch_id": "Dk35VdjDhGV5ewoM7eKBtCYVuLsCjVqfki5H2CksyhrZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.462534570233885e+22
+    },
+    {
+        "timestamp": "2024-02-08T23:20:56.991Z",
+        "balance": 3.743874436905482e+26,
+        "block_height": 112420301,
+        "epoch_id": "8qzKGcof57izqDFXv61CuYSRWS7ZE5ai7oVjZnMVEiBx",
+        "next_epoch_id": "CmAoWQSRkLeDUxsT94gPujHtpC7pmk1ZykuR2GeyAzBC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.567114538417963e+22
+    },
+    {
+        "timestamp": "2024-02-08T10:24:34.902Z",
+        "balance": 3.7434177254516405e+26,
+        "block_height": 112377101,
+        "epoch_id": "8YYjPFCmupD4dRCe5Q6VLnx39oqhhMRzwpQFoAYV1Ghq",
+        "next_epoch_id": "8qzKGcof57izqDFXv61CuYSRWS7ZE5ai7oVjZnMVEiBx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.904722526095291e+22
+    },
+    {
+        "timestamp": "2024-02-07T21:11:05.492Z",
+        "balance": 3.742927253199031e+26,
+        "block_height": 112333901,
+        "epoch_id": "HUfCaWAGLfAXs1uJ3smiyRbwYDuDtwnozW5eeRQwwLwd",
+        "next_epoch_id": "8YYjPFCmupD4dRCe5Q6VLnx39oqhhMRzwpQFoAYV1Ghq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.7637693846076604e+22
+    },
+    {
+        "timestamp": "2024-02-07T06:57:35.866Z",
+        "balance": 3.74245087626057e+26,
+        "block_height": 112290701,
+        "epoch_id": "6FQtSrgYt41183RoGC1SSV9FgPzdjeX8e8rKrdxfxXz3",
+        "next_epoch_id": "HUfCaWAGLfAXs1uJ3smiyRbwYDuDtwnozW5eeRQwwLwd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.790786957877576e+22
+    },
+    {
+        "timestamp": "2024-02-06T17:08:53.482Z",
+        "balance": 3.7419717975647824e+26,
+        "block_height": 112247501,
+        "epoch_id": "BAfiqzy9a4qgK13vfpXGSV1KXdzahe4yX6AFi5oK1p7m",
+        "next_epoch_id": "6FQtSrgYt41183RoGC1SSV9FgPzdjeX8e8rKrdxfxXz3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.863060573178043e+22
+    },
+    {
+        "timestamp": "2024-02-06T03:18:34.715Z",
+        "balance": 3.7414854915074646e+26,
+        "block_height": 112204301,
+        "epoch_id": "CtpWnmW3ieADouoM5ZG6jCucFb4fjmBtr9yZUX6ABymZ",
+        "next_epoch_id": "BAfiqzy9a4qgK13vfpXGSV1KXdzahe4yX6AFi5oK1p7m",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.848547249413739e+22
+    },
+    {
+        "timestamp": "2024-02-05T13:11:58.334Z",
+        "balance": 3.741000636782523e+26,
+        "block_height": 112161101,
+        "epoch_id": "3Ex4dQt4DQCrCsDBMfFLCswyFqg2yyMz3dtJ3aX8yxhp",
+        "next_epoch_id": "CtpWnmW3ieADouoM5ZG6jCucFb4fjmBtr9yZUX6ABymZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.968138777235971e+22
+    },
+    {
+        "timestamp": "2024-02-04T23:04:22.522Z",
+        "balance": 3.7405038229048e+26,
+        "block_height": 112117900,
+        "epoch_id": "DJGNNGjwBGrrhh8QGt1G4sQ1YT6GfvHX8jiD3pFt26w4",
+        "next_epoch_id": "3Ex4dQt4DQCrCsDBMfFLCswyFqg2yyMz3dtJ3aX8yxhp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.5642612668417884e+22
+    },
+    {
+        "timestamp": "2024-02-04T08:36:09.514Z",
+        "balance": 3.7400473967781155e+26,
+        "block_height": 112074700,
+        "epoch_id": "5SVWnzNh1XAUdBJC4X1ExtX17b6NRFP7UgxWQT7g1pgs",
+        "next_epoch_id": "DJGNNGjwBGrrhh8QGt1G4sQ1YT6GfvHX8jiD3pFt26w4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.466223221250445e+22
+    },
+    {
+        "timestamp": "2024-02-03T19:17:30.550Z",
+        "balance": 3.7396007744559904e+26,
+        "block_height": 112031500,
+        "epoch_id": "9KfbuVkZhwCXtsneMzyEBgjACCjGc8cygwQG3LJ1y6ax",
+        "next_epoch_id": "5SVWnzNh1XAUdBJC4X1ExtX17b6NRFP7UgxWQT7g1pgs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.439471602319822e+22
+    },
+    {
+        "timestamp": "2024-02-03T05:39:25.142Z",
+        "balance": 3.7391568272957585e+26,
+        "block_height": 111988300,
+        "epoch_id": "2TGfEj7EeyheuuV3WgCnWdwrH9XtmxaPHoTYyiDZ57DZ",
+        "next_epoch_id": "9KfbuVkZhwCXtsneMzyEBgjACCjGc8cygwQG3LJ1y6ax",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.681021360405822e+22
+    },
+    {
+        "timestamp": "2024-02-02T16:43:47.237Z",
+        "balance": 3.738688725159718e+26,
+        "block_height": 111945100,
+        "epoch_id": "52U72spZRxRAVH6pV2EFrxiE1FndDnUU99Mv8djrP22o",
+        "next_epoch_id": "2TGfEj7EeyheuuV3WgCnWdwrH9XtmxaPHoTYyiDZ57DZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.343367232368997e+22
+    },
+    {
+        "timestamp": "2024-02-02T03:06:21.431Z",
+        "balance": 3.738254388436481e+26,
+        "block_height": 111901900,
+        "epoch_id": "4c3AEoBnXPoqPM8cQHxqRfXbq5hm6CpJAv9okUSGMMxZ",
+        "next_epoch_id": "52U72spZRxRAVH6pV2EFrxiE1FndDnUU99Mv8djrP22o",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.402918627996338e+22
+    },
+    {
+        "timestamp": "2024-02-01T14:28:04.304Z",
+        "balance": 3.737814096573681e+26,
+        "block_height": 111858700,
+        "epoch_id": "2GMCQDZShYozXyii3ejCjdg7271AouAnrMvFgA5Px3Xg",
+        "next_epoch_id": "4c3AEoBnXPoqPM8cQHxqRfXbq5hm6CpJAv9okUSGMMxZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.483676084300727e+22
+    },
+    {
+        "timestamp": "2024-02-01T01:39:31.393Z",
+        "balance": 3.737365728965251e+26,
+        "block_height": 111815500,
+        "epoch_id": "9MrNGefnSr2uKFbut9Cp1RPmAAMeqgeMDyhUavwRrcPo",
+        "next_epoch_id": "2GMCQDZShYozXyii3ejCjdg7271AouAnrMvFgA5Px3Xg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.342649097076426e+22
+    },
+    {
+        "timestamp": "2024-01-31T12:42:10.117Z",
+        "balance": 3.7369314640555436e+26,
+        "block_height": 111772300,
+        "epoch_id": "5gjEgGSP8W1GEtyanUQeVEjJ4FLnaprwVJzFYXb7N6DV",
+        "next_epoch_id": "9MrNGefnSr2uKFbut9Cp1RPmAAMeqgeMDyhUavwRrcPo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 3.703236385238889e+22
+    },
+    {
+        "timestamp": "2024-01-31T00:07:41.160Z",
+        "balance": 3.73656114041702e+26,
+        "block_height": 111729100,
+        "epoch_id": "FCKt2GEBTp1Uf8ZcreEFRHkNJz78JwRuvcDprChz8nTp",
+        "next_epoch_id": "5gjEgGSP8W1GEtyanUQeVEjJ4FLnaprwVJzFYXb7N6DV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4243019593391035e+22
+    },
+    {
+        "timestamp": "2024-01-30T11:28:07.779Z",
+        "balance": 3.736118710221086e+26,
+        "block_height": 111685900,
+        "epoch_id": "HymgHHvdiKT5vcywbDX5b8sSp9crhRShJyTReJydMbq4",
+        "next_epoch_id": "FCKt2GEBTp1Uf8ZcreEFRHkNJz78JwRuvcDprChz8nTp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.483043814784611e+22
+    },
+    {
+        "timestamp": "2024-01-29T22:56:40.904Z",
+        "balance": 3.7356704058396074e+26,
+        "block_height": 111642700,
+        "epoch_id": "4dSwY8oFquTQhKoArWVeBKAJb8VTcE1jqH3CDCXwUZiW",
+        "next_epoch_id": "HymgHHvdiKT5vcywbDX5b8sSp9crhRShJyTReJydMbq4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.371800505021207e+22
+    },
+    {
+        "timestamp": "2024-01-29T10:15:39.892Z",
+        "balance": 3.735233225789105e+26,
+        "block_height": 111599500,
+        "epoch_id": "8bbGQR8aNc4raaCDTT9p26gQw7Ctea3udmxYpuvCpcWJ",
+        "next_epoch_id": "4dSwY8oFquTQhKoArWVeBKAJb8VTcE1jqH3CDCXwUZiW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.44769819795492e+22
+    },
+    {
+        "timestamp": "2024-01-28T21:52:52.362Z",
+        "balance": 3.73478845596931e+26,
+        "block_height": 111556300,
+        "epoch_id": "5ntCN2bJJkjQd3RvPGX9RZQn4rYK2g2vGUSgSYgdjCRn",
+        "next_epoch_id": "8bbGQR8aNc4raaCDTT9p26gQw7Ctea3udmxYpuvCpcWJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.397443017140341e+22
+    },
+    {
+        "timestamp": "2024-01-28T09:18:03.057Z",
+        "balance": 3.734348711667596e+26,
+        "block_height": 111513100,
+        "epoch_id": "HAuJng8qLkrD97aEAan3Jxm6gbkcyjpHCYLTRhNefEfy",
+        "next_epoch_id": "5ntCN2bJJkjQd3RvPGX9RZQn4rYK2g2vGUSgSYgdjCRn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.278273619938278e+22
+    },
+    {
+        "timestamp": "2024-01-27T10:05:23.367Z",
+        "balance": 3.733920884305602e+26,
+        "block_height": 111433012,
+        "epoch_id": "JDg6EDdhL7Pcii6T9D4ximgBS9KB3vG6e49UhcLGiXN7",
+        "next_epoch_id": "HAuJng8qLkrD97aEAan3Jxm6gbkcyjpHCYLTRhNefEfy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.252394154871997e+22
+    },
+    {
+        "timestamp": "2024-01-27T08:09:12.267Z",
+        "balance": 3.733495644890115e+26,
+        "block_height": 111426700,
+        "epoch_id": "2HgpiAAVJb9RYf8aBz1go5Ah4egE43ME2AYbMrZXgE6M",
+        "next_epoch_id": "JDg6EDdhL7Pcii6T9D4ximgBS9KB3vG6e49UhcLGiXN7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.32609078281204e+22
+    },
+    {
+        "timestamp": "2024-01-26T19:28:44.656Z",
+        "balance": 3.7330630358118335e+26,
+        "block_height": 111383500,
+        "epoch_id": "9Fu24tmUcursMTtRvFQtTBu8fw56QypsNSTHfXHa348a",
+        "next_epoch_id": "2HgpiAAVJb9RYf8aBz1go5Ah4egE43ME2AYbMrZXgE6M",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3940303113472784e+22
+    },
+    {
+        "timestamp": "2024-01-26T06:38:16.624Z",
+        "balance": 3.732623632780699e+26,
+        "block_height": 111340300,
+        "epoch_id": "FJEPdwkdTJo3E4asCwsc9GzybpnTToE3MxR9NQHgBqtw",
+        "next_epoch_id": "9Fu24tmUcursMTtRvFQtTBu8fw56QypsNSTHfXHa348a",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.599110147689544e+22
+    },
+    {
+        "timestamp": "2024-01-25T17:32:40.235Z",
+        "balance": 3.73216372176593e+26,
+        "block_height": 111297100,
+        "epoch_id": "ELqczo4hiCWsiz6UNQ3t8TxRX5L4nhtfocwfPvXvQVvR",
+        "next_epoch_id": "FJEPdwkdTJo3E4asCwsc9GzybpnTToE3MxR9NQHgBqtw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.497838181974184e+22
+    },
+    {
+        "timestamp": "2024-01-25T04:20:12.948Z",
+        "balance": 3.7317139379477324e+26,
+        "block_height": 111253900,
+        "epoch_id": "DhYQCttE7ZViwuWF1bYdKkSf7MkugHtpLQJzympGzNAe",
+        "next_epoch_id": "ELqczo4hiCWsiz6UNQ3t8TxRX5L4nhtfocwfPvXvQVvR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4779275005447595e+22
+    },
+    {
+        "timestamp": "2024-01-24T15:29:49.934Z",
+        "balance": 3.731266145197678e+26,
+        "block_height": 111210700,
+        "epoch_id": "AVnCmjS9pmC24tzecWpz4R8Qk9NQYkJf9cnjXhkGkuUQ",
+        "next_epoch_id": "DhYQCttE7ZViwuWF1bYdKkSf7MkugHtpLQJzympGzNAe",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.294380730399112e+22
+    },
+    {
+        "timestamp": "2024-01-24T02:43:40.917Z",
+        "balance": 3.730836707124638e+26,
+        "block_height": 111167500,
+        "epoch_id": "Bbe64oVHQDHYnxqxBdtKLjE2MJHgwPEysqtmhkVaCBrD",
+        "next_epoch_id": "AVnCmjS9pmC24tzecWpz4R8Qk9NQYkJf9cnjXhkGkuUQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.400445357802334e+22
+    },
+    {
+        "timestamp": "2024-01-23T14:28:59.093Z",
+        "balance": 3.730396662588858e+26,
+        "block_height": 111124300,
+        "epoch_id": "9DwYHux2uboRX9TKdvi7msd4NFXE8qEb4eoK9H4THnb6",
+        "next_epoch_id": "Bbe64oVHQDHYnxqxBdtKLjE2MJHgwPEysqtmhkVaCBrD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.524735577777934e+22
+    },
+    {
+        "timestamp": "2024-01-23T02:02:51.719Z",
+        "balance": 3.72994418903108e+26,
+        "block_height": 111081100,
+        "epoch_id": "5L8gB29pTvyy5mrAn45EzGiBZXvUDC4nhbXychmMkBj3",
+        "next_epoch_id": "9DwYHux2uboRX9TKdvi7msd4NFXE8qEb4eoK9H4THnb6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.0295229666970755e+22
+    },
+    {
+        "timestamp": "2024-01-22T13:11:25.158Z",
+        "balance": 3.72944123673441e+26,
+        "block_height": 111037900,
+        "epoch_id": "9xtMBA11FmiFSZifW6bMgsQqcEJZwWtMTYBYQkGE3gzC",
+        "next_epoch_id": "5L8gB29pTvyy5mrAn45EzGiBZXvUDC4nhbXychmMkBj3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.526435108685851e+22
+    },
+    {
+        "timestamp": "2024-01-21T22:52:28.106Z",
+        "balance": 3.728988593223542e+26,
+        "block_height": 110994700,
+        "epoch_id": "4CGwPZtyTD7KCiYvTDjPCYyFA9GGjauAS2jEcxzJcaMN",
+        "next_epoch_id": "9xtMBA11FmiFSZifW6bMgsQqcEJZwWtMTYBYQkGE3gzC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.174581146623248e+22
+    },
+    {
+        "timestamp": "2024-01-21T09:58:51.325Z",
+        "balance": 3.7285711351088794e+26,
+        "block_height": 110951500,
+        "epoch_id": "6tAfksHeYTW6esDYvxTWFodNCU7rvqAYBcd6VudKMVeN",
+        "next_epoch_id": "4CGwPZtyTD7KCiYvTDjPCYyFA9GGjauAS2jEcxzJcaMN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.298415429136605e+22
+    },
+    {
+        "timestamp": "2024-01-20T12:47:22.422Z",
+        "balance": 3.728141293565966e+26,
+        "block_height": 110875525,
+        "epoch_id": "ExkTLvX3Fvo9zWaPkp5tonXzSuPmZnk1B35fP9sYfKKD",
+        "next_epoch_id": "6tAfksHeYTW6esDYvxTWFodNCU7rvqAYBcd6VudKMVeN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.487359107487635e+22
+    },
+    {
+        "timestamp": "2024-01-20T09:50:57.571Z",
+        "balance": 3.727692557655217e+26,
+        "block_height": 110865100,
+        "epoch_id": "dBWXZQUoTwzgJWFdp3yvJ2SCCkJeVJ8LJpiRU1qqcRd",
+        "next_epoch_id": "ExkTLvX3Fvo9zWaPkp5tonXzSuPmZnk1B35fP9sYfKKD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.466219782122384e+22
+    },
+    {
+        "timestamp": "2024-01-19T21:02:53.897Z",
+        "balance": 3.727245935677005e+26,
+        "block_height": 110821900,
+        "epoch_id": "CRbiLgThEWqVPuoVuuBY3SWFFzR3drT1Rvkym2ygvqgJ",
+        "next_epoch_id": "dBWXZQUoTwzgJWFdp3yvJ2SCCkJeVJ8LJpiRU1qqcRd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.516402840444251e+22
+    },
+    {
+        "timestamp": "2024-01-19T08:22:02.073Z",
+        "balance": 3.72679429539296e+26,
+        "block_height": 110778700,
+        "epoch_id": "5VE2bm5DtYhWZasGb3pxfXXSztNqe2JUVBLxFuzyjorb",
+        "next_epoch_id": "CRbiLgThEWqVPuoVuuBY3SWFFzR3drT1Rvkym2ygvqgJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.625961319783944e+22
+    },
+    {
+        "timestamp": "2024-01-18T19:29:51.878Z",
+        "balance": 3.726331699260982e+26,
+        "block_height": 110735500,
+        "epoch_id": "Fnpo31qeJS9jVJ3B4DboSWPeJTAXNEvoTQiCCC1NdXMr",
+        "next_epoch_id": "5VE2bm5DtYhWZasGb3pxfXXSztNqe2JUVBLxFuzyjorb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.261553419945242e+22
+    },
+    {
+        "timestamp": "2024-01-18T06:19:12.263Z",
+        "balance": 3.7259055439189874e+26,
+        "block_height": 110692300,
+        "epoch_id": "AgjVJKR2y5aEgTN6Jyq3BA84ysJgEApvJg9d4xvFd3xw",
+        "next_epoch_id": "Fnpo31qeJS9jVJ3B4DboSWPeJTAXNEvoTQiCCC1NdXMr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.368618826357374e+22
+    },
+    {
+        "timestamp": "2024-01-17T18:11:33.826Z",
+        "balance": 3.7254686820363516e+26,
+        "block_height": 110649100,
+        "epoch_id": "5Q5EtpkboSocZTjd1TPBPNSY9mMCxE9JXmTxDyZGqDfk",
+        "next_epoch_id": "AgjVJKR2y5aEgTN6Jyq3BA84ysJgEApvJg9d4xvFd3xw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.446791646102949e+22
+    },
+    {
+        "timestamp": "2024-01-17T05:45:43.086Z",
+        "balance": 3.725024002871741e+26,
+        "block_height": 110605900,
+        "epoch_id": "Fbnr2CUcuCfbvrgYXZPwoJfYagd4fsMsJ5NuyUCuy9cD",
+        "next_epoch_id": "5Q5EtpkboSocZTjd1TPBPNSY9mMCxE9JXmTxDyZGqDfk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.445046799180634e+22
+    },
+    {
+        "timestamp": "2024-01-16T17:05:58.179Z",
+        "balance": 3.724579498191823e+26,
+        "block_height": 110562700,
+        "epoch_id": "J7MppdLy6bfZEFoJDp6jd3EeAnms4SZGVukaAeY23iNG",
+        "next_epoch_id": "Fbnr2CUcuCfbvrgYXZPwoJfYagd4fsMsJ5NuyUCuy9cD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.395529636072416e+22
+    },
+    {
+        "timestamp": "2024-01-16T04:18:35.413Z",
+        "balance": 3.724139945228216e+26,
+        "block_height": 110519500,
+        "epoch_id": "71dtZ8GPL4m5UYn865pprJko9cVCPdhHTyp32jDd7qh",
+        "next_epoch_id": "J7MppdLy6bfZEFoJDp6jd3EeAnms4SZGVukaAeY23iNG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.352747454082625e+22
+    },
+    {
+        "timestamp": "2024-01-15T15:19:21.808Z",
+        "balance": 3.723704670482808e+26,
+        "block_height": 110476300,
+        "epoch_id": "CrST55F9zGVXiDBBnvqggDdxS9PnxbADWBtzrgW5sBH7",
+        "next_epoch_id": "71dtZ8GPL4m5UYn865pprJko9cVCPdhHTyp32jDd7qh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.275260577571557e+22
+    },
+    {
+        "timestamp": "2024-01-15T02:27:49.648Z",
+        "balance": 3.7232771444250506e+26,
+        "block_height": 110433100,
+        "epoch_id": "AMcLDji82La3PBnzy1fpjv8e8YFRk1DxFJR6Tgf1Bv67",
+        "next_epoch_id": "CrST55F9zGVXiDBBnvqggDdxS9PnxbADWBtzrgW5sBH7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.351639655545662e+22
+    },
+    {
+        "timestamp": "2024-01-14T06:26:57.696Z",
+        "balance": 3.722841980459496e+26,
+        "block_height": 110364142,
+        "epoch_id": "9dg2D4gwjaFWFgmnDRwF4iFmDaoQsBACeDBomqADENBL",
+        "next_epoch_id": "AMcLDji82La3PBnzy1fpjv8e8YFRk1DxFJR6Tgf1Bv67",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.336743889641429e+22
+    },
+    {
+        "timestamp": "2024-01-14T01:04:57.193Z",
+        "balance": 3.722408306070532e+26,
+        "block_height": 110346700,
+        "epoch_id": "9zWyG8yvX9B6nrXbo4kvjdrkrPt3V2e6TDe3V89W7Hbc",
+        "next_epoch_id": "9dg2D4gwjaFWFgmnDRwF4iFmDaoQsBACeDBomqADENBL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.546288540063517e+22
+    },
+    {
+        "timestamp": "2024-01-13T12:15:50.187Z",
+        "balance": 3.7219536772165255e+26,
+        "block_height": 110303500,
+        "epoch_id": "44G8FvD4uuZwdfxaNz59WXjEC2FLYorWCKSuxKpTvb5G",
+        "next_epoch_id": "9zWyG8yvX9B6nrXbo4kvjdrkrPt3V2e6TDe3V89W7Hbc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.549634453590081e+22
+    },
+    {
+        "timestamp": "2024-01-12T23:22:23.021Z",
+        "balance": 3.7214987137711665e+26,
+        "block_height": 110260300,
+        "epoch_id": "HDVHBSF2PvdCCc9QD1TgVvncfXJspGbom6TxWKVhFv1j",
+        "next_epoch_id": "44G8FvD4uuZwdfxaNz59WXjEC2FLYorWCKSuxKpTvb5G",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.476446215953575e+22
+    },
+    {
+        "timestamp": "2024-01-12T10:28:25.841Z",
+        "balance": 3.721051069149571e+26,
+        "block_height": 110217100,
+        "epoch_id": "FdSWpLzk9vu2CsQW3dxnWT2ek3GBJKoPf48LdEu8DHQg",
+        "next_epoch_id": "HDVHBSF2PvdCCc9QD1TgVvncfXJspGbom6TxWKVhFv1j",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.560486037524007e+22
+    },
+    {
+        "timestamp": "2024-01-11T21:24:10.388Z",
+        "balance": 3.720595020545819e+26,
+        "block_height": 110173900,
+        "epoch_id": "29qx3fhiRFkJSVXZfjdTVsFgwMaFyVmiQmJBLLwx2EQv",
+        "next_epoch_id": "FdSWpLzk9vu2CsQW3dxnWT2ek3GBJKoPf48LdEu8DHQg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.492492410618372e+22
+    },
+    {
+        "timestamp": "2024-01-11T08:24:41.396Z",
+        "balance": 3.720145771304757e+26,
+        "block_height": 110130700,
+        "epoch_id": "7ZGH1NrTRhhzgRNWEbEuoUwRsgqsE5aZfANNeqneLnDo",
+        "next_epoch_id": "29qx3fhiRFkJSVXZfjdTVsFgwMaFyVmiQmJBLLwx2EQv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.473198056961564e+22
+    },
+    {
+        "timestamp": "2024-01-10T19:46:16.366Z",
+        "balance": 3.719698451499061e+26,
+        "block_height": 110087500,
+        "epoch_id": "ChpoxWRHVbweSmbGjSW4YzgQCarcVeqtSeDa5hVbfmuM",
+        "next_epoch_id": "7ZGH1NrTRhhzgRNWEbEuoUwRsgqsE5aZfANNeqneLnDo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.451526793011012e+22
+    },
+    {
+        "timestamp": "2024-01-10T07:11:54.284Z",
+        "balance": 3.71925329881976e+26,
+        "block_height": 110044300,
+        "epoch_id": "FxX1vqJjjyiVtSHy2xKThHKn4Eu8RBpuKVKexmMufXjk",
+        "next_epoch_id": "ChpoxWRHVbweSmbGjSW4YzgQCarcVeqtSeDa5hVbfmuM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.547371246102739e+22
+    },
+    {
+        "timestamp": "2024-01-09T18:23:35.727Z",
+        "balance": 3.7187985616951494e+26,
+        "block_height": 110001100,
+        "epoch_id": "96rreXvC4cHyZ1DgGCG44gXi4pSP1ybDLZfZuVf2ET6X",
+        "next_epoch_id": "FxX1vqJjjyiVtSHy2xKThHKn4Eu8RBpuKVKexmMufXjk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.484159264575602e+22
+    },
+    {
+        "timestamp": "2024-01-09T05:36:39.657Z",
+        "balance": 3.718350145768692e+26,
+        "block_height": 109957900,
+        "epoch_id": "Ydiv51eXotAGPdLAiFmtw58x6K63he94NYPhijSicet",
+        "next_epoch_id": "96rreXvC4cHyZ1DgGCG44gXi4pSP1ybDLZfZuVf2ET6X",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.488448249009646e+22
+    },
+    {
+        "timestamp": "2024-01-08T17:00:56.838Z",
+        "balance": 3.717901300943791e+26,
+        "block_height": 109914700,
+        "epoch_id": "Cvy1vn5Lr2Ar45homvaXVMfUqA4kqrLEhgm8gC2W61dh",
+        "next_epoch_id": "Ydiv51eXotAGPdLAiFmtw58x6K63he94NYPhijSicet",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.634289681047605e+22
+    },
+    {
+        "timestamp": "2024-01-07T19:06:40.567Z",
+        "balance": 3.717437871975686e+26,
+        "block_height": 109839780,
+        "epoch_id": "558E8JNHdAiPGKSLzYWBESVaZvrhyNLAUWNbnRGw6G1G",
+        "next_epoch_id": "Cvy1vn5Lr2Ar45homvaXVMfUqA4kqrLEhgm8gC2W61dh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4757186772870936e+22
+    },
+    {
+        "timestamp": "2024-01-07T12:37:06.308Z",
+        "balance": 3.7169903001079574e+26,
+        "block_height": 109817821,
+        "epoch_id": "AbJdpakcsrPL7N46Equ6b1bzZWC9nYVJUQENqGokZF6K",
+        "next_epoch_id": "558E8JNHdAiPGKSLzYWBESVaZvrhyNLAUWNbnRGw6G1G",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.5321593922796434e+22
+    },
+    {
+        "timestamp": "2024-01-07T03:11:30.862Z",
+        "balance": 3.7165370841687294e+26,
+        "block_height": 109785100,
+        "epoch_id": "9vcq28yZLGPtH2CFMhJpm6XBWRYNjX2Ac4XvKCW4ACJr",
+        "next_epoch_id": "AbJdpakcsrPL7N46Equ6b1bzZWC9nYVJUQENqGokZF6K",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.5337706163441085e+22
+    },
+    {
+        "timestamp": "2024-01-06T14:34:59.801Z",
+        "balance": 3.716083707107095e+26,
+        "block_height": 109741900,
+        "epoch_id": "5HKoiHmejnZiNHkfrTkBa86pC6fJ2o41DKUkg3eFsPf",
+        "next_epoch_id": "9vcq28yZLGPtH2CFMhJpm6XBWRYNjX2Ac4XvKCW4ACJr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.584851600725532e+22
+    },
+    {
+        "timestamp": "2024-01-06T01:58:18.723Z",
+        "balance": 3.7156252219470225e+26,
+        "block_height": 109698700,
+        "epoch_id": "5pz3rWoKsNUGDGTVXrFumGFuERNGvQyEBv8sY3pUjqhh",
+        "next_epoch_id": "5HKoiHmejnZiNHkfrTkBa86pC6fJ2o41DKUkg3eFsPf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.493709323630996e+22
+    },
+    {
+        "timestamp": "2024-01-05T13:12:32.250Z",
+        "balance": 3.7151758510146594e+26,
+        "block_height": 109655500,
+        "epoch_id": "Ex6C45VatGBWGmdTG8LUXSyr2odQr9kkEzpLAfgkCyZ",
+        "next_epoch_id": "5pz3rWoKsNUGDGTVXrFumGFuERNGvQyEBv8sY3pUjqhh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.563571407112505e+22
+    },
+    {
+        "timestamp": "2024-01-05T00:45:11.249Z",
+        "balance": 3.714719493873948e+26,
+        "block_height": 109612300,
+        "epoch_id": "Ano2ragReV7QooGfV7so3sTmjUVm3UTtgpH35RGPym1K",
+        "next_epoch_id": "Ex6C45VatGBWGmdTG8LUXSyr2odQr9kkEzpLAfgkCyZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.547042899962385e+22
+    },
+    {
+        "timestamp": "2024-01-04T12:08:04.670Z",
+        "balance": 3.714264789583952e+26,
+        "block_height": 109569100,
+        "epoch_id": "ALu7KjjnLk8Nk991u3gY5oX8ivZR6xEvobhcYZ1TK9sy",
+        "next_epoch_id": "Ano2ragReV7QooGfV7so3sTmjUVm3UTtgpH35RGPym1K",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.612443027331517e+22
+    },
+    {
+        "timestamp": "2024-01-03T23:35:38.246Z",
+        "balance": 3.713803545281219e+26,
+        "block_height": 109525900,
+        "epoch_id": "J1MgmZqB1PiwHedPw3D6VT96guNnqZRACy4MGbqS6sZf",
+        "next_epoch_id": "ALu7KjjnLk8Nk991u3gY5oX8ivZR6xEvobhcYZ1TK9sy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.389661195935167e+22
+    },
+    {
+        "timestamp": "2024-01-03T10:51:42.962Z",
+        "balance": 3.713364579161625e+26,
+        "block_height": 109482700,
+        "epoch_id": "FTZMyWsY6bSodhb4cXMfsJaL8E7fCFGveNjzcWSt9CRM",
+        "next_epoch_id": "J1MgmZqB1PiwHedPw3D6VT96guNnqZRACy4MGbqS6sZf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.411689157826749e+22
+    },
+    {
+        "timestamp": "2024-01-02T22:37:23.195Z",
+        "balance": 3.7129234102458425e+26,
+        "block_height": 109439500,
+        "epoch_id": "AY3AWNj33ZgVLgmT5oco5j3PejHjwVe7L4oSxEAD9pJf",
+        "next_epoch_id": "FTZMyWsY6bSodhb4cXMfsJaL8E7fCFGveNjzcWSt9CRM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4068090497663635e+22
+    },
+    {
+        "timestamp": "2024-01-02T10:20:13.789Z",
+        "balance": 3.712482729340866e+26,
+        "block_height": 109396300,
+        "epoch_id": "Aqee7HQANcuLNgn2iR62TA6DjWSbfZVMzx587hosTMst",
+        "next_epoch_id": "AY3AWNj33ZgVLgmT5oco5j3PejHjwVe7L4oSxEAD9pJf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.481038218913415e+22
+    },
+    {
+        "timestamp": "2024-01-01T18:22:01.526Z",
+        "balance": 3.7120346255189746e+26,
+        "block_height": 109340191,
+        "epoch_id": "4T8VzBdhjAcJp8jtZGq7DjjSHtmjFTybEzcdmnuTAUdK",
+        "next_epoch_id": "Aqee7HQANcuLNgn2iR62TA6DjWSbfZVMzx587hosTMst",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.488876723131585e+22
+    },
+    {
+        "timestamp": "2024-01-01T09:32:59.150Z",
+        "balance": 3.7115857378466614e+26,
+        "block_height": 109309900,
+        "epoch_id": "DN2n3wc4jv1uFizWnHWnXqY2jgTbgJTcaoWrTita7m7z",
+        "next_epoch_id": "4T8VzBdhjAcJp8jtZGq7DjjSHtmjFTybEzcdmnuTAUdK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.486177498199087e+22
+    },
+    {
+        "timestamp": "2023-12-31T21:02:23.992Z",
+        "balance": 3.7111371200968415e+26,
+        "block_height": 109266700,
+        "epoch_id": "5Q4LPFWhkBMPc294USGY3gkYnaZn4SLfoAXY3caDFJkx",
+        "next_epoch_id": "DN2n3wc4jv1uFizWnHWnXqY2jgTbgJTcaoWrTita7m7z",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.563896881617109e+22
+    },
+    {
+        "timestamp": "2023-12-31T08:32:32.504Z",
+        "balance": 3.71068073040868e+26,
+        "block_height": 109223500,
+        "epoch_id": "9FhHDowYaGUrkgjsDB64k2vCBWKoviDV7xxR38vpn9Qi",
+        "next_epoch_id": "5Q4LPFWhkBMPc294USGY3gkYnaZn4SLfoAXY3caDFJkx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.691019095687869e+22
+    },
+    {
+        "timestamp": "2023-12-30T20:08:48.458Z",
+        "balance": 3.710211628499111e+26,
+        "block_height": 109180300,
+        "epoch_id": "B4eT2u6t8VkDGqmchV1GEv3tHEi6g3HAsTdhzKi3sivC",
+        "next_epoch_id": "9FhHDowYaGUrkgjsDB64k2vCBWKoviDV7xxR38vpn9Qi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.36854733352289e+22
+    },
+    {
+        "timestamp": "2023-12-30T07:12:33.749Z",
+        "balance": 3.709674773765759e+26,
+        "block_height": 109137100,
+        "epoch_id": "45GPH3VvaHmace5jwuAiJVBmfXHw8KuPCdrRBqZE8DnM",
+        "next_epoch_id": "B4eT2u6t8VkDGqmchV1GEv3tHEi6g3HAsTdhzKi3sivC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.7218225032301426e+22
+    },
+    {
+        "timestamp": "2023-12-29T16:13:21.726Z",
+        "balance": 3.709202591515436e+26,
+        "block_height": 109093900,
+        "epoch_id": "7QfSgeTE4sh7bC2coaVpW3b13AaAivujPVnFhKNyLEcx",
+        "next_epoch_id": "45GPH3VvaHmace5jwuAiJVBmfXHw8KuPCdrRBqZE8DnM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.461583706393432e+22
+    },
+    {
+        "timestamp": "2023-12-29T02:12:06.058Z",
+        "balance": 3.7087564331447964e+26,
+        "block_height": 109050700,
+        "epoch_id": "GTmXn99YLU3FfFirR4NNBvcJPQuNw6wgYSKTf1cTQok5",
+        "next_epoch_id": "7QfSgeTE4sh7bC2coaVpW3b13AaAivujPVnFhKNyLEcx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.554540861219561e+22
+    },
+    {
+        "timestamp": "2023-12-28T13:07:53.950Z",
+        "balance": 3.7083009790586744e+26,
+        "block_height": 109007500,
+        "epoch_id": "55LZmxDnBAGYJMqqXTsjkZqerWQ5HpjNwpNWGtKDgpxH",
+        "next_epoch_id": "GTmXn99YLU3FfFirR4NNBvcJPQuNw6wgYSKTf1cTQok5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.717846306262804e+22
+    },
+    {
+        "timestamp": "2023-12-27T23:46:15.126Z",
+        "balance": 3.707829194428048e+26,
+        "block_height": 108964300,
+        "epoch_id": "6f9pU2Xa4xMf1xWfxhuAUtQnC5FKhFBwHuWR1d82grRN",
+        "next_epoch_id": "55LZmxDnBAGYJMqqXTsjkZqerWQ5HpjNwpNWGtKDgpxH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.842909252104624e+22
+    },
+    {
+        "timestamp": "2023-12-27T09:57:00.269Z",
+        "balance": 3.7073449035028377e+26,
+        "block_height": 108921100,
+        "epoch_id": "4DHZr9V41VHemWPvJVb7XE5znVP3JNPyngxUDtupzM7T",
+        "next_epoch_id": "6f9pU2Xa4xMf1xWfxhuAUtQnC5FKhFBwHuWR1d82grRN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.669860110319415e+22
+    },
+    {
+        "timestamp": "2023-12-26T07:04:49.481Z",
+        "balance": 3.706877917491806e+26,
+        "block_height": 108838459,
+        "epoch_id": "9zQhCKgEZTsfrfGrSciahcHC8T2JzVpe21paS2YqEtU",
+        "next_epoch_id": "4DHZr9V41VHemWPvJVb7XE5znVP3JNPyngxUDtupzM7T",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.641344144813301e+22
+    },
+    {
+        "timestamp": "2023-12-26T05:54:15.757Z",
+        "balance": 3.7064137830773244e+26,
+        "block_height": 108834700,
+        "epoch_id": "2nNJ5pPufatW72K65831hAn71QegMYP7P6kiunBQTjYN",
+        "next_epoch_id": "9zQhCKgEZTsfrfGrSciahcHC8T2JzVpe21paS2YqEtU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.531630645432287e+22
+    },
+    {
+        "timestamp": "2023-12-25T16:12:42.803Z",
+        "balance": 3.705960620012781e+26,
+        "block_height": 108791500,
+        "epoch_id": "5dEVWDrsdGbNKsEaCZ1p8vcGZFBoYJdenkdfb48ZJe2C",
+        "next_epoch_id": "2nNJ5pPufatW72K65831hAn71QegMYP7P6kiunBQTjYN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.642481050316142e+22
+    },
+    {
+        "timestamp": "2023-12-25T03:01:59.444Z",
+        "balance": 3.7054963719077495e+26,
+        "block_height": 108748300,
+        "epoch_id": "FvRQMaVNEobsCFRtSUxmufp5tj1L2i7Q6aB9ow658JuN",
+        "next_epoch_id": "5dEVWDrsdGbNKsEaCZ1p8vcGZFBoYJdenkdfb48ZJe2C",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.705972477471995e+22
+    },
+    {
+        "timestamp": "2023-12-24T12:06:42.284Z",
+        "balance": 3.705025774660002e+26,
+        "block_height": 108701169,
+        "epoch_id": "AxFiBDDvEegXXD5xTkSWDgi3rwi5F4nr64abeCqpe4Kk",
+        "next_epoch_id": "FvRQMaVNEobsCFRtSUxmufp5tj1L2i7Q6aB9ow658JuN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.489044644601828e+22
+    },
+    {
+        "timestamp": "2023-12-23T23:31:59.757Z",
+        "balance": 3.704576870195542e+26,
+        "block_height": 108661900,
+        "epoch_id": "DjFmbjxBwQdpfG8dmCtkjZEcpq4mfSnL5vkgJnR6y3J3",
+        "next_epoch_id": "AxFiBDDvEegXXD5xTkSWDgi3rwi5F4nr64abeCqpe4Kk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6791016301324115e+22
+    },
+    {
+        "timestamp": "2023-12-23T10:20:34.160Z",
+        "balance": 3.704108960032529e+26,
+        "block_height": 108618700,
+        "epoch_id": "B46AvcfzV8qaNo6C7ZSdc25pFEqMAPFbhGARQGFT4AXx",
+        "next_epoch_id": "DjFmbjxBwQdpfG8dmCtkjZEcpq4mfSnL5vkgJnR6y3J3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.779797800774168e+22
+    },
+    {
+        "timestamp": "2023-12-22T20:34:01.588Z",
+        "balance": 3.7036309802524515e+26,
+        "block_height": 108575500,
+        "epoch_id": "GuM7bVJgaaK4h3UCDGunSTn8pDAVx6HhgKyQY5trMReg",
+        "next_epoch_id": "B46AvcfzV8qaNo6C7ZSdc25pFEqMAPFbhGARQGFT4AXx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.957204679084421e+22
+    },
+    {
+        "timestamp": "2023-12-22T04:39:40.631Z",
+        "balance": 3.703135259784543e+26,
+        "block_height": 108527169,
+        "epoch_id": "8Ujo8fRXknDPGANSGkHwMPQN3NAumhUmK913CFsCHpxn",
+        "next_epoch_id": "GuM7bVJgaaK4h3UCDGunSTn8pDAVx6HhgKyQY5trMReg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.744152916457575e+22
+    },
+    {
+        "timestamp": "2023-12-21T15:41:53.131Z",
+        "balance": 3.702660844492897e+26,
+        "block_height": 108489100,
+        "epoch_id": "2CoJRhJwL1B5Jv5QvMQH5hDEh4L79bc7fgmV6zjzDwph",
+        "next_epoch_id": "8Ujo8fRXknDPGANSGkHwMPQN3NAumhUmK913CFsCHpxn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.617507409424421e+22
+    },
+    {
+        "timestamp": "2023-12-21T01:35:23.592Z",
+        "balance": 3.702199093751955e+26,
+        "block_height": 108445900,
+        "epoch_id": "DQt8Ydj591kJCKmdAxpWNuZMWsRgFj4ShVmY6MgTZhHD",
+        "next_epoch_id": "2CoJRhJwL1B5Jv5QvMQH5hDEh4L79bc7fgmV6zjzDwph",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4779550692801256e+22
+    },
+    {
+        "timestamp": "2023-12-20T11:51:39.401Z",
+        "balance": 3.701751298245027e+26,
+        "block_height": 108402700,
+        "epoch_id": "6edRLngcFw73JjUd88UdukgHpdtFNrpWGQctEZfNhDwe",
+        "next_epoch_id": "DQt8Ydj591kJCKmdAxpWNuZMWsRgFj4ShVmY6MgTZhHD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.7228097110013915e+22
+    },
+    {
+        "timestamp": "2023-12-19T22:31:45.728Z",
+        "balance": 3.701279017273927e+26,
+        "block_height": 108359500,
+        "epoch_id": "Bow4CecqyX6fuQQG81nwqQrV3v3bCUXp4meJHNnRZDdT",
+        "next_epoch_id": "6edRLngcFw73JjUd88UdukgHpdtFNrpWGQctEZfNhDwe",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.382785100298975e+22
+    },
+    {
+        "timestamp": "2023-12-19T08:27:11.564Z",
+        "balance": 3.700840738763897e+26,
+        "block_height": 108316300,
+        "epoch_id": "59uVM5ZK3VjwsTAgoBmwUpFbKJVkivrUweMWmemSLepy",
+        "next_epoch_id": "Bow4CecqyX6fuQQG81nwqQrV3v3bCUXp4meJHNnRZDdT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.343893920112825e+22
+    },
+    {
+        "timestamp": "2023-12-18T19:22:44.667Z",
+        "balance": 3.7004063493718855e+26,
+        "block_height": 108273100,
+        "epoch_id": "FogbZduQdPbnTpyqgAVJCkNw9B2uzhB7mjwgDvJwedqd",
+        "next_epoch_id": "59uVM5ZK3VjwsTAgoBmwUpFbKJVkivrUweMWmemSLepy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.243051764474135e+22
+    },
+    {
+        "timestamp": "2023-12-18T06:24:32.979Z",
+        "balance": 3.699982044195438e+26,
+        "block_height": 108229900,
+        "epoch_id": "BxJcgiTVsuE1SsStSRvdG13kvcaMeQLt65pncze3wuv4",
+        "next_epoch_id": "FogbZduQdPbnTpyqgAVJCkNw9B2uzhB7mjwgDvJwedqd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.277828061302301e+22
+    },
+    {
+        "timestamp": "2023-12-17T17:44:40.389Z",
+        "balance": 3.699554261389308e+26,
+        "block_height": 108186700,
+        "epoch_id": "8jdz6VLqC5xJD449BGs9gST3KpXz5bK8bpqWqX3Rq8pY",
+        "next_epoch_id": "BxJcgiTVsuE1SsStSRvdG13kvcaMeQLt65pncze3wuv4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2482257780605545e+22
+    },
+    {
+        "timestamp": "2023-12-17T04:58:54.189Z",
+        "balance": 3.699129438811502e+26,
+        "block_height": 108143500,
+        "epoch_id": "DMSx5tvsEoFqVMQek1X3vQeGz9R9Y25msA3cW8Fahoii",
+        "next_epoch_id": "8jdz6VLqC5xJD449BGs9gST3KpXz5bK8bpqWqX3Rq8pY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.479854398232106e+22
+    },
+    {
+        "timestamp": "2023-12-16T16:17:25.734Z",
+        "balance": 3.6986814533716786e+26,
+        "block_height": 108100300,
+        "epoch_id": "6u4DwRSiR56yq9QP2L8orxSYgfYxwAbzrWTGhF645RST",
+        "next_epoch_id": "DMSx5tvsEoFqVMQek1X3vQeGz9R9Y25msA3cW8Fahoii",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.41103300244444e+22
+    },
+    {
+        "timestamp": "2023-12-16T03:30:55.460Z",
+        "balance": 3.698240350071434e+26,
+        "block_height": 108057100,
+        "epoch_id": "8Y4AKn9NzSTE6142PER2G1Kt2qcDrGXX9Dg1fe5SzgHM",
+        "next_epoch_id": "6u4DwRSiR56yq9QP2L8orxSYgfYxwAbzrWTGhF645RST",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4550444368260485e+22
+    },
+    {
+        "timestamp": "2023-12-15T14:55:52.342Z",
+        "balance": 3.6977948456277516e+26,
+        "block_height": 108013900,
+        "epoch_id": "ESMMzH6hpJrBycVzF2p4NNrG1RaGLhRYnmrS532DdELs",
+        "next_epoch_id": "8Y4AKn9NzSTE6142PER2G1Kt2qcDrGXX9Dg1fe5SzgHM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.482339604483823e+22
+    },
+    {
+        "timestamp": "2023-12-15T02:20:04.359Z",
+        "balance": 3.697346611667303e+26,
+        "block_height": 107970700,
+        "epoch_id": "dYQ6qLhsWFtDjL41g9TiPs5t3QzEfuMaYwEug9zUd4u",
+        "next_epoch_id": "ESMMzH6hpJrBycVzF2p4NNrG1RaGLhRYnmrS532DdELs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.463053650656047e+22
+    },
+    {
+        "timestamp": "2023-12-14T13:39:23.446Z",
+        "balance": 3.6969003063022376e+26,
+        "block_height": 107927500,
+        "epoch_id": "S49cjbZS4waM8Du6e7MNurnyfZcdGGqt9tQZ2UoafjJ",
+        "next_epoch_id": "dYQ6qLhsWFtDjL41g9TiPs5t3QzEfuMaYwEug9zUd4u",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.471961828079133e+22
+    },
+    {
+        "timestamp": "2023-12-14T01:03:44.086Z",
+        "balance": 3.69645311011943e+26,
+        "block_height": 107884300,
+        "epoch_id": "35CiYReJWoAVcy2EXfJGTPQ6hygzYkDjLx6PBZ6cfPeb",
+        "next_epoch_id": "S49cjbZS4waM8Du6e7MNurnyfZcdGGqt9tQZ2UoafjJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.455042055022729e+22
+    },
+    {
+        "timestamp": "2023-12-13T12:27:58.090Z",
+        "balance": 3.6960076059139274e+26,
+        "block_height": 107841100,
+        "epoch_id": "GcVG4W245xNmJ4JWZJNJ8rsDThDrGQRBZrPnBJq8J58A",
+        "next_epoch_id": "35CiYReJWoAVcy2EXfJGTPQ6hygzYkDjLx6PBZ6cfPeb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.575642407523336e+22
+    },
+    {
+        "timestamp": "2023-12-12T23:54:11.583Z",
+        "balance": 3.695550041673175e+26,
+        "block_height": 107797900,
+        "epoch_id": "GryY6XoTN6XNtgX2AT3vd28uyEbQMqSDvqQEj7vxGiqu",
+        "next_epoch_id": "GcVG4W245xNmJ4JWZJNJ8rsDThDrGQRBZrPnBJq8J58A",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4739867766400316e+22
+    },
+    {
+        "timestamp": "2023-12-12T10:59:27.762Z",
+        "balance": 3.695102642995511e+26,
+        "block_height": 107754700,
+        "epoch_id": "C2pFtxCPvPo1jD5pRxWonKKVBuJZJ8AXaiABkkFGqisT",
+        "next_epoch_id": "GryY6XoTN6XNtgX2AT3vd28uyEbQMqSDvqQEj7vxGiqu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.481206010998627e+22
+    },
+    {
+        "timestamp": "2023-12-11T22:20:20.771Z",
+        "balance": 3.694654522394411e+26,
+        "block_height": 107711500,
+        "epoch_id": "CKQk8zfAbKgtYpbLeYdmAfEv1BR3GcUrADzu62Nnajrx",
+        "next_epoch_id": "C2pFtxCPvPo1jD5pRxWonKKVBuJZJ8AXaiABkkFGqisT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.589501554263475e+22
+    },
+    {
+        "timestamp": "2023-12-11T09:38:54.010Z",
+        "balance": 3.694195572238985e+26,
+        "block_height": 107668300,
+        "epoch_id": "CyD7vrq1hDkvr4tGiVqjZLHauzLpseNXAX9yhL3VRV2S",
+        "next_epoch_id": "CKQk8zfAbKgtYpbLeYdmAfEv1BR3GcUrADzu62Nnajrx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.595765924861395e+22
+    },
+    {
+        "timestamp": "2023-12-10T20:38:38.410Z",
+        "balance": 3.693735995646499e+26,
+        "block_height": 107625100,
+        "epoch_id": "5Gne4mJJ4WWWy3jax6cE6VFsbA24KS5KV51HeT8FwRJP",
+        "next_epoch_id": "CyD7vrq1hDkvr4tGiVqjZLHauzLpseNXAX9yhL3VRV2S",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 8.924874909244207e+22
+    },
+    {
+        "timestamp": "2023-12-09T19:40:58.440Z",
+        "balance": 3.692843508155574e+26,
+        "block_height": 107541063,
+        "epoch_id": "7VCSxVhcEc696MqbBJK67XAr3E96C1gUpcXHwZH4YDnH",
+        "next_epoch_id": "5Gne4mJJ4WWWy3jax6cE6VFsbA24KS5KV51HeT8FwRJP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-12-09T18:59:14.244Z",
+        "balance": 3.692843508155574e+26,
+        "block_height": 107538700,
+        "epoch_id": "6YX8z84L1o3fAizZC2n77tDF1qdsrqLRyLs8box8iGgQ",
+        "next_epoch_id": "7VCSxVhcEc696MqbBJK67XAr3E96C1gUpcXHwZH4YDnH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.59766061988726e+22
+    },
+    {
+        "timestamp": "2023-12-09T06:17:54.051Z",
+        "balance": 3.6923837420935856e+26,
+        "block_height": 107495500,
+        "epoch_id": "4MrEnnyxmj6Bt48dcpzkfF4cdeqoucCGdvMxxTxcJEMh",
+        "next_epoch_id": "6YX8z84L1o3fAizZC2n77tDF1qdsrqLRyLs8box8iGgQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.651728260988293e+22
+    },
+    {
+        "timestamp": "2023-12-08T17:19:51.253Z",
+        "balance": 3.691918569267487e+26,
+        "block_height": 107452300,
+        "epoch_id": "G5nSDb5qc8E9m3kTKB4FnPDFAd1UVv4Hcubm2Ckwyt56",
+        "next_epoch_id": "4MrEnnyxmj6Bt48dcpzkfF4cdeqoucCGdvMxxTxcJEMh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.750160524537203e+22
+    },
+    {
+        "timestamp": "2023-12-08T04:08:33.379Z",
+        "balance": 3.691443553215033e+26,
+        "block_height": 107409100,
+        "epoch_id": "7nRZGaRQ3wWBB4jUCHFeZwsnxKu367GMjJokh1smCKpD",
+        "next_epoch_id": "G5nSDb5qc8E9m3kTKB4FnPDFAd1UVv4Hcubm2Ckwyt56",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.764649530045495e+22
+    },
+    {
+        "timestamp": "2023-12-07T14:42:21.440Z",
+        "balance": 3.6909670882620285e+26,
+        "block_height": 107365900,
+        "epoch_id": "3rN8X8Nx68TprbV2fNmRWNHK3WeCr2LDACBzd2yF7BUQ",
+        "next_epoch_id": "7nRZGaRQ3wWBB4jUCHFeZwsnxKu367GMjJokh1smCKpD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.687392272842096e+22
+    },
+    {
+        "timestamp": "2023-12-07T01:16:26.583Z",
+        "balance": 3.690498349034744e+26,
+        "block_height": 107322700,
+        "epoch_id": "9NeGCKyg6UTLsnKeuA8mWicMBu6LLpsawJoKM4JX58hh",
+        "next_epoch_id": "3rN8X8Nx68TprbV2fNmRWNHK3WeCr2LDACBzd2yF7BUQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.845079970048227e+22
+    },
+    {
+        "timestamp": "2023-12-06T12:08:03.578Z",
+        "balance": 3.6900138410377394e+26,
+        "block_height": 107279500,
+        "epoch_id": "62idP6CosAjEJmbbzLFGkXaPobZfw86Lek2YC5a3GYPy",
+        "next_epoch_id": "9NeGCKyg6UTLsnKeuA8mWicMBu6LLpsawJoKM4JX58hh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.177434024157349e+22
+    },
+    {
+        "timestamp": "2023-12-05T22:36:11.640Z",
+        "balance": 3.689496097635324e+26,
+        "block_height": 107236300,
+        "epoch_id": "B8LJP2Qyqhd11a59SAVvePsC17q5BYaBpNycNCHHzjdg",
+        "next_epoch_id": "62idP6CosAjEJmbbzLFGkXaPobZfw86Lek2YC5a3GYPy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.350365795337164e+22
+    },
+    {
+        "timestamp": "2023-12-05T08:04:30.231Z",
+        "balance": 3.68896106105579e+26,
+        "block_height": 107193100,
+        "epoch_id": "XaaXGwMreD1FpgFEC6bLKCvZrgxVaqy4uyfJeH26G71",
+        "next_epoch_id": "B8LJP2Qyqhd11a59SAVvePsC17q5BYaBpNycNCHHzjdg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.305611307520299e+22
+    },
+    {
+        "timestamp": "2023-12-04T17:02:53.780Z",
+        "balance": 3.688430499925038e+26,
+        "block_height": 107149900,
+        "epoch_id": "cWcdHiArPVupg7RVtjsBwYWTxtPwcmhAKYMtkGP5Xqj",
+        "next_epoch_id": "XaaXGwMreD1FpgFEC6bLKCvZrgxVaqy4uyfJeH26G71",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.315150365597644e+22
+    },
+    {
+        "timestamp": "2023-12-04T02:08:01.590Z",
+        "balance": 3.687898984888478e+26,
+        "block_height": 107106700,
+        "epoch_id": "9pn6Z5AYZubVovHjgbFVJwJWLEtvn461mqJH4MNjuhhg",
+        "next_epoch_id": "cWcdHiArPVupg7RVtjsBwYWTxtPwcmhAKYMtkGP5Xqj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.3996516414642715e+22
+    },
+    {
+        "timestamp": "2023-12-03T11:54:44.991Z",
+        "balance": 3.687359019724332e+26,
+        "block_height": 107063500,
+        "epoch_id": "J1UkWoKkzf7LbEsPLQSwdCX6aXQaWsxfiruD8qHs1qbB",
+        "next_epoch_id": "9pn6Z5AYZubVovHjgbFVJwJWLEtvn461mqJH4MNjuhhg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.755266010019164e+22
+    },
+    {
+        "timestamp": "2023-12-02T21:23:45.944Z",
+        "balance": 3.68678349312333e+26,
+        "block_height": 107020300,
+        "epoch_id": "AHs8W2ccDunNzeo3v4SdFmbqqxbtZjnQ8c46aEkrWHDo",
+        "next_epoch_id": "J1UkWoKkzf7LbEsPLQSwdCX6aXQaWsxfiruD8qHs1qbB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5777171917282738000
+    },
+    {
+        "timestamp": "2023-12-02T06:04:37.365Z",
+        "balance": 3.686783435351611e+26,
+        "block_height": 106977100,
+        "epoch_id": "FHSQPi6ScaSx1bW25in7PS2qQYvxvCxi8XUq2e8c6yuJ",
+        "next_epoch_id": "AHs8W2ccDunNzeo3v4SdFmbqqxbtZjnQ8c46aEkrWHDo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2394990724799004700
+    },
+    {
+        "timestamp": "2023-12-01T14:36:34.112Z",
+        "balance": 3.6867834114017034e+26,
+        "block_height": 106933900,
+        "epoch_id": "HQxo5YUYXQZNrHkM1EdXqmytc1GjXEfisWSREE5VcbEF",
+        "next_epoch_id": "FHSQPi6ScaSx1bW25in7PS2qQYvxvCxi8XUq2e8c6yuJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1675453479310590000
+    },
+    {
+        "timestamp": "2023-11-30T21:47:32.598Z",
+        "balance": 3.6867833946471686e+26,
+        "block_height": 106890700,
+        "epoch_id": "GRBpmqaeWzeRpRkpepTDxzSXtcY3FqyGPVpAEwNx4kZd",
+        "next_epoch_id": "HQxo5YUYXQZNrHkM1EdXqmytc1GjXEfisWSREE5VcbEF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 198665395903660030
+    },
+    {
+        "timestamp": "2023-11-30T04:43:54.198Z",
+        "balance": 3.686783392660515e+26,
+        "block_height": 106847500,
+        "epoch_id": "53PzcG1utUtCH1nnRi7UAbfHDgEWZrihisQ725kzsvbR",
+        "next_epoch_id": "GRBpmqaeWzeRpRkpepTDxzSXtcY3FqyGPVpAEwNx4kZd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.064849282940171e+22
+    },
+    {
+        "timestamp": "2023-11-29T11:53:45.341Z",
+        "balance": 3.6862769077322207e+26,
+        "block_height": 106804300,
+        "epoch_id": "A43Urb7gVSeNABJM1KQPaSEEzRNpez2MrHz7BMNdX9pG",
+        "next_epoch_id": "53PzcG1utUtCH1nnRi7UAbfHDgEWZrihisQ725kzsvbR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.61110123365738e+22
+    },
+    {
+        "timestamp": "2023-11-28T21:29:56.408Z",
+        "balance": 3.685815797608855e+26,
+        "block_height": 106761100,
+        "epoch_id": "5sLjSwFFoLYCe7cnP4KXPFZ5qfkpFLKnUu12aPk7zdqw",
+        "next_epoch_id": "A43Urb7gVSeNABJM1KQPaSEEzRNpez2MrHz7BMNdX9pG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.495495666768106e+22
+    },
+    {
+        "timestamp": "2023-11-28T07:51:01.911Z",
+        "balance": 3.685366248042178e+26,
+        "block_height": 106717900,
+        "epoch_id": "FmhJCyrEcBNg8AyHMU1Fb7es6KHg2xeMZb67HD2m9GUR",
+        "next_epoch_id": "5sLjSwFFoLYCe7cnP4KXPFZ5qfkpFLKnUu12aPk7zdqw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.30556691251641e+22
+    },
+    {
+        "timestamp": "2023-11-27T18:41:42.063Z",
+        "balance": 3.6849356913509265e+26,
+        "block_height": 106674700,
+        "epoch_id": "HZRGriJSh1DSWxZsoce1tAq3jfjoYMAMWnK2hqgG5Bhd",
+        "next_epoch_id": "FmhJCyrEcBNg8AyHMU1Fb7es6KHg2xeMZb67HD2m9GUR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.906047904933563e+22
+    },
+    {
+        "timestamp": "2023-11-27T06:04:56.950Z",
+        "balance": 3.684445086560433e+26,
+        "block_height": 106631500,
+        "epoch_id": "85uogWEf7tAAXgHPoCFjiDftiRMA6pQ6Ei26LHrR4Y2B",
+        "next_epoch_id": "HZRGriJSh1DSWxZsoce1tAq3jfjoYMAMWnK2hqgG5Bhd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.979970587860072e+22
+    },
+    {
+        "timestamp": "2023-11-26T15:34:45.753Z",
+        "balance": 3.683947089501647e+26,
+        "block_height": 106588300,
+        "epoch_id": "715E5tD3488RK3umVLnYVUNS2jLaCUBspFrk5XjSQsJH",
+        "next_epoch_id": "85uogWEf7tAAXgHPoCFjiDftiRMA6pQ6Ei26LHrR4Y2B",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.305799729664314e+22
+    },
+    {
+        "timestamp": "2023-11-26T00:51:56.471Z",
+        "balance": 3.683516509528681e+26,
+        "block_height": 106545100,
+        "epoch_id": "t7zFW1ZnfsY8k679tQQLZSJnJBwBku3qyZcPR9uueT2",
+        "next_epoch_id": "715E5tD3488RK3umVLnYVUNS2jLaCUBspFrk5XjSQsJH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.538161773143554e+22
+    },
+    {
+        "timestamp": "2023-11-25T12:15:49.970Z",
+        "balance": 3.683062693351366e+26,
+        "block_height": 106501900,
+        "epoch_id": "6QCNJVPJtiUavJEPYTggu1iQPgGi4NKjy1hju2q99Lz7",
+        "next_epoch_id": "t7zFW1ZnfsY8k679tQQLZSJnJBwBku3qyZcPR9uueT2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.911685193291324e+22
+    },
+    {
+        "timestamp": "2023-11-24T22:58:59.912Z",
+        "balance": 3.682571524832037e+26,
+        "block_height": 106458700,
+        "epoch_id": "8ARPVha27PijfbG6vfNPgmQJQbbL5ekZCcqBdSchzvXC",
+        "next_epoch_id": "6QCNJVPJtiUavJEPYTggu1iQPgGi4NKjy1hju2q99Lz7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.831720269648033e+22
+    },
+    {
+        "timestamp": "2023-11-24T08:27:59.904Z",
+        "balance": 3.6820883528050724e+26,
+        "block_height": 106415500,
+        "epoch_id": "CNfk2TrXTM2cfoAYvstUCtQ8L7JgxPNYFiDeASv7rXEC",
+        "next_epoch_id": "8ARPVha27PijfbG6vfNPgmQJQbbL5ekZCcqBdSchzvXC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.384939827027927e+22
+    },
+    {
+        "timestamp": "2023-11-23T17:58:42.124Z",
+        "balance": 3.6816498588223696e+26,
+        "block_height": 106372300,
+        "epoch_id": "6EpTKT9iMwqS8o3vwH4uSsisvxgrd89hW6HCfVid7GU6",
+        "next_epoch_id": "CNfk2TrXTM2cfoAYvstUCtQ8L7JgxPNYFiDeASv7rXEC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.475661929554095e+22
+    },
+    {
+        "timestamp": "2023-11-23T05:09:30.127Z",
+        "balance": 3.681202292629414e+26,
+        "block_height": 106329100,
+        "epoch_id": "Cag1V1AymLWjjqNRGcjnHkio4rmgitsPMF7UcCkVzcYs",
+        "next_epoch_id": "6EpTKT9iMwqS8o3vwH4uSsisvxgrd89hW6HCfVid7GU6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.025194260556924e+22
+    },
+    {
+        "timestamp": "2023-11-22T16:03:44.507Z",
+        "balance": 3.6806997732033585e+26,
+        "block_height": 106285900,
+        "epoch_id": "3TyBh46psna1KTkLdY4sLH57FX4SqT3L5AjdsVxVPRmL",
+        "next_epoch_id": "Cag1V1AymLWjjqNRGcjnHkio4rmgitsPMF7UcCkVzcYs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.934020730181094e+22
+    },
+    {
+        "timestamp": "2023-11-22T01:13:25.371Z",
+        "balance": 3.6802063711303404e+26,
+        "block_height": 106242700,
+        "epoch_id": "DEEZnDyJdnf26Rjp16ij5673cY6bojqPcGhkdtqErjRW",
+        "next_epoch_id": "3TyBh46psna1KTkLdY4sLH57FX4SqT3L5AjdsVxVPRmL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.554499123442061e+22
+    },
+    {
+        "timestamp": "2023-11-21T10:42:37.492Z",
+        "balance": 3.679750921217996e+26,
+        "block_height": 106199500,
+        "epoch_id": "DBtAnhiYSFLYVDS86nZrQor6dc2Z5k71cHHztZFCDnf6",
+        "next_epoch_id": "DEEZnDyJdnf26Rjp16ij5673cY6bojqPcGhkdtqErjRW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.437131289126297e+22
+    },
+    {
+        "timestamp": "2023-11-20T16:30:39.377Z",
+        "balance": 3.6793072080890835e+26,
+        "block_height": 106139438,
+        "epoch_id": "BQXByRZm7w5cq3n8voDajWFNEcbLgUKeaGYjWGzE2wzZ",
+        "next_epoch_id": "DBtAnhiYSFLYVDS86nZrQor6dc2Z5k71cHHztZFCDnf6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.956708057369232e+22
+    },
+    {
+        "timestamp": "2023-11-19T19:43:47.798Z",
+        "balance": 3.6788115372833466e+26,
+        "block_height": 106075146,
+        "epoch_id": "DL9yH2EfnixQ2NvYoyp6GFdzc6V6XNFD5QkFYuhoc5g1",
+        "next_epoch_id": "BQXByRZm7w5cq3n8voDajWFNEcbLgUKeaGYjWGzE2wzZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.9790946913681e+22
+    },
+    {
+        "timestamp": "2023-11-19T16:17:23.330Z",
+        "balance": 3.67831362781421e+26,
+        "block_height": 106064813,
+        "epoch_id": "5rpyJpGTc5rxdEm6ywrNb56tXqACom8ERoucWMQARCcZ",
+        "next_epoch_id": "DL9yH2EfnixQ2NvYoyp6GFdzc6V6XNFD5QkFYuhoc5g1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.338712700320325e+22
+    },
+    {
+        "timestamp": "2023-11-19T03:22:39.890Z",
+        "balance": 3.677879756544178e+26,
+        "block_height": 106026697,
+        "epoch_id": "D8Bmtk9fFDWaiZ8s3c28LYtUHmnJYmUCeYjpAGDsE3gc",
+        "next_epoch_id": "5rpyJpGTc5rxdEm6ywrNb56tXqACom8ERoucWMQARCcZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.540294922300408e+22
+    },
+    {
+        "timestamp": "2023-11-18T14:46:06.634Z",
+        "balance": 3.677425727051948e+26,
+        "block_height": 105983497,
+        "epoch_id": "7aUiMKBFZ5Y9zJGUoPsNAGeAgmkiiT5MnTZGE3ySNLqv",
+        "next_epoch_id": "D8Bmtk9fFDWaiZ8s3c28LYtUHmnJYmUCeYjpAGDsE3gc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.93075526119957e+22
+    },
+    {
+        "timestamp": "2023-11-18T01:35:32.212Z",
+        "balance": 3.676932651525828e+26,
+        "block_height": 105940297,
+        "epoch_id": "AL9jSgQZGhYkmYuye1pXQcMX5Y6HQy5hNtsKc5mtA78F",
+        "next_epoch_id": "7aUiMKBFZ5Y9zJGUoPsNAGeAgmkiiT5MnTZGE3ySNLqv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.9947582510248845e+22
+    },
+    {
+        "timestamp": "2023-11-17T11:06:33.466Z",
+        "balance": 3.676433175700725e+26,
+        "block_height": 105897097,
+        "epoch_id": "2pdf19UuwaxmP6qShhiRPYSV26gLUzvXKGTEgh6CAAuC",
+        "next_epoch_id": "AL9jSgQZGhYkmYuye1pXQcMX5Y6HQy5hNtsKc5mtA78F",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.529142350549328e+22
+    },
+    {
+        "timestamp": "2023-11-16T20:27:00.131Z",
+        "balance": 3.6759802614656704e+26,
+        "block_height": 105853897,
+        "epoch_id": "7e2y3KW9Q8w9nZsXJFimCPP6ozxpnKWMdpwVYctD8V1v",
+        "next_epoch_id": "2pdf19UuwaxmP6qShhiRPYSV26gLUzvXKGTEgh6CAAuC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.754646086813759e+22
+    },
+    {
+        "timestamp": "2023-11-16T07:46:57.733Z",
+        "balance": 3.675504796856989e+26,
+        "block_height": 105810697,
+        "epoch_id": "8dWFyMuDpEmiRtSF9npKNCMXEFkYCVuHGezXcNoyTLbU",
+        "next_epoch_id": "7e2y3KW9Q8w9nZsXJFimCPP6ozxpnKWMdpwVYctD8V1v",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.393914119970383e+22
+    },
+    {
+        "timestamp": "2023-11-15T18:32:35.745Z",
+        "balance": 3.674965405444992e+26,
+        "block_height": 105767497,
+        "epoch_id": "3pvKP5AGddAHbwKFu6dRPjXiCpyGiryy3gkXkh4tYWoM",
+        "next_epoch_id": "8dWFyMuDpEmiRtSF9npKNCMXEFkYCVuHGezXcNoyTLbU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.424862251397241e+22
+    },
+    {
+        "timestamp": "2023-11-15T02:34:40.072Z",
+        "balance": 3.674422919219852e+26,
+        "block_height": 105724297,
+        "epoch_id": "7Kkssrfx5qmMzVTwRAqku8ViLSHbQ4AiC7LJP5EevbCc",
+        "next_epoch_id": "3pvKP5AGddAHbwKFu6dRPjXiCpyGiryy3gkXkh4tYWoM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5655004943192412e+22
+    },
+    {
+        "timestamp": "2023-11-14T10:32:20.603Z",
+        "balance": 3.67426636917042e+26,
+        "block_height": 105681096,
+        "epoch_id": "3gLGXbixzJGGQ61u9hKtFibzn1S8m7EpPni7KkyGo4Wy",
+        "next_epoch_id": "7Kkssrfx5qmMzVTwRAqku8ViLSHbQ4AiC7LJP5EevbCc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5233273250649509e+22
+    },
+    {
+        "timestamp": "2023-11-13T21:05:17.873Z",
+        "balance": 3.674114036437914e+26,
+        "block_height": 105637896,
+        "epoch_id": "HFok8JunhFcEB2QFg3qYQJnt5FMeTFWt3LvB5s8hZuGE",
+        "next_epoch_id": "3gLGXbixzJGGQ61u9hKtFibzn1S8m7EpPni7KkyGo4Wy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.505435982220056e+22
+    },
+    {
+        "timestamp": "2023-11-12T20:31:29.690Z",
+        "balance": 3.673663492839692e+26,
+        "block_height": 105557754,
+        "epoch_id": "87ZHPhhGgmrSjbvFW9Nh1hwFGEuRqSu5VMmDV5CZBYCo",
+        "next_epoch_id": "HFok8JunhFcEB2QFg3qYQJnt5FMeTFWt3LvB5s8hZuGE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.422451787600368e+22
+    },
+    {
+        "timestamp": "2023-11-12T18:40:46.642Z",
+        "balance": 3.673221247660932e+26,
+        "block_height": 105551496,
+        "epoch_id": "2oYakRFtr3oh9A22xcG8GM25YM1BisdmucVJfNYG948E",
+        "next_epoch_id": "87ZHPhhGgmrSjbvFW9Nh1hwFGEuRqSu5VMmDV5CZBYCo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.463795050700693e+22
+    },
+    {
+        "timestamp": "2023-11-12T05:36:25.989Z",
+        "balance": 3.672774868155862e+26,
+        "block_height": 105508296,
+        "epoch_id": "C7TyM1BnvNngfeTyy6tw94auVpBnLJnFu6Y2U6pD7294",
+        "next_epoch_id": "2oYakRFtr3oh9A22xcG8GM25YM1BisdmucVJfNYG948E",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.46304576554964e+22
+    },
+    {
+        "timestamp": "2023-11-11T16:25:48.695Z",
+        "balance": 3.672328563579307e+26,
+        "block_height": 105465096,
+        "epoch_id": "4ahdM9aD16Z2S4xm1Ny3548mZhstta5QrFuLEiFPuw53",
+        "next_epoch_id": "C7TyM1BnvNngfeTyy6tw94auVpBnLJnFu6Y2U6pD7294",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.395549863306796e+22
+    },
+    {
+        "timestamp": "2023-11-11T03:16:34.935Z",
+        "balance": 3.671889008592976e+26,
+        "block_height": 105421896,
+        "epoch_id": "8hJSZNNyimPvsCA1v3dMr3Hg5ucYeLUbTvEfhr6jaWJy",
+        "next_epoch_id": "4ahdM9aD16Z2S4xm1Ny3548mZhstta5QrFuLEiFPuw53",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.466695547545103e+22
+    },
+    {
+        "timestamp": "2023-11-10T14:19:40.419Z",
+        "balance": 3.6714423390382215e+26,
+        "block_height": 105378696,
+        "epoch_id": "7TgyeAcsejxyrk8jbL4rWBmvP9wy9DJGBq3T6VtriS2T",
+        "next_epoch_id": "8hJSZNNyimPvsCA1v3dMr3Hg5ucYeLUbTvEfhr6jaWJy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.482412709809363e+22
+    },
+    {
+        "timestamp": "2023-11-10T01:11:26.065Z",
+        "balance": 3.6709940977672406e+26,
+        "block_height": 105335496,
+        "epoch_id": "1461rFj48Zx93F9JaXkEfycu54Szh4QB1NME7ZEu4FiY",
+        "next_epoch_id": "7TgyeAcsejxyrk8jbL4rWBmvP9wy9DJGBq3T6VtriS2T",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.902331366680607e+22
+    },
+    {
+        "timestamp": "2023-11-09T12:00:41.968Z",
+        "balance": 3.6705038646305725e+26,
+        "block_height": 105292296,
+        "epoch_id": "6s9JXdqZ56FXAjvcBpUrGCFxoGYTzXKoGi59DPwZqBa7",
+        "next_epoch_id": "1461rFj48Zx93F9JaXkEfycu54Szh4QB1NME7ZEu4FiY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.7526378269289686e+22
+    },
+    {
+        "timestamp": "2023-11-08T21:37:35.379Z",
+        "balance": 3.6700286008478796e+26,
+        "block_height": 105249096,
+        "epoch_id": "CuPwC1hpNBwsDSVVjH5ZAAcxWcCVKnyRjecnWSPDWkm3",
+        "next_epoch_id": "6s9JXdqZ56FXAjvcBpUrGCFxoGYTzXKoGi59DPwZqBa7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.694853004862329e+22
+    },
+    {
+        "timestamp": "2023-11-08T07:37:00.574Z",
+        "balance": 3.6695591155473934e+26,
+        "block_height": 105205896,
+        "epoch_id": "DBJP3NfLyr2rnkk8WrdBSVJ6ZDCM72yn7dZf9DkvQbp9",
+        "next_epoch_id": "CuPwC1hpNBwsDSVVjH5ZAAcxWcCVKnyRjecnWSPDWkm3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.743295347614975e+22
+    },
+    {
+        "timestamp": "2023-11-07T17:40:46.139Z",
+        "balance": 3.669084786012632e+26,
+        "block_height": 105162696,
+        "epoch_id": "4zxZWEBLmXb5PubNS88DDSmBF4Xmvn3UP3mBjPfFoxj1",
+        "next_epoch_id": "DBJP3NfLyr2rnkk8WrdBSVJ6ZDCM72yn7dZf9DkvQbp9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 3.871130321264394e+22
+    },
+    {
+        "timestamp": "2023-11-07T03:35:04.706Z",
+        "balance": 3.6686976729805055e+26,
+        "block_height": 105119496,
+        "epoch_id": "AButo2XNSBqvBfRjWkxp63XjUaPDiqqgN6SAYvbGV6b9",
+        "next_epoch_id": "4zxZWEBLmXb5PubNS88DDSmBF4Xmvn3UP3mBjPfFoxj1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.444357069787026e+22
+    },
+    {
+        "timestamp": "2023-11-06T13:57:44.324Z",
+        "balance": 3.668453237273527e+26,
+        "block_height": 105076296,
+        "epoch_id": "FXcvd7hqftFEeej5rw6KbM2MwvtoCY8kPDfZutWzG1kL",
+        "next_epoch_id": "AButo2XNSBqvBfRjWkxp63XjUaPDiqqgN6SAYvbGV6b9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.761063386246047e+22
+    },
+    {
+        "timestamp": "2023-11-06T00:15:06.793Z",
+        "balance": 3.668177130934902e+26,
+        "block_height": 105033096,
+        "epoch_id": "3PwKJ5H89tNzEJ5RHdajdDGDzj3Qj1foLdBXLAkjFc2T",
+        "next_epoch_id": "FXcvd7hqftFEeej5rw6KbM2MwvtoCY8kPDfZutWzG1kL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.523975799987417e+22
+    },
+    {
+        "timestamp": "2023-11-05T08:09:08.148Z",
+        "balance": 3.6677247333549034e+26,
+        "block_height": 104979959,
+        "epoch_id": "FYkqPPMP75p5eQo2iEqD4d8TJ2P6EoLZESSNFXpNSSVk",
+        "next_epoch_id": "3PwKJ5H89tNzEJ5RHdajdDGDzj3Qj1foLdBXLAkjFc2T",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.419007778766238e+22
+    },
+    {
+        "timestamp": "2023-11-04T21:42:59.045Z",
+        "balance": 3.667282832577027e+26,
+        "block_height": 104946696,
+        "epoch_id": "HRqzbo6Vk1Gk7QrJXcFWrN53G9gmLyr3xWtQoJECiwjx",
+        "next_epoch_id": "FYkqPPMP75p5eQo2iEqD4d8TJ2P6EoLZESSNFXpNSSVk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.5312539022191795e+22
+    },
+    {
+        "timestamp": "2023-11-04T08:30:29.786Z",
+        "balance": 3.666829707186805e+26,
+        "block_height": 104903496,
+        "epoch_id": "AK9TTCRBKPce883gQUhTe85FiYJiWRid7hCUV1y63nmK",
+        "next_epoch_id": "HRqzbo6Vk1Gk7QrJXcFWrN53G9gmLyr3xWtQoJECiwjx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.510634965303226e+22
+    },
+    {
+        "timestamp": "2023-11-03T18:58:31.558Z",
+        "balance": 3.6663786436902746e+26,
+        "block_height": 104860296,
+        "epoch_id": "6N1sa42FvJBQ5QTjBJUqHAg2KEWdiCKnYrHvkPSjoKGt",
+        "next_epoch_id": "AK9TTCRBKPce883gQUhTe85FiYJiWRid7hCUV1y63nmK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.580839499590817e+22
+    },
+    {
+        "timestamp": "2023-11-02T17:33:58.230Z",
+        "balance": 3.6659205597403155e+26,
+        "block_height": 104779005,
+        "epoch_id": "9YYE8S5xH46MxpcWbVwSHDDqHLtPh4Rk4nBbRrGBwWw9",
+        "next_epoch_id": "6N1sa42FvJBQ5QTjBJUqHAg2KEWdiCKnYrHvkPSjoKGt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.603168580835504e+22
+    },
+    {
+        "timestamp": "2023-11-02T15:58:15.253Z",
+        "balance": 3.665460242882232e+26,
+        "block_height": 104773896,
+        "epoch_id": "5YLKhTMoJAPce1azgwaQH8dPp2LrPhtutQBwFQwspZ3V",
+        "next_epoch_id": "9YYE8S5xH46MxpcWbVwSHDDqHLtPh4Rk4nBbRrGBwWw9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.488392292409623e+22
+    },
+    {
+        "timestamp": "2023-11-02T02:13:12.815Z",
+        "balance": 3.665011403652991e+26,
+        "block_height": 104730696,
+        "epoch_id": "9WjQAeq9F9GhPp1AfukVFTeCnDaKPCQt12Vki6cPyCdt",
+        "next_epoch_id": "5YLKhTMoJAPce1azgwaQH8dPp2LrPhtutQBwFQwspZ3V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.659269728999739e+22
+    },
+    {
+        "timestamp": "2023-11-01T12:48:32.118Z",
+        "balance": 3.664545476680091e+26,
+        "block_height": 104687496,
+        "epoch_id": "EYtCdswhj7dCkWGgEuvN3Zps1DqYnV9u1PUsZD6hPo9Y",
+        "next_epoch_id": "9WjQAeq9F9GhPp1AfukVFTeCnDaKPCQt12Vki6cPyCdt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.761015042813402e+22
+    },
+    {
+        "timestamp": "2023-10-31T22:53:34.022Z",
+        "balance": 3.6640693751758096e+26,
+        "block_height": 104644296,
+        "epoch_id": "GCAeNDQ9JdaVTkuuRWVqHKji1q9BYQDzqQ3gNMSY4wpJ",
+        "next_epoch_id": "EYtCdswhj7dCkWGgEuvN3Zps1DqYnV9u1PUsZD6hPo9Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.508648598701553e+22
+    },
+    {
+        "timestamp": "2023-10-31T08:38:47.474Z",
+        "balance": 3.6636185103159395e+26,
+        "block_height": 104601096,
+        "epoch_id": "5hu1dSnYtxFwFy178ZNoSWqrW6Nn65U2qHRwQtkBmYYM",
+        "next_epoch_id": "GCAeNDQ9JdaVTkuuRWVqHKji1q9BYQDzqQ3gNMSY4wpJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.548852696754539e+22
+    },
+    {
+        "timestamp": "2023-10-30T19:10:21.747Z",
+        "balance": 3.663163625046264e+26,
+        "block_height": 104557896,
+        "epoch_id": "3df2DeMZMFa4HM8CCba5pdzw9REef7F2RK84XYg5xgkW",
+        "next_epoch_id": "5hu1dSnYtxFwFy178ZNoSWqrW6Nn65U2qHRwQtkBmYYM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7262107181075956e+22
+    },
+    {
+        "timestamp": "2023-10-30T05:34:27.534Z",
+        "balance": 3.662991003974453e+26,
+        "block_height": 104514696,
+        "epoch_id": "8gMRJgFyyKXiaxW6iTGHV9DK1tVNbMsMedLE1ZdspTAX",
+        "next_epoch_id": "3df2DeMZMFa4HM8CCba5pdzw9REef7F2RK84XYg5xgkW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.7458699201995495e+22
+    },
+    {
+        "timestamp": "2023-10-29T15:39:11.332Z",
+        "balance": 3.662516416982433e+26,
+        "block_height": 104471496,
+        "epoch_id": "J89tuXFznSQBQs4qfNSYPZVWiDkG5vQh5wnPuWVciYK6",
+        "next_epoch_id": "8gMRJgFyyKXiaxW6iTGHV9DK1tVNbMsMedLE1ZdspTAX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.515828343151709e+22
+    },
+    {
+        "timestamp": "2023-10-29T01:29:28.230Z",
+        "balance": 3.662064834148118e+26,
+        "block_height": 104428296,
+        "epoch_id": "3Gn451D7KzvNYSiLD4FpptfM1xbCBXMcG8heZ6aWaBdu",
+        "next_epoch_id": "J89tuXFznSQBQs4qfNSYPZVWiDkG5vQh5wnPuWVciYK6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.844182298044576e+22
+    },
+    {
+        "timestamp": "2023-10-28T11:59:38.761Z",
+        "balance": 3.661580415918314e+26,
+        "block_height": 104385095,
+        "epoch_id": "E9ry4bMVKuDgD7itnjb8TFvfw9YUWUvVjnqCnDWwxATv",
+        "next_epoch_id": "3Gn451D7KzvNYSiLD4FpptfM1xbCBXMcG8heZ6aWaBdu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.845312012851322e+22
+    },
+    {
+        "timestamp": "2023-10-27T14:44:44.869Z",
+        "balance": 3.6610958847170286e+26,
+        "block_height": 104321308,
+        "epoch_id": "3as7u1WyEL5NZSwEsnZAo1Cd54P7JB7zYVABTSFbkCp3",
+        "next_epoch_id": "E9ry4bMVKuDgD7itnjb8TFvfw9YUWUvVjnqCnDWwxATv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.161852681252189e+22
+    },
+    {
+        "timestamp": "2023-10-26T19:46:12.773Z",
+        "balance": 3.660579699448903e+26,
+        "block_height": 104266413,
+        "epoch_id": "H8gzG4Rw6hTuPbqyoUzXLyrC5TJWTB5J7xtx5wXugMFj",
+        "next_epoch_id": "3as7u1WyEL5NZSwEsnZAo1Cd54P7JB7zYVABTSFbkCp3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5.255149660027427e+22
+    },
+    {
+        "timestamp": "2023-10-26T16:03:32.477Z",
+        "balance": 3.6600541844829006e+26,
+        "block_height": 104255495,
+        "epoch_id": "EURXgukqgy6v5ZGqhtS7apriERMjKrGEmuF7zH3nAtxV",
+        "next_epoch_id": "H8gzG4Rw6hTuPbqyoUzXLyrC5TJWTB5J7xtx5wXugMFj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.841306127166504e+22
+    },
+    {
+        "timestamp": "2023-10-26T00:36:07.902Z",
+        "balance": 3.659570053870184e+26,
+        "block_height": 104212295,
+        "epoch_id": "6TXAYsAUfsujXFV6xH8cm1yBTMy3WJEqNrGGuSYvkw96",
+        "next_epoch_id": "EURXgukqgy6v5ZGqhtS7apriERMjKrGEmuF7zH3nAtxV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.862623025411988e+22
+    },
+    {
+        "timestamp": "2023-10-25T10:20:56.918Z",
+        "balance": 3.659083791567643e+26,
+        "block_height": 104169095,
+        "epoch_id": "tincM7uA6thkQtr5rTRvRkgZDXPDDo4PeTX4QugQjBx",
+        "next_epoch_id": "6TXAYsAUfsujXFV6xH8cm1yBTMy3WJEqNrGGuSYvkw96",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.8919585168737268e+22
+    },
+    {
+        "timestamp": "2023-10-24T20:02:21.011Z",
+        "balance": 3.6587945957159554e+26,
+        "block_height": 104125895,
+        "epoch_id": "CbS4oeucYsMNep9hKyZaUWhamsY4JjmHo12YtT21xCt7",
+        "next_epoch_id": "tincM7uA6thkQtr5rTRvRkgZDXPDDo4PeTX4QugQjBx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.274508093764824e+22
+    },
+    {
+        "timestamp": "2023-10-24T05:59:59.378Z",
+        "balance": 3.658567144906579e+26,
+        "block_height": 104082695,
+        "epoch_id": "5dCFhmP6r8WRSkQTiALZRBkf2jdHFyfGfv3HKJgjHbDS",
+        "next_epoch_id": "CbS4oeucYsMNep9hKyZaUWhamsY4JjmHo12YtT21xCt7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5153093096168843e+22
+    },
+    {
+        "timestamp": "2023-10-23T05:22:13.969Z",
+        "balance": 3.658415613975617e+26,
+        "block_height": 104009036,
+        "epoch_id": "641dmDs9kztD2xkQfoLbf72HEbGtqk96x2PwDvSpLMXF",
+        "next_epoch_id": "5dCFhmP6r8WRSkQTiALZRBkf2jdHFyfGfv3HKJgjHbDS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 6.628245826190461e+22
+    },
+    {
+        "timestamp": "2023-10-23T01:16:41.956Z",
+        "balance": 3.657752789392998e+26,
+        "block_height": 103996295,
+        "epoch_id": "4WFawBvVLC4xWuWLGufr1qMkXvgiv3a1GNSEZkkWLT6n",
+        "next_epoch_id": "641dmDs9kztD2xkQfoLbf72HEbGtqk96x2PwDvSpLMXF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 3804015631708193000
+    },
+    {
+        "timestamp": "2023-10-22T11:46:16.850Z",
+        "balance": 3.657752751352842e+26,
+        "block_height": 103953095,
+        "epoch_id": "7DYdDGBo5gXLZTjxnvEgwNJQq2npnWxRRHJnEbKdqdqR",
+        "next_epoch_id": "4WFawBvVLC4xWuWLGufr1qMkXvgiv3a1GNSEZkkWLT6n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 707237970981158900
+    },
+    {
+        "timestamp": "2023-10-21T21:59:40.919Z",
+        "balance": 3.657752744280462e+26,
+        "block_height": 103909895,
+        "epoch_id": "5n9giJjpMMLFjEqzfCPHf89LBkDZHYHng6r5UqJEBDBh",
+        "next_epoch_id": "7DYdDGBo5gXLZTjxnvEgwNJQq2npnWxRRHJnEbKdqdqR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 701977701195448300
+    },
+    {
+        "timestamp": "2023-10-21T08:30:49.869Z",
+        "balance": 3.657752737260685e+26,
+        "block_height": 103866695,
+        "epoch_id": "7xauZAB7D2puRxTYWTgyCX3U8MwQpwBAWMzSkUMKLKV9",
+        "next_epoch_id": "5n9giJjpMMLFjEqzfCPHf89LBkDZHYHng6r5UqJEBDBh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.984811587521936e+22
+    },
+    {
+        "timestamp": "2023-10-20T18:37:05.326Z",
+        "balance": 3.657254256101933e+26,
+        "block_height": 103823495,
+        "epoch_id": "2jBAqak9qszpRfgdR2xg5RrMGccNNyif8mFtUK1tXRC8",
+        "next_epoch_id": "7xauZAB7D2puRxTYWTgyCX3U8MwQpwBAWMzSkUMKLKV9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.0471229160914066e+24
+    },
+    {
+        "timestamp": "2023-10-20T04:14:44.224Z",
+        "balance": 3.616783026941019e+26,
+        "block_height": 103780295,
+        "epoch_id": "GYi3SRbWY3onrAKUwnYXo7xM1tMkz7y9Hmo1d9KHfWxY",
+        "next_epoch_id": "2jBAqak9qszpRfgdR2xg5RrMGccNNyif8mFtUK1tXRC8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 3.6590404677879473e+24
+    },
+    {
+        "timestamp": "2023-10-19T13:51:16.420Z",
+        "balance": 3.5801926222631394e+26,
+        "block_height": 103737095,
+        "epoch_id": "AJF8xJm5vEDTaJd4CLrf19zKK8mWAJRKyfkKVMWVJp9F",
+        "next_epoch_id": "GYi3SRbWY3onrAKUwnYXo7xM1tMkz7y9Hmo1d9KHfWxY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.397201074066543e+22
+    },
+    {
+        "timestamp": "2023-10-19T00:07:51.042Z",
+        "balance": 3.579752902155733e+26,
+        "block_height": 103693895,
+        "epoch_id": "3nho9d3838BLyb8DDHoKWhnkomsK31DVNBu9NVAFP3PT",
+        "next_epoch_id": "AJF8xJm5vEDTaJd4CLrf19zKK8mWAJRKyfkKVMWVJp9F",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.531688213105466e+22
+    },
+    {
+        "timestamp": "2023-10-18T10:28:51.193Z",
+        "balance": 3.579299733334422e+26,
+        "block_height": 103650695,
+        "epoch_id": "ESpVQK2aRhCtZkem1itzvhyfpzeW48TmRiwEDFrfausQ",
+        "next_epoch_id": "3nho9d3838BLyb8DDHoKWhnkomsK31DVNBu9NVAFP3PT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.397287381936008e+22
+    },
+    {
+        "timestamp": "2023-10-17T20:24:54.758Z",
+        "balance": 3.5788600045962286e+26,
+        "block_height": 103607495,
+        "epoch_id": "4v1bbCE1FqmiWtGecAciXvEDNunS51PwoTk7Ba2PnXk8",
+        "next_epoch_id": "ESpVQK2aRhCtZkem1itzvhyfpzeW48TmRiwEDFrfausQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4534429565374215e+22
+    },
+    {
+        "timestamp": "2023-10-17T06:32:26.087Z",
+        "balance": 3.578414660300575e+26,
+        "block_height": 103564295,
+        "epoch_id": "HWuZwyrDesgyTwcdHnYJutCLYdvTMd3fep9XQfdHPqh3",
+        "next_epoch_id": "4v1bbCE1FqmiWtGecAciXvEDNunS51PwoTk7Ba2PnXk8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.445161330242274e+22
+    },
+    {
+        "timestamp": "2023-10-16T16:29:10.863Z",
+        "balance": 3.5779701441675506e+26,
+        "block_height": 103521095,
+        "epoch_id": "4HxpJMnt286Z15wQyqx2Qjnq9dkCe4Gn9gBoVwxh536J",
+        "next_epoch_id": "HWuZwyrDesgyTwcdHnYJutCLYdvTMd3fep9XQfdHPqh3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.204526987130244e+22
+    },
+    {
+        "timestamp": "2023-10-16T02:28:25.444Z",
+        "balance": 3.5775496914688376e+26,
+        "block_height": 103477895,
+        "epoch_id": "9VkgYTM8cyhJDDcHzss8FtrimoUNoZetgM4iv2gQyEMN",
+        "next_epoch_id": "4HxpJMnt286Z15wQyqx2Qjnq9dkCe4Gn9gBoVwxh536J",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.372884107334205e+22
+    },
+    {
+        "timestamp": "2023-10-15T13:11:23.375Z",
+        "balance": 3.577112403058104e+26,
+        "block_height": 103434695,
+        "epoch_id": "CBkQQVqyQsAfqhcAJBAWzJnwwUhqpRZvr7rzYJrN9LHL",
+        "next_epoch_id": "9VkgYTM8cyhJDDcHzss8FtrimoUNoZetgM4iv2gQyEMN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2473115223497965e+22
+    },
+    {
+        "timestamp": "2023-10-14T23:22:27.425Z",
+        "balance": 3.576687671905869e+26,
+        "block_height": 103391495,
+        "epoch_id": "2inr9SLexJEJkmvAVu66q5xnrzcac8u9SJahBd9TVVzN",
+        "next_epoch_id": "CBkQQVqyQsAfqhcAJBAWzJnwwUhqpRZvr7rzYJrN9LHL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.287320403260886e+22
+    },
+    {
+        "timestamp": "2023-10-14T10:05:50.593Z",
+        "balance": 3.576258939865543e+26,
+        "block_height": 103348295,
+        "epoch_id": "E53mXPYvFSSLh7WiyQjBm1f8eXSWju73ts3SPvV1r1NG",
+        "next_epoch_id": "2inr9SLexJEJkmvAVu66q5xnrzcac8u9SJahBd9TVVzN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.338613190546025e+22
+    },
+    {
+        "timestamp": "2023-10-13T20:41:33.965Z",
+        "balance": 3.5758250785464885e+26,
+        "block_height": 103305095,
+        "epoch_id": "H5eeTE4gSnbyRM74pvALXDPqtnj56UihSr69pWVqvZcj",
+        "next_epoch_id": "E53mXPYvFSSLh7WiyQjBm1f8eXSWju73ts3SPvV1r1NG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.332169068076345e+22
+    },
+    {
+        "timestamp": "2023-10-13T07:06:54.536Z",
+        "balance": 3.575391861639681e+26,
+        "block_height": 103261895,
+        "epoch_id": "9FvVNfvwHedRx1p7ecHv82j5eWzdhmf6et5Zz1N9VdCH",
+        "next_epoch_id": "H5eeTE4gSnbyRM74pvALXDPqtnj56UihSr69pWVqvZcj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.429657321336271e+22
+    },
+    {
+        "timestamp": "2023-10-12T17:34:11.937Z",
+        "balance": 3.574948895907547e+26,
+        "block_height": 103218695,
+        "epoch_id": "AQwyVUzBDaAtDUaD6wh4PCWvpQh8gpiD46kH4PermPSx",
+        "next_epoch_id": "9FvVNfvwHedRx1p7ecHv82j5eWzdhmf6et5Zz1N9VdCH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.314546115078372e+22
+    },
+    {
+        "timestamp": "2023-10-12T03:42:06.067Z",
+        "balance": 3.5745174412960394e+26,
+        "block_height": 103175495,
+        "epoch_id": "CeAzbUa8odFqUznW6Vbt8HCXvabBM2XNhkrSmfJ4ZT5t",
+        "next_epoch_id": "AQwyVUzBDaAtDUaD6wh4PCWvpQh8gpiD46kH4PermPSx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.363582150823619e+22
+    },
+    {
+        "timestamp": "2023-10-11T14:11:07.090Z",
+        "balance": 3.574081083080957e+26,
+        "block_height": 103132295,
+        "epoch_id": "GAXYJ2YvdQnYPgUqSikJtRKEndX3ZDGdCguTA2qhGQZr",
+        "next_epoch_id": "CeAzbUa8odFqUznW6Vbt8HCXvabBM2XNhkrSmfJ4ZT5t",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.302278519377154e+22
+    },
+    {
+        "timestamp": "2023-10-11T00:35:30.439Z",
+        "balance": 3.573650855229019e+26,
+        "block_height": 103089095,
+        "epoch_id": "GPgmf1kKFPqmbxXQexnH2ZFPX8FG3StMQjLuL7Rjhesq",
+        "next_epoch_id": "GAXYJ2YvdQnYPgUqSikJtRKEndX3ZDGdCguTA2qhGQZr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.511782891128648e+22
+    },
+    {
+        "timestamp": "2023-10-10T10:56:36.114Z",
+        "balance": 3.5731996769399065e+26,
+        "block_height": 103045895,
+        "epoch_id": "ATocmfYagxFxUyVgNtqKtVSSyEjjhVRN6UyEyPk2xPuJ",
+        "next_epoch_id": "GPgmf1kKFPqmbxXQexnH2ZFPX8FG3StMQjLuL7Rjhesq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.352834488784252e+22
+    },
+    {
+        "timestamp": "2023-10-09T20:38:01.427Z",
+        "balance": 3.572764393491028e+26,
+        "block_height": 103002695,
+        "epoch_id": "Cd2wHdPkxV6ogcqXRr37kZECVx2Fhu559htByMFdGawZ",
+        "next_epoch_id": "ATocmfYagxFxUyVgNtqKtVSSyEjjhVRN6UyEyPk2xPuJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.300748325966146e+22
+    },
+    {
+        "timestamp": "2023-10-09T06:46:48.969Z",
+        "balance": 3.5723343186584314e+26,
+        "block_height": 102959495,
+        "epoch_id": "8apFPV3ucTgNgi88GGRDw2BziDk6xAhKqpa2ayUMMM3o",
+        "next_epoch_id": "Cd2wHdPkxV6ogcqXRr37kZECVx2Fhu559htByMFdGawZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.338779239623558e+22
+    },
+    {
+        "timestamp": "2023-10-08T17:04:28.668Z",
+        "balance": 3.571900440734469e+26,
+        "block_height": 102916295,
+        "epoch_id": "3rV9rL4aKq9JvW5cjetjYXhkLGnPCfmsuQHKwXqW3JxD",
+        "next_epoch_id": "8apFPV3ucTgNgi88GGRDw2BziDk6xAhKqpa2ayUMMM3o",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.201781535987008e+22
+    },
+    {
+        "timestamp": "2023-10-08T03:15:26.515Z",
+        "balance": 3.5714802625808704e+26,
+        "block_height": 102873095,
+        "epoch_id": "J1rE45u3brwE645FNDymDVXtj3PG4VoJEBqk2UQZ82G4",
+        "next_epoch_id": "3rV9rL4aKq9JvW5cjetjYXhkLGnPCfmsuQHKwXqW3JxD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.291226779535618e+22
+    },
+    {
+        "timestamp": "2023-10-07T13:52:23.685Z",
+        "balance": 3.571051139902917e+26,
+        "block_height": 102829895,
+        "epoch_id": "BPq4Kvz5brSf4zXWozVuyRpGiWajzQf2jNG1UGfAtqSf",
+        "next_epoch_id": "J1rE45u3brwE645FNDymDVXtj3PG4VoJEBqk2UQZ82G4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2124204834911966e+22
+    },
+    {
+        "timestamp": "2023-10-07T00:12:37.263Z",
+        "balance": 3.570629897854568e+26,
+        "block_height": 102786695,
+        "epoch_id": "Gfj8xePVu39ZXYk2upfKpYDzomGyPYnUGDcQvjjijjbW",
+        "next_epoch_id": "BPq4Kvz5brSf4zXWozVuyRpGiWajzQf2jNG1UGfAtqSf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.278934736262076e+22
+    },
+    {
+        "timestamp": "2023-10-06T10:47:24.700Z",
+        "balance": 3.5702020043809415e+26,
+        "block_height": 102743495,
+        "epoch_id": "581DEMZcCYRRcMKbpNCc5EuvhPJuE1xEBvfoFbksvcWd",
+        "next_epoch_id": "Gfj8xePVu39ZXYk2upfKpYDzomGyPYnUGDcQvjjijjbW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3447170479700195e+22
+    },
+    {
+        "timestamp": "2023-10-05T21:07:57.288Z",
+        "balance": 3.5697675326761445e+26,
+        "block_height": 102700295,
+        "epoch_id": "3HKLLD8tW2HfHhMfHYVpcxsnm4sJ6pvot49zQ1UQWnFc",
+        "next_epoch_id": "581DEMZcCYRRcMKbpNCc5EuvhPJuE1xEBvfoFbksvcWd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.219385839261165e+22
+    },
+    {
+        "timestamp": "2023-10-05T07:15:14.912Z",
+        "balance": 3.5693455940922184e+26,
+        "block_height": 102657095,
+        "epoch_id": "A3KTb4tBN1UW7q5fYkzwsTJBfg1x6HjGkMbb9Cr3MGXp",
+        "next_epoch_id": "3HKLLD8tW2HfHhMfHYVpcxsnm4sJ6pvot49zQ1UQWnFc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.360474023990126e+22
+    },
+    {
+        "timestamp": "2023-10-04T17:45:18.499Z",
+        "balance": 3.568909546689819e+26,
+        "block_height": 102613895,
+        "epoch_id": "4BRi8TmwddYLLFBSHsRbYAwezeASpdhSsi9s4ApEtkHD",
+        "next_epoch_id": "A3KTb4tBN1UW7q5fYkzwsTJBfg1x6HjGkMbb9Cr3MGXp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.310750728503254e+22
+    },
+    {
+        "timestamp": "2023-10-04T03:50:22.960Z",
+        "balance": 3.568478471616969e+26,
+        "block_height": 102570695,
+        "epoch_id": "ELQbbiFrH3zgYM3dEBojtePTq48v5t4hEo5Q6W3MiLo7",
+        "next_epoch_id": "4BRi8TmwddYLLFBSHsRbYAwezeASpdhSsi9s4ApEtkHD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.372264249847513e+22
+    },
+    {
+        "timestamp": "2023-10-03T14:04:39.584Z",
+        "balance": 3.568041245191984e+26,
+        "block_height": 102527495,
+        "epoch_id": "6RHK2Lg6D4vyavxvmXT3hnswcZcToLikqucQzivepKu1",
+        "next_epoch_id": "ELQbbiFrH3zgYM3dEBojtePTq48v5t4hEo5Q6W3MiLo7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.370445220655507e+22
+    },
+    {
+        "timestamp": "2023-10-03T00:07:08.613Z",
+        "balance": 3.567604200669919e+26,
+        "block_height": 102484295,
+        "epoch_id": "8Pbz4SAdgjsF6ro4FtpFpt3FP92kncMSjKVkVDwurd2N",
+        "next_epoch_id": "6RHK2Lg6D4vyavxvmXT3hnswcZcToLikqucQzivepKu1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.319286390356057e+22
+    },
+    {
+        "timestamp": "2023-10-02T10:10:09.978Z",
+        "balance": 3.567172272030883e+26,
+        "block_height": 102441095,
+        "epoch_id": "JDNZPRK2oqrQ9A6s9edr2X3vvw2cKc9VhFZopajLTXiJ",
+        "next_epoch_id": "8Pbz4SAdgjsF6ro4FtpFpt3FP92kncMSjKVkVDwurd2N",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3738164406997504e+22
+    },
+    {
+        "timestamp": "2023-10-01T20:23:03.345Z",
+        "balance": 3.566734890386813e+26,
+        "block_height": 102397895,
+        "epoch_id": "EXW1iUMXX5rBVqjotMYSuEUUTjn84FRjcTG6PH6mr8dK",
+        "next_epoch_id": "JDNZPRK2oqrQ9A6s9edr2X3vvw2cKc9VhFZopajLTXiJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.280108383876976e+22
+    },
+    {
+        "timestamp": "2023-10-01T06:25:28.793Z",
+        "balance": 3.5663068795484254e+26,
+        "block_height": 102354695,
+        "epoch_id": "AQpqn7LUjtwqtbfezsB9WNLetuXu62MqMAUV1VqycbpE",
+        "next_epoch_id": "EXW1iUMXX5rBVqjotMYSuEUUTjn84FRjcTG6PH6mr8dK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.398266012870597e+22
+    },
+    {
+        "timestamp": "2023-09-30T16:45:38.169Z",
+        "balance": 3.5658670529471384e+26,
+        "block_height": 102311495,
+        "epoch_id": "8xNC6CTh3ar5q4kprpQqE6t2wZbNDV4XBf4Nhjobiexk",
+        "next_epoch_id": "AQpqn7LUjtwqtbfezsB9WNLetuXu62MqMAUV1VqycbpE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.23945344349863e+22
+    },
+    {
+        "timestamp": "2023-09-30T02:43:14.804Z",
+        "balance": 3.5654431076027885e+26,
+        "block_height": 102268295,
+        "epoch_id": "ASNHqLGctjVU1GCYzBmmKG3Czwx1SR1RK7B1AHqbDjsW",
+        "next_epoch_id": "8xNC6CTh3ar5q4kprpQqE6t2wZbNDV4XBf4Nhjobiexk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.29159864981627e+22
+    },
+    {
+        "timestamp": "2023-09-29T13:11:31.868Z",
+        "balance": 3.565013947737807e+26,
+        "block_height": 102225095,
+        "epoch_id": "C9TDDYthANoduoTBZS7WYDsBSe9XCm4M2F9hRoVXVXWY",
+        "next_epoch_id": "ASNHqLGctjVU1GCYzBmmKG3Czwx1SR1RK7B1AHqbDjsW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.313926540743413e+22
+    },
+    {
+        "timestamp": "2023-09-28T23:29:37.704Z",
+        "balance": 3.5645825550837325e+26,
+        "block_height": 102181895,
+        "epoch_id": "2RMQiomr6CSSwUWpmB62YohxHbfadrHfcsaa3FVb4J9x",
+        "next_epoch_id": "C9TDDYthANoduoTBZS7WYDsBSe9XCm4M2F9hRoVXVXWY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.20853298814696e+22
+    },
+    {
+        "timestamp": "2023-09-28T09:44:05.514Z",
+        "balance": 3.564161701784918e+26,
+        "block_height": 102138695,
+        "epoch_id": "FePmx4MgMDCyWffnt5BEhgXnRuKL7VqSLrniaaBfsmq9",
+        "next_epoch_id": "2RMQiomr6CSSwUWpmB62YohxHbfadrHfcsaa3FVb4J9x",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.355543332849201e+22
+    },
+    {
+        "timestamp": "2023-09-27T20:18:24.567Z",
+        "balance": 3.563726147451633e+26,
+        "block_height": 102095495,
+        "epoch_id": "2S6BVRy5d3Dam9HoUEMNvAuwhCgNodpUwo3hhLxdGBq9",
+        "next_epoch_id": "FePmx4MgMDCyWffnt5BEhgXnRuKL7VqSLrniaaBfsmq9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3055524350956245e+22
+    },
+    {
+        "timestamp": "2023-09-27T06:25:32.079Z",
+        "balance": 3.5632955922081234e+26,
+        "block_height": 102052295,
+        "epoch_id": "9CG91yVxDbW1S9dGyARxxuw2KWU6VhUbNdYwyuCq7WgY",
+        "next_epoch_id": "2S6BVRy5d3Dam9HoUEMNvAuwhCgNodpUwo3hhLxdGBq9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.495551291556136e+22
+    },
+    {
+        "timestamp": "2023-09-26T16:42:59.317Z",
+        "balance": 3.562846037078968e+26,
+        "block_height": 102009095,
+        "epoch_id": "8HpHnWmXiXPBgkiDDiSymZw14TGUDsC66k9Qmzh2oTmo",
+        "next_epoch_id": "9CG91yVxDbW1S9dGyARxxuw2KWU6VhUbNdYwyuCq7WgY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.368565145526519e+22
+    },
+    {
+        "timestamp": "2023-09-26T02:20:13.273Z",
+        "balance": 3.562409180564415e+26,
+        "block_height": 101965895,
+        "epoch_id": "DPLpycd9tU6xhtpm8kkdmMfDaWsZ4j5tdYkdAm8db1t5",
+        "next_epoch_id": "8HpHnWmXiXPBgkiDDiSymZw14TGUDsC66k9Qmzh2oTmo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.333279039859888e+22
+    },
+    {
+        "timestamp": "2023-09-25T12:20:37.261Z",
+        "balance": 3.561975852660429e+26,
+        "block_height": 101922695,
+        "epoch_id": "7KQcMo7hKcNbYz8RX76k5iUCFDBXxJDTUYZWaFMvprJV",
+        "next_epoch_id": "DPLpycd9tU6xhtpm8kkdmMfDaWsZ4j5tdYkdAm8db1t5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.271482035198467e+22
+    },
+    {
+        "timestamp": "2023-09-24T22:27:35.111Z",
+        "balance": 3.561548704456909e+26,
+        "block_height": 101879495,
+        "epoch_id": "FPho7WucSwLqCD8Dyb62b6FDoqx8BX88SFHsszhT5K9D",
+        "next_epoch_id": "7KQcMo7hKcNbYz8RX76k5iUCFDBXxJDTUYZWaFMvprJV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.342352707300076e+22
+    },
+    {
+        "timestamp": "2023-09-24T08:46:28.747Z",
+        "balance": 3.561114469186179e+26,
+        "block_height": 101836295,
+        "epoch_id": "FLXMaP1caeMQw3arXzxtaU3LmpWRfo1W5YbRh4rebkKz",
+        "next_epoch_id": "FPho7WucSwLqCD8Dyb62b6FDoqx8BX88SFHsszhT5K9D",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.458153199995024e+22
+    },
+    {
+        "timestamp": "2023-09-23T15:23:46.487Z",
+        "balance": 3.56066865386618e+26,
+        "block_height": 101782375,
+        "epoch_id": "317TEBw3BBo7wEQEv2YkjmmajiDpFGjNsoTsR1tSkdHi",
+        "next_epoch_id": "FLXMaP1caeMQw3arXzxtaU3LmpWRfo1W5YbRh4rebkKz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.256039197786802e+22
+    },
+    {
+        "timestamp": "2023-09-23T04:34:26.875Z",
+        "balance": 3.560243049946401e+26,
+        "block_height": 101749895,
+        "epoch_id": "FdQEkavzT5rvg519wANZbT5H6YbLQwiPDNHWjGZ9AUff",
+        "next_epoch_id": "317TEBw3BBo7wEQEv2YkjmmajiDpFGjNsoTsR1tSkdHi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.437036409958962e+22
+    },
+    {
+        "timestamp": "2023-09-22T14:55:34.642Z",
+        "balance": 3.559799346305405e+26,
+        "block_height": 101706695,
+        "epoch_id": "DnwrSRbbxXSdQRUE5dosn4Nu1NWg8Yxp9MfcmhM7pGB8",
+        "next_epoch_id": "FdQEkavzT5rvg519wANZbT5H6YbLQwiPDNHWjGZ9AUff",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2703550713423255e+22
+    },
+    {
+        "timestamp": "2023-09-22T00:42:23.148Z",
+        "balance": 3.559372310798271e+26,
+        "block_height": 101663495,
+        "epoch_id": "5YpBVBDx2e7HzbRgNpmoUhdE6217hnEqftuhhXN2Eb76",
+        "next_epoch_id": "DnwrSRbbxXSdQRUE5dosn4Nu1NWg8Yxp9MfcmhM7pGB8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.270120495889787e+22
+    },
+    {
+        "timestamp": "2023-09-21T11:01:19.623Z",
+        "balance": 3.558945298748682e+26,
+        "block_height": 101620295,
+        "epoch_id": "BymwaahPJGU9sDcqc1yTfkTUVLd6m9hBaEJGdGQZrfDt",
+        "next_epoch_id": "5YpBVBDx2e7HzbRgNpmoUhdE6217hnEqftuhhXN2Eb76",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.342353084020247e+22
+    },
+    {
+        "timestamp": "2023-09-20T21:19:23.508Z",
+        "balance": 3.55851106344028e+26,
+        "block_height": 101577095,
+        "epoch_id": "4Yait96feKATCdH3KeQREtKpDuuqh6BQRY7XFV5ocyJz",
+        "next_epoch_id": "BymwaahPJGU9sDcqc1yTfkTUVLd6m9hBaEJGdGQZrfDt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.248316400702269e+22
+    },
+    {
+        "timestamp": "2023-09-20T07:20:13.081Z",
+        "balance": 3.55808623180021e+26,
+        "block_height": 101533895,
+        "epoch_id": "2ZpTDBCeQ3XBcXjEnsZgWBdRNXZPmtPq1U4oZWbJrQUu",
+        "next_epoch_id": "4Yait96feKATCdH3KeQREtKpDuuqh6BQRY7XFV5ocyJz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3361257554261836e+22
+    },
+    {
+        "timestamp": "2023-09-19T17:42:17.137Z",
+        "balance": 3.557652619224667e+26,
+        "block_height": 101490695,
+        "epoch_id": "DDpNZrX1p6swwvNWB7orn8A8mkEVvtyQYacMZ9NLZsbj",
+        "next_epoch_id": "2ZpTDBCeQ3XBcXjEnsZgWBdRNXZPmtPq1U4oZWbJrQUu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.465846903081045e+22
+    },
+    {
+        "timestamp": "2023-09-19T03:48:16.940Z",
+        "balance": 3.557206034534359e+26,
+        "block_height": 101447495,
+        "epoch_id": "5neaV4TWTwaBgXoq3HyZi41hW6n6z6uyK75ieSD13gSQ",
+        "next_epoch_id": "DDpNZrX1p6swwvNWB7orn8A8mkEVvtyQYacMZ9NLZsbj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.413235928588313e+22
+    },
+    {
+        "timestamp": "2023-09-18T13:29:00.322Z",
+        "balance": 3.5567647109415e+26,
+        "block_height": 101404295,
+        "epoch_id": "Ce3iGv8nDhww18ieWV4V5AnCpWwPEbRWmkMqGvuVqkPA",
+        "next_epoch_id": "5neaV4TWTwaBgXoq3HyZi41hW6n6z6uyK75ieSD13gSQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.420289977199035e+22
+    },
+    {
+        "timestamp": "2023-09-17T23:23:57.994Z",
+        "balance": 3.55632268194378e+26,
+        "block_height": 101361095,
+        "epoch_id": "ADB25spsjY5EB7Mm64YJEQNWcwxnJYT87S8oG1VRwkjj",
+        "next_epoch_id": "Ce3iGv8nDhww18ieWV4V5AnCpWwPEbRWmkMqGvuVqkPA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.319943879260428e+22
+    },
+    {
+        "timestamp": "2023-09-17T09:18:01.877Z",
+        "balance": 3.555890687555854e+26,
+        "block_height": 101317895,
+        "epoch_id": "3LrNa6ciEzntmZLbGBK2wj7Dome53XLKLH2uL1KfJUU4",
+        "next_epoch_id": "ADB25spsjY5EB7Mm64YJEQNWcwxnJYT87S8oG1VRwkjj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4125500408997605e+22
+    },
+    {
+        "timestamp": "2023-09-16T19:32:13.012Z",
+        "balance": 3.555449432551764e+26,
+        "block_height": 101274695,
+        "epoch_id": "J6iUpd89oaysr42KGD13AGDPqMzrDn7aokS7Qt3r8NAB",
+        "next_epoch_id": "3LrNa6ciEzntmZLbGBK2wj7Dome53XLKLH2uL1KfJUU4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4680894380043095e+22
+    },
+    {
+        "timestamp": "2023-09-16T05:27:58.229Z",
+        "balance": 3.555002623607964e+26,
+        "block_height": 101231495,
+        "epoch_id": "GABeMMm9HncoePJdCHqAkY3cZLX3UyhfpUxYVjKMSSYk",
+        "next_epoch_id": "J6iUpd89oaysr42KGD13AGDPqMzrDn7aokS7Qt3r8NAB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.524354290523787e+22
+    },
+    {
+        "timestamp": "2023-09-15T15:12:52.901Z",
+        "balance": 3.5545501881789114e+26,
+        "block_height": 101188295,
+        "epoch_id": "C7ggKzrbgKcgQT9tgFa2HmtK2RAW3i9GQCcr7WLKTYVF",
+        "next_epoch_id": "GABeMMm9HncoePJdCHqAkY3cZLX3UyhfpUxYVjKMSSYk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.407050158613202e+22
+    },
+    {
+        "timestamp": "2023-09-14T19:35:45.757Z",
+        "balance": 3.55410948316305e+26,
+        "block_height": 101128445,
+        "epoch_id": "DkHDoCSUQCUj5u6y4251DJnErsdRbRTjBYEDgs3EZHdC",
+        "next_epoch_id": "C7ggKzrbgKcgQT9tgFa2HmtK2RAW3i9GQCcr7WLKTYVF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.414292566079578e+22
+    },
+    {
+        "timestamp": "2023-09-14T10:41:49.123Z",
+        "balance": 3.553668053906442e+26,
+        "block_height": 101101895,
+        "epoch_id": "2v4fC712vbLUaNEq8vpx1TQQKcRDY2EUU3LxXwvDye1R",
+        "next_epoch_id": "DkHDoCSUQCUj5u6y4251DJnErsdRbRTjBYEDgs3EZHdC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3549295838711566e+22
+    },
+    {
+        "timestamp": "2023-09-13T20:36:20.758Z",
+        "balance": 3.553232560948055e+26,
+        "block_height": 101058695,
+        "epoch_id": "CKTimDySSPoVYSfKPAZsEDfVoMVXD9SduQkVGSf1QoBd",
+        "next_epoch_id": "2v4fC712vbLUaNEq8vpx1TQQKcRDY2EUU3LxXwvDye1R",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.327977009241293e+22
+    },
+    {
+        "timestamp": "2023-09-13T06:42:03.925Z",
+        "balance": 3.552799763247131e+26,
+        "block_height": 101015495,
+        "epoch_id": "8LWp9FvUoSKzGchRQMjspmp3262FcoShugJcDG4dPTSM",
+        "next_epoch_id": "CKTimDySSPoVYSfKPAZsEDfVoMVXD9SduQkVGSf1QoBd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.400245371494392e+22
+    },
+    {
+        "timestamp": "2023-09-12T16:53:57.386Z",
+        "balance": 3.5523597387099815e+26,
+        "block_height": 100972295,
+        "epoch_id": "EfkKwBeEJScwEHJC1QsUohnQqPey3CtFt7K8hS6GAfvZ",
+        "next_epoch_id": "8LWp9FvUoSKzGchRQMjspmp3262FcoShugJcDG4dPTSM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.281442457625712e+22
+    },
+    {
+        "timestamp": "2023-09-12T02:52:27.816Z",
+        "balance": 3.551931594464219e+26,
+        "block_height": 100929095,
+        "epoch_id": "91xf4anmftn1rM4ay9mFDdLmxWPm4TB7ukNttSeBtyJS",
+        "next_epoch_id": "EfkKwBeEJScwEHJC1QsUohnQqPey3CtFt7K8hS6GAfvZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.399134044294762e+22
+    },
+    {
+        "timestamp": "2023-09-11T13:12:56.998Z",
+        "balance": 3.5514916810597894e+26,
+        "block_height": 100885895,
+        "epoch_id": "Ek9d3AP7xgQXc1Zsy13kcJrwu7fmfMduC6hYJgSHtaZp",
+        "next_epoch_id": "91xf4anmftn1rM4ay9mFDdLmxWPm4TB7ukNttSeBtyJS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3463978844177415e+22
+    },
+    {
+        "timestamp": "2023-09-10T23:10:39.061Z",
+        "balance": 3.5510570412713476e+26,
+        "block_height": 100842695,
+        "epoch_id": "21xvXqN4dejSsreNxHVzqzN7gDX5bnz1shjb4WtCXXF4",
+        "next_epoch_id": "Ek9d3AP7xgQXc1Zsy13kcJrwu7fmfMduC6hYJgSHtaZp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.393108241757851e+22
+    },
+    {
+        "timestamp": "2023-09-10T09:19:24.322Z",
+        "balance": 3.550617730447172e+26,
+        "block_height": 100799495,
+        "epoch_id": "3W49t9j5g1wb228NgD6F61eK47zthDTPvGutzAarehQQ",
+        "next_epoch_id": "21xvXqN4dejSsreNxHVzqzN7gDX5bnz1shjb4WtCXXF4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.387057689702108e+22
+    },
+    {
+        "timestamp": "2023-09-09T19:18:55.921Z",
+        "balance": 3.5501790246782017e+26,
+        "block_height": 100756295,
+        "epoch_id": "CgJkXs96WhpW9KYxWGJn4mppWHwnW1HE8J15vY453JtT",
+        "next_epoch_id": "3W49t9j5g1wb228NgD6F61eK47zthDTPvGutzAarehQQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.377406443120749e+22
+    },
+    {
+        "timestamp": "2023-09-09T05:19:49.225Z",
+        "balance": 3.5497412840338896e+26,
+        "block_height": 100713095,
+        "epoch_id": "5LndKLFDRTA9W9uGr3MH7zJTtoYDcKn3oJETa9wLEoLz",
+        "next_epoch_id": "CgJkXs96WhpW9KYxWGJn4mppWHwnW1HE8J15vY453JtT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.509720443393831e+22
+    },
+    {
+        "timestamp": "2023-09-08T15:17:51.016Z",
+        "balance": 3.54929031198955e+26,
+        "block_height": 100669895,
+        "epoch_id": "7XY3WEXy1oQsQhFyys3tFa7CYgm8Bd6bNVFkWyc1Sy65",
+        "next_epoch_id": "5LndKLFDRTA9W9uGr3MH7zJTtoYDcKn3oJETa9wLEoLz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.454339449885223e+22
+    },
+    {
+        "timestamp": "2023-09-08T00:51:00.908Z",
+        "balance": 3.548844878044562e+26,
+        "block_height": 100626695,
+        "epoch_id": "89apPFfAL7ffQDYBxL4j8UaGWzuRpL3ds4uR3XRqhYkG",
+        "next_epoch_id": "7XY3WEXy1oQsQhFyys3tFa7CYgm8Bd6bNVFkWyc1Sy65",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.496106134549191e+22
+    },
+    {
+        "timestamp": "2023-09-07T10:34:31.315Z",
+        "balance": 3.548395267431107e+26,
+        "block_height": 100583495,
+        "epoch_id": "GLio6GPMmHzNqUzJEaCiN5WAgv1BTJXbEf6Dop5KKVqY",
+        "next_epoch_id": "89apPFfAL7ffQDYBxL4j8UaGWzuRpL3ds4uR3XRqhYkG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.61943959979653e+22
+    },
+    {
+        "timestamp": "2023-09-06T20:13:39.044Z",
+        "balance": 3.547933323471127e+26,
+        "block_height": 100540295,
+        "epoch_id": "94rdnY3fY6qvgM5bYopnh2Na6gPMhz9KS8463YuPw92N",
+        "next_epoch_id": "GLio6GPMmHzNqUzJEaCiN5WAgv1BTJXbEf6Dop5KKVqY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.37217552712066e+22
+    },
+    {
+        "timestamp": "2023-09-06T05:26:26.019Z",
+        "balance": 3.547496105918415e+26,
+        "block_height": 100497095,
+        "epoch_id": "D9TbTYV18N3pXS8GMtZshiC2ikS8fPswYLuPsQNDTkKJ",
+        "next_epoch_id": "94rdnY3fY6qvgM5bYopnh2Na6gPMhz9KS8463YuPw92N",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.657010189098359e+22
+    },
+    {
+        "timestamp": "2023-09-05T15:25:51.183Z",
+        "balance": 3.547030404899505e+26,
+        "block_height": 100453895,
+        "epoch_id": "HCLc5revQXzx8fTU1Tq7gyL4QYV3CHbef84iq89FKTuz",
+        "next_epoch_id": "D9TbTYV18N3pXS8GMtZshiC2ikS8fPswYLuPsQNDTkKJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4737639318701776e+22
+    },
+    {
+        "timestamp": "2023-09-05T00:29:20.733Z",
+        "balance": 3.546583028506318e+26,
+        "block_height": 100410695,
+        "epoch_id": "GH8K8PVGXvjRvQ98mxJikaHVadidvEQqTrGa6fK4BikG",
+        "next_epoch_id": "HCLc5revQXzx8fTU1Tq7gyL4QYV3CHbef84iq89FKTuz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.397587370269605e+22
+    },
+    {
+        "timestamp": "2023-09-04T10:07:04.618Z",
+        "balance": 3.546143269769291e+26,
+        "block_height": 100367495,
+        "epoch_id": "C29sq5qnTvAsgPVNXiYB8MRF3dh6kzB9eCBNSTke7w5u",
+        "next_epoch_id": "GH8K8PVGXvjRvQ98mxJikaHVadidvEQqTrGa6fK4BikG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.4465296174118685e+22
+    },
+    {
+        "timestamp": "2023-09-03T19:59:23.819Z",
+        "balance": 3.54569861680755e+26,
+        "block_height": 100324295,
+        "epoch_id": "4LypgvNUatTmYJrZc68GCM7sP7RQHSjRJWNZsUKwydkq",
+        "next_epoch_id": "C29sq5qnTvAsgPVNXiYB8MRF3dh6kzB9eCBNSTke7w5u",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.431881008582395e+22
+    },
+    {
+        "timestamp": "2023-09-03T05:43:20.614Z",
+        "balance": 3.545255428706692e+26,
+        "block_height": 100281095,
+        "epoch_id": "GgZFRWa3wYU3onArX3W1EvDU6rAnNA1e6w1GAH9MGrPG",
+        "next_epoch_id": "4LypgvNUatTmYJrZc68GCM7sP7RQHSjRJWNZsUKwydkq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3874207925526315e+22
+    },
+    {
+        "timestamp": "2023-09-02T15:30:51.850Z",
+        "balance": 3.5448166866274365e+26,
+        "block_height": 100237895,
+        "epoch_id": "tt3Q9pYZtEPPautdXBVBYKbQBNsB481AV3isGt5YtaF",
+        "next_epoch_id": "GgZFRWa3wYU3onArX3W1EvDU6rAnNA1e6w1GAH9MGrPG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.28673358864123e+22
+    },
+    {
+        "timestamp": "2023-09-02T01:24:04.483Z",
+        "balance": 3.5443880132685724e+26,
+        "block_height": 100194695,
+        "epoch_id": "L66Umxg3B6WoBrdhoBfV9amhH5KARzoYx3RGL3r9f9g",
+        "next_epoch_id": "tt3Q9pYZtEPPautdXBVBYKbQBNsB481AV3isGt5YtaF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.291052767506255e+22
+    },
+    {
+        "timestamp": "2023-09-01T11:36:30.768Z",
+        "balance": 3.543958907991822e+26,
+        "block_height": 100151495,
+        "epoch_id": "FN9rbjn3kNbEMXobuf5MYNVnokGhddD4NfxBJdgmQPoa",
+        "next_epoch_id": "L66Umxg3B6WoBrdhoBfV9amhH5KARzoYx3RGL3r9f9g",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.259078110954314e+22
+    },
+    {
+        "timestamp": "2023-08-31T21:49:07.308Z",
+        "balance": 3.5435330001807263e+26,
+        "block_height": 100108295,
+        "epoch_id": "3GG5J89DxWDDRsKkwGVbHPF6NTGFoTdJDEe2awka6Eph",
+        "next_epoch_id": "FN9rbjn3kNbEMXobuf5MYNVnokGhddD4NfxBJdgmQPoa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.202173012710903e+22
+    },
+    {
+        "timestamp": "2023-08-31T08:07:49.571Z",
+        "balance": 3.543112782879455e+26,
+        "block_height": 100065095,
+        "epoch_id": "2rZGzEXGHDGf1zf3oy4CELZLk4L9aLe9DTnXJk7XdgGn",
+        "next_epoch_id": "3GG5J89DxWDDRsKkwGVbHPF6NTGFoTdJDEe2awka6Eph",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.300987268685742e+22
+    },
+    {
+        "timestamp": "2023-08-30T18:36:33.793Z",
+        "balance": 3.542682684152587e+26,
+        "block_height": 100021895,
+        "epoch_id": "9n8aatTSFqqVgHaCE78Rs19q2z6a5bMhhAezZsdSE8VQ",
+        "next_epoch_id": "2rZGzEXGHDGf1zf3oy4CELZLk4L9aLe9DTnXJk7XdgGn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2219546966805054e+22
+    },
+    {
+        "timestamp": "2023-08-30T04:46:03.039Z",
+        "balance": 3.5422604886829186e+26,
+        "block_height": 99978695,
+        "epoch_id": "4ntNYZVYq3TNRKpDWCfvAGJ2R9QzYbHuJ8G9t5bCwbmX",
+        "next_epoch_id": "9n8aatTSFqqVgHaCE78Rs19q2z6a5bMhhAezZsdSE8VQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3189299574179455e+22
+    },
+    {
+        "timestamp": "2023-08-29T15:11:34.944Z",
+        "balance": 3.541828595687177e+26,
+        "block_height": 99935495,
+        "epoch_id": "CRnv4iJMgg6zgv8Aq84UgaAJe6VbCn9MLFDyY25N8yc3",
+        "next_epoch_id": "4ntNYZVYq3TNRKpDWCfvAGJ2R9QzYbHuJ8G9t5bCwbmX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.270961877089983e+22
+    },
+    {
+        "timestamp": "2023-08-29T01:18:40.172Z",
+        "balance": 3.541401499499468e+26,
+        "block_height": 99892295,
+        "epoch_id": "GgxCjeXgDuK8t5ZET4ugdavXpPnfENGXcssudCBzXzfq",
+        "next_epoch_id": "CRnv4iJMgg6zgv8Aq84UgaAJe6VbCn9MLFDyY25N8yc3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2566833174887726e+22
+    },
+    {
+        "timestamp": "2023-08-28T11:34:21.434Z",
+        "balance": 3.540975831167719e+26,
+        "block_height": 99849095,
+        "epoch_id": "DeUcMR2y5NQTczuoFoPATw9xDYb8ahJsusHmQjAaQbiH",
+        "next_epoch_id": "GgxCjeXgDuK8t5ZET4ugdavXpPnfENGXcssudCBzXzfq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3605122497282e+22
+    },
+    {
+        "timestamp": "2023-08-27T18:39:50.701Z",
+        "balance": 3.540539779942746e+26,
+        "block_height": 99796002,
+        "epoch_id": "HnMFcAAMnphzKf8R94VNLj2DLPnMfNVVxyaT2dSHG5H7",
+        "next_epoch_id": "DeUcMR2y5NQTczuoFoPATw9xDYb8ahJsusHmQjAaQbiH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.27290860476503e+22
+    },
+    {
+        "timestamp": "2023-08-27T07:51:37.942Z",
+        "balance": 3.5401124890822696e+26,
+        "block_height": 99762695,
+        "epoch_id": "BkHwFzkzgieP64XAQ6t4oTcTRbXvwQAwXRZbXR3e3f8K",
+        "next_epoch_id": "HnMFcAAMnphzKf8R94VNLj2DLPnMfNVVxyaT2dSHG5H7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.213771281224108e+22
+    },
+    {
+        "timestamp": "2023-08-26T18:07:33.982Z",
+        "balance": 3.539691111954147e+26,
+        "block_height": 99719495,
+        "epoch_id": "6uJ1r7rGZXcqdZ17n7XxvoMHbntoNgcp2kZ4jJpZ96m4",
+        "next_epoch_id": "BkHwFzkzgieP64XAQ6t4oTcTRbXvwQAwXRZbXR3e3f8K",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.229688621743552e+22
+    },
+    {
+        "timestamp": "2023-08-26T04:33:21.063Z",
+        "balance": 3.539268143091973e+26,
+        "block_height": 99676295,
+        "epoch_id": "CJcq2xdYJxVtuDsFwVVtmJPrUXCsosV2Le8HPDNRAKY5",
+        "next_epoch_id": "6uJ1r7rGZXcqdZ17n7XxvoMHbntoNgcp2kZ4jJpZ96m4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.235092569640851e+22
+    },
+    {
+        "timestamp": "2023-08-25T14:56:17.487Z",
+        "balance": 3.538844633835009e+26,
+        "block_height": 99633095,
+        "epoch_id": "2X7cTDfE5dfNKJRSPXbr7kV3kbxNPfKRBaV1YQ99giGx",
+        "next_epoch_id": "CJcq2xdYJxVtuDsFwVVtmJPrUXCsosV2Le8HPDNRAKY5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2678930349273414e+22
+    },
+    {
+        "timestamp": "2023-08-25T01:19:13.729Z",
+        "balance": 3.538417844531516e+26,
+        "block_height": 99589895,
+        "epoch_id": "CBRftMBkrNaQzdGS6eaogYHm5W87n3gwPfYwf2ds6NKt",
+        "next_epoch_id": "2X7cTDfE5dfNKJRSPXbr7kV3kbxNPfKRBaV1YQ99giGx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2438232810837225e+22
+    },
+    {
+        "timestamp": "2023-08-24T11:43:36.205Z",
+        "balance": 3.537993462203408e+26,
+        "block_height": 99546695,
+        "epoch_id": "EFoCWoNqt3Y15GXqz6L6gsYrgMX3aRysHUPqB9e9yjyU",
+        "next_epoch_id": "CBRftMBkrNaQzdGS6eaogYHm5W87n3gwPfYwf2ds6NKt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.2664549372699825e+22
+    },
+    {
+        "timestamp": "2023-08-23T22:14:03.236Z",
+        "balance": 3.537566816709681e+26,
+        "block_height": 99503495,
+        "epoch_id": "D6kHHbWo5qRS5KSbZ2dsEYRR1HgRpk4UUhVTFF6Ucddf",
+        "next_epoch_id": "EFoCWoNqt3Y15GXqz6L6gsYrgMX3aRysHUPqB9e9yjyU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.330314061805598e+22
+    },
+    {
+        "timestamp": "2023-08-23T08:38:28.149Z",
+        "balance": 3.5371337853035e+26,
+        "block_height": 99460295,
+        "epoch_id": "nNZV13LazX6YYJ9ru4JKMFCvrDoigBTnbuZaiZToNez",
+        "next_epoch_id": "D6kHHbWo5qRS5KSbZ2dsEYRR1HgRpk4UUhVTFF6Ucddf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.384565329608551e+22
+    },
+    {
+        "timestamp": "2023-08-22T19:16:05.609Z",
+        "balance": 3.536695328770539e+26,
+        "block_height": 99417095,
+        "epoch_id": "3AowhNYFEPYZQSg1Yfwv11ZkYQDc6CB7DvVgoZ7QbTDH",
+        "next_epoch_id": "nNZV13LazX6YYJ9ru4JKMFCvrDoigBTnbuZaiZToNez",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.331366646510747e+22
+    },
+    {
+        "timestamp": "2023-08-22T05:43:06.502Z",
+        "balance": 3.536262192105888e+26,
+        "block_height": 99373895,
+        "epoch_id": "8x4fAerzGPd1x5a18ujPYLukf4NACVh9ifQCAKGnPC6c",
+        "next_epoch_id": "3AowhNYFEPYZQSg1Yfwv11ZkYQDc6CB7DvVgoZ7QbTDH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.388264656669986e+22
+    },
+    {
+        "timestamp": "2023-08-21T16:19:39.528Z",
+        "balance": 3.535823365640221e+26,
+        "block_height": 99330695,
+        "epoch_id": "E4uMDDxocRuCase1NAyK3CXveynLCBzCQZXXo2xBCCME",
+        "next_epoch_id": "8x4fAerzGPd1x5a18ujPYLukf4NACVh9ifQCAKGnPC6c",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.392605937106863e+22
+    },
+    {
+        "timestamp": "2023-08-21T02:45:47.677Z",
+        "balance": 3.5353841050465105e+26,
+        "block_height": 99287495,
+        "epoch_id": "5WH3cdYbgfYyE19impvhws8Nx9kdWQAymD9mmSn5fLFC",
+        "next_epoch_id": "E4uMDDxocRuCase1NAyK3CXveynLCBzCQZXXo2xBCCME",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.320608486348102e+22
+    },
+    {
+        "timestamp": "2023-08-20T13:12:25.207Z",
+        "balance": 3.534952044197876e+26,
+        "block_height": 99244295,
+        "epoch_id": "3HsJyUXjs9CKyRP8Q37xj5gbQAr81VVxqu5frxfyRkzx",
+        "next_epoch_id": "5WH3cdYbgfYyE19impvhws8Nx9kdWQAymD9mmSn5fLFC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.45378337468323e+22
+    },
+    {
+        "timestamp": "2023-08-19T23:53:23.005Z",
+        "balance": 3.5345066658604074e+26,
+        "block_height": 99201095,
+        "epoch_id": "CUAAtYGaPkj18pRvKAAUED1miRuGRs9b6VHJNMazJqvT",
+        "next_epoch_id": "3HsJyUXjs9CKyRP8Q37xj5gbQAr81VVxqu5frxfyRkzx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.354724741872477e+22
+    },
+    {
+        "timestamp": "2023-08-19T10:08:25.082Z",
+        "balance": 3.53407119338622e+26,
+        "block_height": 99157895,
+        "epoch_id": "5GENxjLa414B3ANSVwxDmJC7u5kCPfg1MKCfKPxaYdMK",
+        "next_epoch_id": "CUAAtYGaPkj18pRvKAAUED1miRuGRs9b6VHJNMazJqvT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.442025496719066e+22
+    },
+    {
+        "timestamp": "2023-08-18T20:40:53.423Z",
+        "balance": 3.533626990836548e+26,
+        "block_height": 99114695,
+        "epoch_id": "58yECAoDxRUydEe197LX2Ej1CpyicjRGuHvQHVzfyBU6",
+        "next_epoch_id": "5GENxjLa414B3ANSVwxDmJC7u5kCPfg1MKCfKPxaYdMK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.413411337540327e+22
+    },
+    {
+        "timestamp": "2023-08-18T06:58:16.003Z",
+        "balance": 3.533185649702794e+26,
+        "block_height": 99071495,
+        "epoch_id": "CWwhgePhYSiCNUz6wwZrQXKLsrnof3zRKvmguVLwLvXu",
+        "next_epoch_id": "58yECAoDxRUydEe197LX2Ej1CpyicjRGuHvQHVzfyBU6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.446582503598183e+22
+    },
+    {
+        "timestamp": "2023-08-17T17:20:19.040Z",
+        "balance": 3.5327409914524344e+26,
+        "block_height": 99028295,
+        "epoch_id": "Ans9AmeRBtGBPz6EokwM5QJsZb3HMDc1iBpBLmdbmdbz",
+        "next_epoch_id": "CWwhgePhYSiCNUz6wwZrQXKLsrnof3zRKvmguVLwLvXu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.414136212385628e+22
+    },
+    {
+        "timestamp": "2023-08-16T16:35:46.991Z",
+        "balance": 3.532299577831196e+26,
+        "block_height": 98949734,
+        "epoch_id": "2GtG4z91sdCQTP8LH5g1kau2FV8cP2Su5ENnFjcmGxao",
+        "next_epoch_id": "Ans9AmeRBtGBPz6EokwM5QJsZb3HMDc1iBpBLmdbmdbz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.363356137233766e+22
+    },
+    {
+        "timestamp": "2023-08-16T13:55:36.608Z",
+        "balance": 3.5318632422174724e+26,
+        "block_height": 98941895,
+        "epoch_id": "FaYGkMoWKFPeE7udF7QRNBFCJTCfz7aNbHYmpWgfc2hj",
+        "next_epoch_id": "2GtG4z91sdCQTP8LH5g1kau2FV8cP2Su5ENnFjcmGxao",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.427924400376778e+22
+    },
+    {
+        "timestamp": "2023-08-16T00:26:18.141Z",
+        "balance": 3.531420449777435e+26,
+        "block_height": 98898695,
+        "epoch_id": "7M7qpKxfTjypBAfCqkyLW75n8DfptNgbsNcYMbENxEAi",
+        "next_epoch_id": "FaYGkMoWKFPeE7udF7QRNBFCJTCfz7aNbHYmpWgfc2hj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.327088431044054e+22
+    },
+    {
+        "timestamp": "2023-08-15T10:49:16.611Z",
+        "balance": 3.5309877409343303e+26,
+        "block_height": 98855495,
+        "epoch_id": "4mKpkfKaznoyoo6QyvoJ8ytm2Npepkjaoq9GkEFf3w6h",
+        "next_epoch_id": "7M7qpKxfTjypBAfCqkyLW75n8DfptNgbsNcYMbENxEAi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6019107555243505e+22
+    },
+    {
+        "timestamp": "2023-08-14T21:24:06.547Z",
+        "balance": 3.530527549858778e+26,
+        "block_height": 98812295,
+        "epoch_id": "cjd4UXVpJRpyYfNmHJzhhVBaxiQtLb77rRx2W87sWJG",
+        "next_epoch_id": "4mKpkfKaznoyoo6QyvoJ8ytm2Npepkjaoq9GkEFf3w6h",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.369320362769578e+22
+    },
+    {
+        "timestamp": "2023-08-14T07:08:17.946Z",
+        "balance": 3.530090617822501e+26,
+        "block_height": 98769095,
+        "epoch_id": "5vYm97W8SQAHAEo39jQ1RremGAGQuhrFJNUS9SGa3xFW",
+        "next_epoch_id": "cjd4UXVpJRpyYfNmHJzhhVBaxiQtLb77rRx2W87sWJG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.5045889058519936e+22
+    },
+    {
+        "timestamp": "2023-08-13T17:41:55.960Z",
+        "balance": 3.529640158931916e+26,
+        "block_height": 98725895,
+        "epoch_id": "EAZF7Gq17AtNkE5kKiNE7YRxMUncC9EUpj7nBCx1Aoq7",
+        "next_epoch_id": "5vYm97W8SQAHAEo39jQ1RremGAGQuhrFJNUS9SGa3xFW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.7649366549108084e+22
+    },
+    {
+        "timestamp": "2023-08-13T03:50:55.736Z",
+        "balance": 3.529163665266425e+26,
+        "block_height": 98682695,
+        "epoch_id": "2noD4kyA6a5iwojfxPdABA2LNqRtrqY1kUDmpu94Tth7",
+        "next_epoch_id": "EAZF7Gq17AtNkE5kKiNE7YRxMUncC9EUpj7nBCx1Aoq7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.739920302060541e+22
+    },
+    {
+        "timestamp": "2023-08-12T13:05:14.060Z",
+        "balance": 3.5286896732362186e+26,
+        "block_height": 98639495,
+        "epoch_id": "BRhr4jg4xhYJAVCzHkAsduSeQjkJwd17Smef42ExN4uo",
+        "next_epoch_id": "2noD4kyA6a5iwojfxPdABA2LNqRtrqY1kUDmpu94Tth7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.506190689454647e+22
+    },
+    {
+        "timestamp": "2023-08-11T22:24:30.266Z",
+        "balance": 3.528239054167273e+26,
+        "block_height": 98596295,
+        "epoch_id": "73mPwzPk9XMe2ppbrTLWbdJGMWefFn4Gn66GnQVTxkER",
+        "next_epoch_id": "BRhr4jg4xhYJAVCzHkAsduSeQjkJwd17Smef42ExN4uo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.426317650197639e+22
+    },
+    {
+        "timestamp": "2023-08-11T08:33:46.520Z",
+        "balance": 3.5277964224022534e+26,
+        "block_height": 98553095,
+        "epoch_id": "71Kd9r8ivviYEVwESLqFiF81gnbWNyvqGR3y3gRj43CT",
+        "next_epoch_id": "73mPwzPk9XMe2ppbrTLWbdJGMWefFn4Gn66GnQVTxkER",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.840606749796565e+22
+    },
+    {
+        "timestamp": "2023-08-10T18:52:11.960Z",
+        "balance": 3.527312361727274e+26,
+        "block_height": 98509526,
+        "epoch_id": "8qDGzWHHbWfW2JaEFfQbMGWVmosV1ecdnH6iZrjSTsyW",
+        "next_epoch_id": "71Kd9r8ivviYEVwESLqFiF81gnbWNyvqGR3y3gRj43CT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.820602527243609e+22
+    },
+    {
+        "timestamp": "2023-08-10T04:02:55.264Z",
+        "balance": 3.5268303014745494e+26,
+        "block_height": 98466695,
+        "epoch_id": "7WAWWFLhrAEdE51dn2kBganC6JChXMRF88Hc6hGjA2oQ",
+        "next_epoch_id": "8qDGzWHHbWfW2JaEFfQbMGWVmosV1ecdnH6iZrjSTsyW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.3921817367453895e+22
+    },
+    {
+        "timestamp": "2023-08-09T13:10:26.583Z",
+        "balance": 3.526391083300875e+26,
+        "block_height": 98423495,
+        "epoch_id": "48fsk8XhxZ4rnruG7iNMeK7kftJ2oEzrhJc3mRAK8MkX",
+        "next_epoch_id": "7WAWWFLhrAEdE51dn2kBganC6JChXMRF88Hc6hGjA2oQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.451487706224766e+22
+    },
+    {
+        "timestamp": "2023-08-08T23:44:14.271Z",
+        "balance": 3.5259459345302524e+26,
+        "block_height": 98380295,
+        "epoch_id": "4b8sbCTdPrxbWy4MBSxCnyJYcyHpWFTn3Hi1H5Ppj26Y",
+        "next_epoch_id": "48fsk8XhxZ4rnruG7iNMeK7kftJ2oEzrhJc3mRAK8MkX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.7861509269743385e+22
+    },
+    {
+        "timestamp": "2023-08-08T10:07:11.800Z",
+        "balance": 3.525467319437555e+26,
+        "block_height": 98337095,
+        "epoch_id": "9s7fYFhayZK69kLSU1Ahvkukex3nPHUMCrZ5svu69Zsa",
+        "next_epoch_id": "4b8sbCTdPrxbWy4MBSxCnyJYcyHpWFTn3Hi1H5Ppj26Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.799194568324722e+22
+    },
+    {
+        "timestamp": "2023-08-07T19:17:19.818Z",
+        "balance": 3.5249873999807225e+26,
+        "block_height": 98293895,
+        "epoch_id": "2ecgMwsMGdWBdfFzc211LJCzQ6KwiFFQrEfSPnicjmae",
+        "next_epoch_id": "9s7fYFhayZK69kLSU1Ahvkukex3nPHUMCrZ5svu69Zsa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.468214231776916e+22
+    },
+    {
+        "timestamp": "2023-08-07T04:23:53.920Z",
+        "balance": 3.524540578557545e+26,
+        "block_height": 98250695,
+        "epoch_id": "UuYssXwxFmu55V3bDovqhxJ8wPpGxPrx6CpmqctHcPS",
+        "next_epoch_id": "2ecgMwsMGdWBdfFzc211LJCzQ6KwiFFQrEfSPnicjmae",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.449900728205888e+22
+    },
+    {
+        "timestamp": "2023-08-06T14:39:15.520Z",
+        "balance": 3.524095588484724e+26,
+        "block_height": 98207495,
+        "epoch_id": "H4yiwRfrsQqZTXJCUFnUvWMGNuycy7w3XR8XSvnMQcNM",
+        "next_epoch_id": "UuYssXwxFmu55V3bDovqhxJ8wPpGxPrx6CpmqctHcPS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.8141649757783976e+22
+    },
+    {
+        "timestamp": "2023-08-06T00:59:00.588Z",
+        "balance": 3.523614171987146e+26,
+        "block_height": 98164295,
+        "epoch_id": "DZmyFt6R5NZ5ze5bn9Z7Xdz2ApCHUmw5hZ7iUJghS3JX",
+        "next_epoch_id": "H4yiwRfrsQqZTXJCUFnUvWMGNuycy7w3XR8XSvnMQcNM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.742158905308896e+22
+    },
+    {
+        "timestamp": "2023-08-05T10:02:53.763Z",
+        "balance": 3.5231399560966154e+26,
+        "block_height": 98121095,
+        "epoch_id": "7nyaixzip8iFRR1yvwpzTTme9BbPgFUeVahkr3BsxFxX",
+        "next_epoch_id": "DZmyFt6R5NZ5ze5bn9Z7Xdz2ApCHUmw5hZ7iUJghS3JX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.480942675909063e+22
+    },
+    {
+        "timestamp": "2023-08-04T19:19:15.288Z",
+        "balance": 3.5226918618290245e+26,
+        "block_height": 98077895,
+        "epoch_id": "64NED9VeWrkXmMnZ9MrkXaXngcQLMViJ48p63QNXjbNA",
+        "next_epoch_id": "7nyaixzip8iFRR1yvwpzTTme9BbPgFUeVahkr3BsxFxX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 8588972519325696
+    },
+    {
+        "timestamp": "2023-08-04T05:33:29.820Z",
+        "balance": 3.522691861743135e+26,
+        "block_height": 98034695,
+        "epoch_id": "475MQYzy2Sx86acsCAo9q58H3jDXUSMKXUA4GaWbDive",
+        "next_epoch_id": "64NED9VeWrkXmMnZ9MrkXaXngcQLMViJ48p63QNXjbNA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.851959438917373e+22
+    },
+    {
+        "timestamp": "2023-08-03T16:05:21.026Z",
+        "balance": 3.522206665799243e+26,
+        "block_height": 97991495,
+        "epoch_id": "HN8cpm6TLDYHScK4aN5TtkRB4DAmje8jCAn2UUjbyrWG",
+        "next_epoch_id": "475MQYzy2Sx86acsCAo9q58H3jDXUSMKXUA4GaWbDive",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 8725724278030336
+    },
+    {
+        "timestamp": "2023-08-02T18:10:18.954Z",
+        "balance": 3.522206665711986e+26,
+        "block_height": 97929411,
+        "epoch_id": "4WpSuocLbFvTgFpt9Am8BsSwrKPymykXZqtnakkMBHRi",
+        "next_epoch_id": "HN8cpm6TLDYHScK4aN5TtkRB4DAmje8jCAn2UUjbyrWG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.339547889256576e+22
+    },
+    {
+        "timestamp": "2023-08-02T09:03:08.750Z",
+        "balance": 3.52177271092306e+26,
+        "block_height": 97905095,
+        "epoch_id": "4VFLmmagNDBMWEaLU6pJx3uB5hykhqtdy7aezXx6rnz4",
+        "next_epoch_id": "4WpSuocLbFvTgFpt9Am8BsSwrKPymykXZqtnakkMBHRi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.419985093317403e+22
+    },
+    {
+        "timestamp": "2023-08-01T19:41:37.444Z",
+        "balance": 3.5213307124137284e+26,
+        "block_height": 97861895,
+        "epoch_id": "8aGPHV3DLmqcZYhGztJZVriL8uEJDmMXreL9M1GboARb",
+        "next_epoch_id": "4VFLmmagNDBMWEaLU6pJx3uB5hykhqtdy7aezXx6rnz4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.414149613061549e+22
+    },
+    {
+        "timestamp": "2023-08-01T06:05:36.357Z",
+        "balance": 3.520889297452422e+26,
+        "block_height": 97818695,
+        "epoch_id": "4Kgkx1FBg1PmpFDhf47z9VkmwNGmKj5yhvgqEYepLrvH",
+        "next_epoch_id": "8aGPHV3DLmqcZYhGztJZVriL8uEJDmMXreL9M1GboARb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.404738137132042e+22
+    },
+    {
+        "timestamp": "2023-07-31T16:35:16.799Z",
+        "balance": 3.520448823638709e+26,
+        "block_height": 97775495,
+        "epoch_id": "BeairHWLBmt8Y1ezZWhL96Zft8TpHKTuwezCV3pPzp7t",
+        "next_epoch_id": "4Kgkx1FBg1PmpFDhf47z9VkmwNGmKj5yhvgqEYepLrvH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.363629589507061e+22
+    },
+    {
+        "timestamp": "2023-07-31T03:06:14.685Z",
+        "balance": 3.5200124606797584e+26,
+        "block_height": 97732295,
+        "epoch_id": "8qTVTm4q2XK1oaABrJKi364skXToyBVDttzgp1qFNLJB",
+        "next_epoch_id": "BeairHWLBmt8Y1ezZWhL96Zft8TpHKTuwezCV3pPzp7t",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.341844225077366e+22
+    },
+    {
+        "timestamp": "2023-07-30T13:45:38.786Z",
+        "balance": 3.5195782762572506e+26,
+        "block_height": 97689095,
+        "epoch_id": "9JrnFmZrMmTMSaxk63NCJSxr8caVZPmKdCuFoLcPPRRm",
+        "next_epoch_id": "8qTVTm4q2XK1oaABrJKi364skXToyBVDttzgp1qFNLJB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.375105431667993e+22
+    },
+    {
+        "timestamp": "2023-07-30T00:27:59.991Z",
+        "balance": 3.519140765714084e+26,
+        "block_height": 97645895,
+        "epoch_id": "6tBSLkmvnVZDLh5U3kgbjXRQmgvXz3DhVL1k39FtvK6U",
+        "next_epoch_id": "9JrnFmZrMmTMSaxk63NCJSxr8caVZPmKdCuFoLcPPRRm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.565710566811519e+22
+    },
+    {
+        "timestamp": "2023-07-29T11:03:28.657Z",
+        "balance": 3.518684194657403e+26,
+        "block_height": 97602695,
+        "epoch_id": "7appb59vhAmdn7qNdnYjkZyHcAEQgNs15UCbc2yk3E2V",
+        "next_epoch_id": "6tBSLkmvnVZDLh5U3kgbjXRQmgvXz3DhVL1k39FtvK6U",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.645769808465771e+22
+    },
+    {
+        "timestamp": "2023-07-28T18:51:39.571Z",
+        "balance": 3.518219617676556e+26,
+        "block_height": 97550364,
+        "epoch_id": "9MxJA9FxdnJAuksShU87omdfRBRVSrTKeHiVrXYkCQkB",
+        "next_epoch_id": "7appb59vhAmdn7qNdnYjkZyHcAEQgNs15UCbc2yk3E2V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.620349081592727e+22
+    },
+    {
+        "timestamp": "2023-07-28T08:13:22.367Z",
+        "balance": 3.517757582768397e+26,
+        "block_height": 97516295,
+        "epoch_id": "9K1wjQFnxQGxgwg4io48CzegFTvJRaVd76oNX28X8yug",
+        "next_epoch_id": "9MxJA9FxdnJAuksShU87omdfRBRVSrTKeHiVrXYkCQkB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.658622467532627e+22
+    },
+    {
+        "timestamp": "2023-07-27T18:51:16.454Z",
+        "balance": 3.5172917205216436e+26,
+        "block_height": 97473095,
+        "epoch_id": "12t1en4ptFywv3criNhG3ARvtEWrWNudJqccRUU7sK5L",
+        "next_epoch_id": "9K1wjQFnxQGxgwg4io48CzegFTvJRaVd76oNX28X8yug",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.654040763670717e+22
+    },
+    {
+        "timestamp": "2023-07-27T05:23:18.464Z",
+        "balance": 3.5168263164452765e+26,
+        "block_height": 97429895,
+        "epoch_id": "5Zr4JP7Gky6ie7NyGJPtMHsHPKJK8JjYfyPJDiFaEJP",
+        "next_epoch_id": "12t1en4ptFywv3criNhG3ARvtEWrWNudJqccRUU7sK5L",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.760515925495439e+22
+    },
+    {
+        "timestamp": "2023-07-26T15:53:21.849Z",
+        "balance": 3.516350264852727e+26,
+        "block_height": 97386695,
+        "epoch_id": "FgPi74FdgS4swH5PVbe1ripFqYPZ6oFjUR8MREs49VMi",
+        "next_epoch_id": "5Zr4JP7Gky6ie7NyGJPtMHsHPKJK8JjYfyPJDiFaEJP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.676025244007461e+22
+    },
+    {
+        "timestamp": "2023-07-26T02:11:45.170Z",
+        "balance": 3.515882662328326e+26,
+        "block_height": 97343495,
+        "epoch_id": "22rUR8e8nHNGioWtJkhG4bT4ZEpmX5reYPKbuhwVTWC3",
+        "next_epoch_id": "FgPi74FdgS4swH5PVbe1ripFqYPZ6oFjUR8MREs49VMi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.640388582979564e+22
+    },
+    {
+        "timestamp": "2023-07-25T12:44:27.242Z",
+        "balance": 3.515418623470028e+26,
+        "block_height": 97300295,
+        "epoch_id": "7k6PBNQ3A9e127Ms9eoeihGqyx5C2fzqKFwM7MM2KvxA",
+        "next_epoch_id": "22rUR8e8nHNGioWtJkhG4bT4ZEpmX5reYPKbuhwVTWC3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6660613315653825e+22
+    },
+    {
+        "timestamp": "2023-07-24T23:22:29.730Z",
+        "balance": 3.514952017336872e+26,
+        "block_height": 97257095,
+        "epoch_id": "DnwDhLXtAWZqCDbHxAggtbW42j1iVHU77E29tcNhAMS7",
+        "next_epoch_id": "7k6PBNQ3A9e127Ms9eoeihGqyx5C2fzqKFwM7MM2KvxA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.647691165906439e+22
+    },
+    {
+        "timestamp": "2023-07-24T09:56:30.359Z",
+        "balance": 3.514487248220281e+26,
+        "block_height": 97213895,
+        "epoch_id": "AwAEE7VvXtRVMjisivVJmdhuqmbNbL45d9gR3nY9PNRd",
+        "next_epoch_id": "DnwDhLXtAWZqCDbHxAggtbW42j1iVHU77E29tcNhAMS7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.689047564370529e+22
+    },
+    {
+        "timestamp": "2023-07-23T20:34:06.583Z",
+        "balance": 3.514018343463844e+26,
+        "block_height": 97170695,
+        "epoch_id": "HjmGaEGNocC641htyJgJqnnbfo5V1dvgybH5ayko9whU",
+        "next_epoch_id": "AwAEE7VvXtRVMjisivVJmdhuqmbNbL45d9gR3nY9PNRd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.706448840259381e+22
+    },
+    {
+        "timestamp": "2023-07-23T07:05:09.977Z",
+        "balance": 3.513547698579818e+26,
+        "block_height": 97127495,
+        "epoch_id": "8czQ2o1aSHVtftHUHhnwwj3a5vX8ERzemS2AyeAhE4fT",
+        "next_epoch_id": "HjmGaEGNocC641htyJgJqnnbfo5V1dvgybH5ayko9whU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.7085364428205055e+22
+    },
+    {
+        "timestamp": "2023-07-22T10:18:14.827Z",
+        "balance": 3.513076844935536e+26,
+        "block_height": 97061369,
+        "epoch_id": "u1vhZ44ybxbf8TvS9oE4HZnq8Yh74R42VKSBW4o54eA",
+        "next_epoch_id": "8czQ2o1aSHVtftHUHhnwwj3a5vX8ERzemS2AyeAhE4fT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6636260218110405e+22
+    },
+    {
+        "timestamp": "2023-07-22T03:58:53.420Z",
+        "balance": 3.512610482333355e+26,
+        "block_height": 97041095,
+        "epoch_id": "8fsjJpuszoY3ArfhGvbpJPEj6VV9QfRY29Y7dagGZKmZ",
+        "next_epoch_id": "u1vhZ44ybxbf8TvS9oE4HZnq8Yh74R42VKSBW4o54eA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6292433427101706e+22
+    },
+    {
+        "timestamp": "2023-07-21T14:32:39.994Z",
+        "balance": 3.512147557999084e+26,
+        "block_height": 96997895,
+        "epoch_id": "HN1pppK3yMNXTYQ1cdQMPftTPsrGLutKsn5P1Ho4b5vt",
+        "next_epoch_id": "8fsjJpuszoY3ArfhGvbpJPEj6VV9QfRY29Y7dagGZKmZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.673280197848717e+22
+    },
+    {
+        "timestamp": "2023-07-21T01:11:11.050Z",
+        "balance": 3.511680229979299e+26,
+        "block_height": 96954695,
+        "epoch_id": "J9LdeJd22Sccxf8uSV15EPSB3MsrpToW4dMRHP7sYGhU",
+        "next_epoch_id": "HN1pppK3yMNXTYQ1cdQMPftTPsrGLutKsn5P1Ho4b5vt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.660993900945923e+22
+    },
+    {
+        "timestamp": "2023-07-20T11:23:27.511Z",
+        "balance": 3.5112141305892044e+26,
+        "block_height": 96910487,
+        "epoch_id": "C34mTetDSGWXiDkDfd6nEf6zH3Q2rQMnzowvVrx2ZbjB",
+        "next_epoch_id": "J9LdeJd22Sccxf8uSV15EPSB3MsrpToW4dMRHP7sYGhU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.712827978987392e+22
+    },
+    {
+        "timestamp": "2023-07-19T22:16:02.336Z",
+        "balance": 3.510742847791306e+26,
+        "block_height": 96868295,
+        "epoch_id": "6ZU5JMm1cwsTmDQSD1gNxiMXQgJuct3gbVMMjXg2HdLp",
+        "next_epoch_id": "C34mTetDSGWXiDkDfd6nEf6zH3Q2rQMnzowvVrx2ZbjB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.647348969788481e+22
+    },
+    {
+        "timestamp": "2023-07-19T08:41:24.244Z",
+        "balance": 3.510278112894327e+26,
+        "block_height": 96825095,
+        "epoch_id": "E9aR677vWBmjVch7rY95oVQbHAf6eatwEPktzD77pLGW",
+        "next_epoch_id": "6ZU5JMm1cwsTmDQSD1gNxiMXQgJuct3gbVMMjXg2HdLp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.684532399255224e+22
+    },
+    {
+        "timestamp": "2023-07-18T19:19:04.152Z",
+        "balance": 3.509809659654401e+26,
+        "block_height": 96781895,
+        "epoch_id": "ARM7YfXgAgdernetnWtHscu8Nw19spSEAWARSFAjCwxm",
+        "next_epoch_id": "E9aR677vWBmjVch7rY95oVQbHAf6eatwEPktzD77pLGW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.757868808542414e+22
+    },
+    {
+        "timestamp": "2023-07-18T05:09:08.232Z",
+        "balance": 3.509333872773547e+26,
+        "block_height": 96736455,
+        "epoch_id": "4q2ipMr4nQQfexmEzdinhjRE92SKSsFTYwAm5cDUKNDY",
+        "next_epoch_id": "ARM7YfXgAgdernetnWtHscu8Nw19spSEAWARSFAjCwxm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.770677982487892e+22
+    },
+    {
+        "timestamp": "2023-07-17T16:09:42.390Z",
+        "balance": 3.508856804975298e+26,
+        "block_height": 96695495,
+        "epoch_id": "7p1S4pYHKStuGeRDsH58AstgC1nuBoR58uJmwE4khS5N",
+        "next_epoch_id": "4q2ipMr4nQQfexmEzdinhjRE92SKSsFTYwAm5cDUKNDY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.652058043929211e+22
+    },
+    {
+        "timestamp": "2023-07-16T15:50:52.405Z",
+        "balance": 3.5083915991709054e+26,
+        "block_height": 96618048,
+        "epoch_id": "FV1doHy8zZv2znLYSdw1YDyeQPsyGqA1FmE3XkG2Th1n",
+        "next_epoch_id": "7p1S4pYHKStuGeRDsH58AstgC1nuBoR58uJmwE4khS5N",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.64608353266828e+22
+    },
+    {
+        "timestamp": "2023-07-16T13:03:02.608Z",
+        "balance": 3.5079269908176386e+26,
+        "block_height": 96609095,
+        "epoch_id": "6Tiwj36A5PQjibqG1vykEEzHa6ATG6qd5MhAGpG53g7j",
+        "next_epoch_id": "FV1doHy8zZv2znLYSdw1YDyeQPsyGqA1FmE3XkG2Th1n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.666511896964995e+22
+    },
+    {
+        "timestamp": "2023-07-15T23:39:58.636Z",
+        "balance": 3.507460339627942e+26,
+        "block_height": 96565895,
+        "epoch_id": "2rvJXida3G6LQ1uB3zubN1XavoHEGe3Hhwyzx8yySskf",
+        "next_epoch_id": "6Tiwj36A5PQjibqG1vykEEzHa6ATG6qd5MhAGpG53g7j",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.667100161400684e+22
+    },
+    {
+        "timestamp": "2023-07-15T06:38:30.141Z",
+        "balance": 3.506993629611802e+26,
+        "block_height": 96511157,
+        "epoch_id": "F1aJs24CqYA1fu2NJs3xeLa4zmDe5BYWJ8YURPa2AnRD",
+        "next_epoch_id": "2rvJXida3G6LQ1uB3zubN1XavoHEGe3Hhwyzx8yySskf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.667056689665859e+22
+    },
+    {
+        "timestamp": "2023-07-14T20:47:09.648Z",
+        "balance": 3.5065269239428354e+26,
+        "block_height": 96479495,
+        "epoch_id": "6gxVz7mV7SxughMjh7VQ5tqxTYWh1fHpVEZ7mt3t313X",
+        "next_epoch_id": "F1aJs24CqYA1fu2NJs3xeLa4zmDe5BYWJ8YURPa2AnRD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.646470328778047e+22
+    },
+    {
+        "timestamp": "2023-07-14T07:20:31.125Z",
+        "balance": 3.5060622769099576e+26,
+        "block_height": 96436295,
+        "epoch_id": "FQDnstBdj7WoJxhof3jYAdXEtSR5F6xhasV9BSAbNiHV",
+        "next_epoch_id": "6gxVz7mV7SxughMjh7VQ5tqxTYWh1fHpVEZ7mt3t313X",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6690891005778154e+22
+    },
+    {
+        "timestamp": "2023-07-13T17:15:50.639Z",
+        "balance": 3.5055953679999e+26,
+        "block_height": 96390912,
+        "epoch_id": "AnFNPP1FPyuGZHQjk5hfTEBhzDRcoJN6noEJ4s8tgX9x",
+        "next_epoch_id": "FQDnstBdj7WoJxhof3jYAdXEtSR5F6xhasV9BSAbNiHV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.686475517364164e+22
+    },
+    {
+        "timestamp": "2023-07-13T04:27:41.995Z",
+        "balance": 3.5051267204481634e+26,
+        "block_height": 96349895,
+        "epoch_id": "AcRbTn754y4GFXAK7whdisM5CdZKhD167XryG35u1JA2",
+        "next_epoch_id": "AnFNPP1FPyuGZHQjk5hfTEBhzDRcoJN6noEJ4s8tgX9x",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.647239420229198e+22
+    },
+    {
+        "timestamp": "2023-07-12T12:09:08.316Z",
+        "balance": 3.5046619965061405e+26,
+        "block_height": 96297794,
+        "epoch_id": "5ubZ8bcMKfxf73MEdmAECVnwMK4DEraitLBGv51DAXCi",
+        "next_epoch_id": "AcRbTn754y4GFXAK7whdisM5CdZKhD167XryG35u1JA2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.704177981291238e+22
+    },
+    {
+        "timestamp": "2023-07-12T01:34:04.214Z",
+        "balance": 3.5041915787080114e+26,
+        "block_height": 96263495,
+        "epoch_id": "3jv3vJZwj1QRff1zc3bVmsBioF9EvGiGfjiGaLieXD8z",
+        "next_epoch_id": "5ubZ8bcMKfxf73MEdmAECVnwMK4DEraitLBGv51DAXCi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.700922334728121e+22
+    },
+    {
+        "timestamp": "2023-07-11T11:57:19.696Z",
+        "balance": 3.5037214864745385e+26,
+        "block_height": 96220295,
+        "epoch_id": "9iTVrcwp9ozw3aqoZef48tSV1EehCopP6vvyTeeaQQp9",
+        "next_epoch_id": "3jv3vJZwj1QRff1zc3bVmsBioF9EvGiGfjiGaLieXD8z",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6691774843870815e+22
+    },
+    {
+        "timestamp": "2023-07-10T22:20:42.384Z",
+        "balance": 3.5032545687261e+26,
+        "block_height": 96177095,
+        "epoch_id": "D2eU4ZhJcCtK3N6jGhUcj6ARQWRKuPdg46iaj4ZV4MyN",
+        "next_epoch_id": "9iTVrcwp9ozw3aqoZef48tSV1EehCopP6vvyTeeaQQp9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.6284862168386205e+22
+    },
+    {
+        "timestamp": "2023-07-10T08:50:04.800Z",
+        "balance": 3.502791720104416e+26,
+        "block_height": 96133895,
+        "epoch_id": "A4HFnMw2ckQ3X9A98Rrga4hP8CzqTg4DtiYzUFyCTVYx",
+        "next_epoch_id": "D2eU4ZhJcCtK3N6jGhUcj6ARQWRKuPdg46iaj4ZV4MyN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.667303657727698e+22
+    },
+    {
+        "timestamp": "2023-07-09T19:26:37.795Z",
+        "balance": 3.502324989738643e+26,
+        "block_height": 96090695,
+        "epoch_id": "4Y3tfnoNyZpTRvvAxQ51AjjJ9C85pWbb2mcAnLjte1cf",
+        "next_epoch_id": "A4HFnMw2ckQ3X9A98Rrga4hP8CzqTg4DtiYzUFyCTVYx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.725271012750194e+22
+    },
+    {
+        "timestamp": "2023-07-08T17:59:27.679Z",
+        "balance": 3.501852462637368e+26,
+        "block_height": 96009929,
+        "epoch_id": "G8S1ivZEzEwZwkPD6ZasHAomrpjHz6uiM4RWn9mSCMSQ",
+        "next_epoch_id": "4Y3tfnoNyZpTRvvAxQ51AjjJ9C85pWbb2mcAnLjte1cf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.631991180439602e+22
+    },
+    {
+        "timestamp": "2023-07-08T16:14:46.128Z",
+        "balance": 3.501389263519324e+26,
+        "block_height": 96004295,
+        "epoch_id": "4sLyVWca5HCv77daRmwGL9pNTRm8ZCSfr2HhFev4kaY2",
+        "next_epoch_id": "G8S1ivZEzEwZwkPD6ZasHAomrpjHz6uiM4RWn9mSCMSQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.61856675559694e+22
+    },
+    {
+        "timestamp": "2023-07-08T02:51:01.912Z",
+        "balance": 3.5009274068437645e+26,
+        "block_height": 95961095,
+        "epoch_id": "2z5shiFjhpUHKUgE79J3qxgyQrTZHwQVSJJ4wMvetq6i",
+        "next_epoch_id": "4sLyVWca5HCv77daRmwGL9pNTRm8ZCSfr2HhFev4kaY2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.628546613287212e+22
+    },
+    {
+        "timestamp": "2023-07-07T05:09:31.436Z",
+        "balance": 3.500464552182436e+26,
+        "block_height": 95891100,
+        "epoch_id": "jRZdRPTSGuVvesj4TEMcd6bUEp8BK5eU8BS5Jtx1rPv",
+        "next_epoch_id": "2z5shiFjhpUHKUgE79J3qxgyQrTZHwQVSJJ4wMvetq6i",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4.64552182435898e+22
+    },
+    {
+        "timestamp": "2023-07-07T00:06:29.458Z",
+        "balance": 3.5e+26,
+        "block_height": 95874695,
+        "epoch_id": "2bWW8xbB5Tcs4WNZUkyP2ep27T2nzAr8mTKzKX4WEc3a",
+        "next_epoch_id": "jRZdRPTSGuVvesj4TEMcd6bUEp8BK5eU8BS5Jtx1rPv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-07-06T18:36:31.697Z",
+        "balance": 3.5e+26,
+        "hash": "Af2ZfAHULc4Eh3KpctLtLARViaqo2c7aXgo5okkLJ7pz",
+        "block_height": 95857053,
+        "epoch_id": "2bWW8xbB5Tcs4WNZUkyP2ep27T2nzAr8mTKzKX4WEc3a",
+        "next_epoch_id": "jRZdRPTSGuVvesj4TEMcd6bUEp8BK5eU8BS5Jtx1rPv",
+        "deposit": 3.5e+26,
+        "withdrawal": 0,
+        "earnings": 0
+    }
+];

--- a/testdata/stakingbalances.js
+++ b/testdata/stakingbalances.js
@@ -1,0 +1,12819 @@
+export const stakingBalances = [
+    {
+        "timestamp": "2023-11-25T12:15:49.970Z",
+        "balance": 0,
+        "block_height": 106501900,
+        "epoch_id": "6QCNJVPJtiUavJEPYTggu1iQPgGi4NKjy1hju2q99Lz7",
+        "next_epoch_id": "t7zFW1ZnfsY8k679tQQLZSJnJBwBku3qyZcPR9uueT2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-24T22:58:59.912Z",
+        "balance": 0,
+        "block_height": 106458700,
+        "epoch_id": "8ARPVha27PijfbG6vfNPgmQJQbbL5ekZCcqBdSchzvXC",
+        "next_epoch_id": "6QCNJVPJtiUavJEPYTggu1iQPgGi4NKjy1hju2q99Lz7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-24T05:54:51.286Z",
+        "balance": 0,
+        "block_height": 106407908,
+        "epoch_id": "CNfk2TrXTM2cfoAYvstUCtQ8L7JgxPNYFiDeASv7rXEC",
+        "next_epoch_id": "8ARPVha27PijfbG6vfNPgmQJQbbL5ekZCcqBdSchzvXC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-24T05:54:51.286Z",
+        "balance": 0,
+        "hash": "Gu7kjCsPaoYQUdQpvxHm6L2LvStZ6go7AGFypQWpNCJx",
+        "block_height": 106407908,
+        "epoch_id": "CNfk2TrXTM2cfoAYvstUCtQ8L7JgxPNYFiDeASv7rXEC",
+        "next_epoch_id": "8ARPVha27PijfbG6vfNPgmQJQbbL5ekZCcqBdSchzvXC",
+        "deposit": 0,
+        "withdrawal": 1.0778187612137944e+26,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-23T17:58:42.124Z",
+        "balance": 1.0778187612137944e+26,
+        "block_height": 106372300,
+        "epoch_id": "6EpTKT9iMwqS8o3vwH4uSsisvxgrd89hW6HCfVid7GU6",
+        "next_epoch_id": "CNfk2TrXTM2cfoAYvstUCtQ8L7JgxPNYFiDeASv7rXEC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-23T05:09:30.127Z",
+        "balance": 1.0778187612137944e+26,
+        "block_height": 106329100,
+        "epoch_id": "Cag1V1AymLWjjqNRGcjnHkio4rmgitsPMF7UcCkVzcYs",
+        "next_epoch_id": "6EpTKT9iMwqS8o3vwH4uSsisvxgrd89hW6HCfVid7GU6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-22T16:03:44.507Z",
+        "balance": 1.0778187612137944e+26,
+        "block_height": 106285900,
+        "epoch_id": "3TyBh46psna1KTkLdY4sLH57FX4SqT3L5AjdsVxVPRmL",
+        "next_epoch_id": "Cag1V1AymLWjjqNRGcjnHkio4rmgitsPMF7UcCkVzcYs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-22T01:13:25.371Z",
+        "balance": 1.0778187612137944e+26,
+        "block_height": 106242700,
+        "epoch_id": "DEEZnDyJdnf26Rjp16ij5673cY6bojqPcGhkdtqErjRW",
+        "next_epoch_id": "3TyBh46psna1KTkLdY4sLH57FX4SqT3L5AjdsVxVPRmL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-21T10:42:37.492Z",
+        "balance": 1.0778187612137944e+26,
+        "block_height": 106199500,
+        "epoch_id": "DBtAnhiYSFLYVDS86nZrQor6dc2Z5k71cHHztZFCDnf6",
+        "next_epoch_id": "DEEZnDyJdnf26Rjp16ij5673cY6bojqPcGhkdtqErjRW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-20T17:28:27.576Z",
+        "balance": 1.0778187612137944e+26,
+        "hash": "8b3CKnA6y7PKHr4TFz6X4ntJ4PHWtQTHpkdtzqkbHL4e",
+        "block_height": 106142571,
+        "epoch_id": "BQXByRZm7w5cq3n8voDajWFNEcbLgUKeaGYjWGzE2wzZ",
+        "next_epoch_id": "DBtAnhiYSFLYVDS86nZrQor6dc2Z5k71cHHztZFCDnf6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2023-11-20T16:30:44.123Z",
+        "balance": 1.0778187612137944e+26,
+        "block_height": 106139442,
+        "epoch_id": "BQXByRZm7w5cq3n8voDajWFNEcbLgUKeaGYjWGzE2wzZ",
+        "next_epoch_id": "DBtAnhiYSFLYVDS86nZrQor6dc2Z5k71cHHztZFCDnf6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 36780931691839490
+    },
+    {
+        "timestamp": "2023-11-19T19:43:48.813Z",
+        "balance": 1.077818760845985e+26,
+        "block_height": 106075147,
+        "epoch_id": "DL9yH2EfnixQ2NvYoyp6GFdzc6V6XNFD5QkFYuhoc5g1",
+        "next_epoch_id": "BQXByRZm7w5cq3n8voDajWFNEcbLgUKeaGYjWGzE2wzZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4981990264668160
+    },
+    {
+        "timestamp": "2023-11-19T16:21:58.244Z",
+        "balance": 1.0778187607961652e+26,
+        "block_height": 106065027,
+        "epoch_id": "5rpyJpGTc5rxdEm6ywrNb56tXqACom8ERoucWMQARCcZ",
+        "next_epoch_id": "DL9yH2EfnixQ2NvYoyp6GFdzc6V6XNFD5QkFYuhoc5g1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5181637524455424
+    },
+    {
+        "timestamp": "2023-11-19T03:22:39.890Z",
+        "balance": 1.0778187607443488e+26,
+        "block_height": 106026697,
+        "epoch_id": "D8Bmtk9fFDWaiZ8s3c28LYtUHmnJYmUCeYjpAGDsE3gc",
+        "next_epoch_id": "5rpyJpGTc5rxdEm6ywrNb56tXqACom8ERoucWMQARCcZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 11552517133434880
+    },
+    {
+        "timestamp": "2023-11-18T14:46:06.634Z",
+        "balance": 1.0778187606288236e+26,
+        "block_height": 105983497,
+        "epoch_id": "7aUiMKBFZ5Y9zJGUoPsNAGeAgmkiiT5MnTZGE3ySNLqv",
+        "next_epoch_id": "D8Bmtk9fFDWaiZ8s3c28LYtUHmnJYmUCeYjpAGDsE3gc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 16356833191002112
+    },
+    {
+        "timestamp": "2023-11-18T01:35:32.212Z",
+        "balance": 1.0778187604652553e+26,
+        "block_height": 105940297,
+        "epoch_id": "AL9jSgQZGhYkmYuye1pXQcMX5Y6HQy5hNtsKc5mtA78F",
+        "next_epoch_id": "7aUiMKBFZ5Y9zJGUoPsNAGeAgmkiiT5MnTZGE3ySNLqv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 33064513670479870
+    },
+    {
+        "timestamp": "2023-11-17T11:06:33.466Z",
+        "balance": 1.0778187601346101e+26,
+        "block_height": 105897097,
+        "epoch_id": "2pdf19UuwaxmP6qShhiRPYSV26gLUzvXKGTEgh6CAAuC",
+        "next_epoch_id": "AL9jSgQZGhYkmYuye1pXQcMX5Y6HQy5hNtsKc5mtA78F",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5162104013193216
+    },
+    {
+        "timestamp": "2023-11-16T20:27:00.131Z",
+        "balance": 1.0778187600829891e+26,
+        "block_height": 105853897,
+        "epoch_id": "7e2y3KW9Q8w9nZsXJFimCPP6ozxpnKWMdpwVYctD8V1v",
+        "next_epoch_id": "2pdf19UuwaxmP6qShhiRPYSV26gLUzvXKGTEgh6CAAuC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 11316551630192640
+    },
+    {
+        "timestamp": "2023-11-16T07:46:57.733Z",
+        "balance": 1.0778187599698236e+26,
+        "block_height": 105810697,
+        "epoch_id": "8dWFyMuDpEmiRtSF9npKNCMXEFkYCVuHGezXcNoyTLbU",
+        "next_epoch_id": "7e2y3KW9Q8w9nZsXJFimCPP6ozxpnKWMdpwVYctD8V1v",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 12472069631508480
+    },
+    {
+        "timestamp": "2023-11-15T18:32:35.745Z",
+        "balance": 1.0778187598451029e+26,
+        "block_height": 105767497,
+        "epoch_id": "3pvKP5AGddAHbwKFu6dRPjXiCpyGiryy3gkXkh4tYWoM",
+        "next_epoch_id": "8dWFyMuDpEmiRtSF9npKNCMXEFkYCVuHGezXcNoyTLbU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5159028816609280
+    },
+    {
+        "timestamp": "2023-11-15T02:34:40.072Z",
+        "balance": 1.0778187597935126e+26,
+        "block_height": 105724297,
+        "epoch_id": "7Kkssrfx5qmMzVTwRAqku8ViLSHbQ4AiC7LJP5EevbCc",
+        "next_epoch_id": "3pvKP5AGddAHbwKFu6dRPjXiCpyGiryy3gkXkh4tYWoM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5161949394370560
+    },
+    {
+        "timestamp": "2023-11-14T10:32:20.603Z",
+        "balance": 1.0778187597418931e+26,
+        "block_height": 105681096,
+        "epoch_id": "3gLGXbixzJGGQ61u9hKtFibzn1S8m7EpPni7KkyGo4Wy",
+        "next_epoch_id": "7Kkssrfx5qmMzVTwRAqku8ViLSHbQ4AiC7LJP5EevbCc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 13663957415886848
+    },
+    {
+        "timestamp": "2023-11-13T21:05:17.873Z",
+        "balance": 1.0778187596052535e+26,
+        "block_height": 105637896,
+        "epoch_id": "HFok8JunhFcEB2QFg3qYQJnt5FMeTFWt3LvB5s8hZuGE",
+        "next_epoch_id": "3gLGXbixzJGGQ61u9hKtFibzn1S8m7EpPni7KkyGo4Wy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5157276469952512
+    },
+    {
+        "timestamp": "2023-11-12T20:32:28.265Z",
+        "balance": 1.0778187595536808e+26,
+        "block_height": 105557810,
+        "epoch_id": "87ZHPhhGgmrSjbvFW9Nh1hwFGEuRqSu5VMmDV5CZBYCo",
+        "next_epoch_id": "HFok8JunhFcEB2QFg3qYQJnt5FMeTFWt3LvB5s8hZuGE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5003997677092864
+    },
+    {
+        "timestamp": "2023-11-12T18:40:46.642Z",
+        "balance": 1.0778187595036408e+26,
+        "block_height": 105551496,
+        "epoch_id": "2oYakRFtr3oh9A22xcG8GM25YM1BisdmucVJfNYG948E",
+        "next_epoch_id": "87ZHPhhGgmrSjbvFW9Nh1hwFGEuRqSu5VMmDV5CZBYCo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5004324094607360
+    },
+    {
+        "timestamp": "2023-11-12T05:36:25.989Z",
+        "balance": 1.0778187594535976e+26,
+        "block_height": 105508296,
+        "epoch_id": "C7TyM1BnvNngfeTyy6tw94auVpBnLJnFu6Y2U6pD7294",
+        "next_epoch_id": "2oYakRFtr3oh9A22xcG8GM25YM1BisdmucVJfNYG948E",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5544149944107008
+    },
+    {
+        "timestamp": "2023-11-11T16:25:48.695Z",
+        "balance": 1.077818759398156e+26,
+        "block_height": 105465096,
+        "epoch_id": "4ahdM9aD16Z2S4xm1Ny3548mZhstta5QrFuLEiFPuw53",
+        "next_epoch_id": "C7TyM1BnvNngfeTyy6tw94auVpBnLJnFu6Y2U6pD7294",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 13661088377733120
+    },
+    {
+        "timestamp": "2023-11-11T03:16:34.935Z",
+        "balance": 1.0778187592615452e+26,
+        "block_height": 105421896,
+        "epoch_id": "8hJSZNNyimPvsCA1v3dMr3Hg5ucYeLUbTvEfhr6jaWJy",
+        "next_epoch_id": "4ahdM9aD16Z2S4xm1Ny3548mZhstta5QrFuLEiFPuw53",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4849877070643200
+    },
+    {
+        "timestamp": "2023-11-10T14:19:40.419Z",
+        "balance": 1.0778187592130464e+26,
+        "block_height": 105378696,
+        "epoch_id": "7TgyeAcsejxyrk8jbL4rWBmvP9wy9DJGBq3T6VtriS2T",
+        "next_epoch_id": "8hJSZNNyimPvsCA1v3dMr3Hg5ucYeLUbTvEfhr6jaWJy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5002537388212224
+    },
+    {
+        "timestamp": "2023-11-10T01:11:26.065Z",
+        "balance": 1.077818759163021e+26,
+        "block_height": 105335496,
+        "epoch_id": "1461rFj48Zx93F9JaXkEfycu54Szh4QB1NME7ZEu4FiY",
+        "next_epoch_id": "7TgyeAcsejxyrk8jbL4rWBmvP9wy9DJGBq3T6VtriS2T",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5015044332978176
+    },
+    {
+        "timestamp": "2023-11-09T12:00:41.968Z",
+        "balance": 1.0778187591128706e+26,
+        "block_height": 105292296,
+        "epoch_id": "6s9JXdqZ56FXAjvcBpUrGCFxoGYTzXKoGi59DPwZqBa7",
+        "next_epoch_id": "1461rFj48Zx93F9JaXkEfycu54Szh4QB1NME7ZEu4FiY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 31305673023160320
+    },
+    {
+        "timestamp": "2023-11-08T21:37:35.379Z",
+        "balance": 1.0778187587998139e+26,
+        "block_height": 105249096,
+        "epoch_id": "CuPwC1hpNBwsDSVVjH5ZAAcxWcCVKnyRjecnWSPDWkm3",
+        "next_epoch_id": "6s9JXdqZ56FXAjvcBpUrGCFxoGYTzXKoGi59DPwZqBa7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5154596410359808
+    },
+    {
+        "timestamp": "2023-11-08T07:37:00.574Z",
+        "balance": 1.0778187587482679e+26,
+        "block_height": 105205896,
+        "epoch_id": "DBJP3NfLyr2rnkk8WrdBSVJ6ZDCM72yn7dZf9DkvQbp9",
+        "next_epoch_id": "CuPwC1hpNBwsDSVVjH5ZAAcxWcCVKnyRjecnWSPDWkm3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4848502681108480
+    },
+    {
+        "timestamp": "2023-11-07T17:40:46.139Z",
+        "balance": 1.0778187586997829e+26,
+        "block_height": 105162696,
+        "epoch_id": "4zxZWEBLmXb5PubNS88DDSmBF4Xmvn3UP3mBjPfFoxj1",
+        "next_epoch_id": "DBJP3NfLyr2rnkk8WrdBSVJ6ZDCM72yn7dZf9DkvQbp9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 5004392814084096
+    },
+    {
+        "timestamp": "2023-11-07T03:35:04.706Z",
+        "balance": 1.077818758649739e+26,
+        "block_height": 105119496,
+        "epoch_id": "AButo2XNSBqvBfRjWkxp63XjUaPDiqqgN6SAYvbGV6b9",
+        "next_epoch_id": "4zxZWEBLmXb5PubNS88DDSmBF4Xmvn3UP3mBjPfFoxj1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 16834622532878336
+    },
+    {
+        "timestamp": "2023-11-06T13:57:44.324Z",
+        "balance": 1.0778187584813927e+26,
+        "block_height": 105076296,
+        "epoch_id": "FXcvd7hqftFEeej5rw6KbM2MwvtoCY8kPDfZutWzG1kL",
+        "next_epoch_id": "AButo2XNSBqvBfRjWkxp63XjUaPDiqqgN6SAYvbGV6b9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 11846877012033536
+    },
+    {
+        "timestamp": "2023-11-06T00:15:06.793Z",
+        "balance": 1.077818758362924e+26,
+        "block_height": 105033096,
+        "epoch_id": "3PwKJ5H89tNzEJ5RHdajdDGDzj3Qj1foLdBXLAkjFc2T",
+        "next_epoch_id": "FXcvd7hqftFEeej5rw6KbM2MwvtoCY8kPDfZutWzG1kL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 8653826525495296
+    },
+    {
+        "timestamp": "2023-11-05T08:09:09.077Z",
+        "balance": 1.0778187582763857e+26,
+        "block_height": 104979960,
+        "epoch_id": "FYkqPPMP75p5eQo2iEqD4d8TJ2P6EoLZESSNFXpNSSVk",
+        "next_epoch_id": "3PwKJ5H89tNzEJ5RHdajdDGDzj3Qj1foLdBXLAkjFc2T",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 11723302212993024
+    },
+    {
+        "timestamp": "2023-11-04T21:42:59.045Z",
+        "balance": 1.0778187581591527e+26,
+        "block_height": 104946696,
+        "epoch_id": "HRqzbo6Vk1Gk7QrJXcFWrN53G9gmLyr3xWtQoJECiwjx",
+        "next_epoch_id": "FYkqPPMP75p5eQo2iEqD4d8TJ2P6EoLZESSNFXpNSSVk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 34712492621955070
+    },
+    {
+        "timestamp": "2023-11-04T08:30:29.786Z",
+        "balance": 1.0778187578120277e+26,
+        "block_height": 104903496,
+        "epoch_id": "AK9TTCRBKPce883gQUhTe85FiYJiWRid7hCUV1y63nmK",
+        "next_epoch_id": "HRqzbo6Vk1Gk7QrJXcFWrN53G9gmLyr3xWtQoJECiwjx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 25841838967488510
+    },
+    {
+        "timestamp": "2023-11-03T18:58:31.558Z",
+        "balance": 1.0778187575536093e+26,
+        "block_height": 104860296,
+        "epoch_id": "6N1sa42FvJBQ5QTjBJUqHAg2KEWdiCKnYrHvkPSjoKGt",
+        "next_epoch_id": "AK9TTCRBKPce883gQUhTe85FiYJiWRid7hCUV1y63nmK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4999719889666048
+    },
+    {
+        "timestamp": "2023-11-02T17:34:27.536Z",
+        "balance": 1.0778187575036121e+26,
+        "block_height": 104779030,
+        "epoch_id": "9YYE8S5xH46MxpcWbVwSHDDqHLtPh4Rk4nBbRrGBwWw9",
+        "next_epoch_id": "6N1sa42FvJBQ5QTjBJUqHAg2KEWdiCKnYrHvkPSjoKGt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4859068300656640
+    },
+    {
+        "timestamp": "2023-11-02T15:58:15.253Z",
+        "balance": 1.0778187574550215e+26,
+        "block_height": 104773896,
+        "epoch_id": "5YLKhTMoJAPce1azgwaQH8dPp2LrPhtutQBwFQwspZ3V",
+        "next_epoch_id": "9YYE8S5xH46MxpcWbVwSHDDqHLtPh4Rk4nBbRrGBwWw9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 35477495016849410
+    },
+    {
+        "timestamp": "2023-11-02T02:13:12.815Z",
+        "balance": 1.0778187571002465e+26,
+        "block_height": 104730696,
+        "epoch_id": "9WjQAeq9F9GhPp1AfukVFTeCnDaKPCQt12Vki6cPyCdt",
+        "next_epoch_id": "5YLKhTMoJAPce1azgwaQH8dPp2LrPhtutQBwFQwspZ3V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 16866662988906496
+    },
+    {
+        "timestamp": "2023-11-01T12:48:32.118Z",
+        "balance": 1.0778187569315799e+26,
+        "block_height": 104687496,
+        "epoch_id": "EYtCdswhj7dCkWGgEuvN3Zps1DqYnV9u1PUsZD6hPo9Y",
+        "next_epoch_id": "9WjQAeq9F9GhPp1AfukVFTeCnDaKPCQt12Vki6cPyCdt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 26990536560738304
+    },
+    {
+        "timestamp": "2023-10-31T22:53:34.022Z",
+        "balance": 1.0778187566616745e+26,
+        "block_height": 104644296,
+        "epoch_id": "GCAeNDQ9JdaVTkuuRWVqHKji1q9BYQDzqQ3gNMSY4wpJ",
+        "next_epoch_id": "EYtCdswhj7dCkWGgEuvN3Zps1DqYnV9u1PUsZD6hPo9Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 4661431085563904
+    },
+    {
+        "timestamp": "2023-10-31T08:38:47.474Z",
+        "balance": 1.0778187566150602e+26,
+        "block_height": 104601096,
+        "epoch_id": "5hu1dSnYtxFwFy178ZNoSWqrW6Nn65U2qHRwQtkBmYYM",
+        "next_epoch_id": "GCAeNDQ9JdaVTkuuRWVqHKji1q9BYQDzqQ3gNMSY4wpJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 27513388699484160
+    },
+    {
+        "timestamp": "2023-10-30T19:10:21.747Z",
+        "balance": 1.0778187563399263e+26,
+        "block_height": 104557896,
+        "epoch_id": "3df2DeMZMFa4HM8CCba5pdzw9REef7F2RK84XYg5xgkW",
+        "next_epoch_id": "5hu1dSnYtxFwFy178ZNoSWqrW6Nn65U2qHRwQtkBmYYM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 11177068272287744
+    },
+    {
+        "timestamp": "2023-10-30T05:34:27.534Z",
+        "balance": 1.0778187562281556e+26,
+        "block_height": 104514696,
+        "epoch_id": "8gMRJgFyyKXiaxW6iTGHV9DK1tVNbMsMedLE1ZdspTAX",
+        "next_epoch_id": "3df2DeMZMFa4HM8CCba5pdzw9REef7F2RK84XYg5xgkW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 16693816325046272
+    },
+    {
+        "timestamp": "2023-10-29T15:39:11.332Z",
+        "balance": 1.0778187560612175e+26,
+        "block_height": 104471496,
+        "epoch_id": "J89tuXFznSQBQs4qfNSYPZVWiDkG5vQh5wnPuWVciYK6",
+        "next_epoch_id": "8gMRJgFyyKXiaxW6iTGHV9DK1tVNbMsMedLE1ZdspTAX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 11935817194799104
+    },
+    {
+        "timestamp": "2023-10-29T01:29:28.230Z",
+        "balance": 1.0778187559418593e+26,
+        "block_height": 104428296,
+        "epoch_id": "3Gn451D7KzvNYSiLD4FpptfM1xbCBXMcG8heZ6aWaBdu",
+        "next_epoch_id": "J89tuXFznSQBQs4qfNSYPZVWiDkG5vQh5wnPuWVciYK6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4475808116832408e+22
+    },
+    {
+        "timestamp": "2023-10-28T11:59:38.761Z",
+        "balance": 1.077673997860691e+26,
+        "block_height": 104385095,
+        "epoch_id": "E9ry4bMVKuDgD7itnjb8TFvfw9YUWUvVjnqCnDWwxATv",
+        "next_epoch_id": "3Gn451D7KzvNYSiLD4FpptfM1xbCBXMcG8heZ6aWaBdu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4558038996116763e+22
+    },
+    {
+        "timestamp": "2023-10-27T14:44:46.239Z",
+        "balance": 1.0775284174707298e+26,
+        "block_height": 104321309,
+        "epoch_id": "3as7u1WyEL5NZSwEsnZAo1Cd54P7JB7zYVABTSFbkCp3",
+        "next_epoch_id": "E9ry4bMVKuDgD7itnjb8TFvfw9YUWUvVjnqCnDWwxATv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5277707424200049e+22
+    },
+    {
+        "timestamp": "2023-10-26T19:46:19.382Z",
+        "balance": 1.0773756403964878e+26,
+        "block_height": 104266418,
+        "epoch_id": "H8gzG4Rw6hTuPbqyoUzXLyrC5TJWTB5J7xtx5wXugMFj",
+        "next_epoch_id": "3as7u1WyEL5NZSwEsnZAo1Cd54P7JB7zYVABTSFbkCp3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5469225299769255e+22
+    },
+    {
+        "timestamp": "2023-10-26T16:03:32.477Z",
+        "balance": 1.0772209481434901e+26,
+        "block_height": 104255495,
+        "epoch_id": "EURXgukqgy6v5ZGqhtS7apriERMjKrGEmuF7zH3nAtxV",
+        "next_epoch_id": "H8gzG4Rw6hTuPbqyoUzXLyrC5TJWTB5J7xtx5wXugMFj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4249410955390193e+22
+    },
+    {
+        "timestamp": "2023-10-26T00:36:07.902Z",
+        "balance": 1.0770784540339362e+26,
+        "block_height": 104212295,
+        "epoch_id": "6TXAYsAUfsujXFV6xH8cm1yBTMy3WJEqNrGGuSYvkw96",
+        "next_epoch_id": "EURXgukqgy6v5ZGqhtS7apriERMjKrGEmuF7zH3nAtxV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.698568146090153e+22
+    },
+    {
+        "timestamp": "2023-10-25T10:20:56.918Z",
+        "balance": 1.0768085972193272e+26,
+        "block_height": 104169095,
+        "epoch_id": "tincM7uA6thkQtr5rTRvRkgZDXPDDo4PeTX4QugQjBx",
+        "next_epoch_id": "6TXAYsAUfsujXFV6xH8cm1yBTMy3WJEqNrGGuSYvkw96",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.647923005400125e+22
+    },
+    {
+        "timestamp": "2023-10-24T20:02:21.011Z",
+        "balance": 1.0765438049187872e+26,
+        "block_height": 104125895,
+        "epoch_id": "CbS4oeucYsMNep9hKyZaUWhamsY4JjmHo12YtT21xCt7",
+        "next_epoch_id": "tincM7uA6thkQtr5rTRvRkgZDXPDDo4PeTX4QugQjBx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.462594586248056e+22
+    },
+    {
+        "timestamp": "2023-10-24T05:59:59.378Z",
+        "balance": 1.0763975454601624e+26,
+        "block_height": 104082695,
+        "epoch_id": "5dCFhmP6r8WRSkQTiALZRBkf2jdHFyfGfv3HKJgjHbDS",
+        "next_epoch_id": "CbS4oeucYsMNep9hKyZaUWhamsY4JjmHo12YtT21xCt7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4043546306923834e+22
+    },
+    {
+        "timestamp": "2023-10-23T05:27:06.301Z",
+        "balance": 1.0762571099970931e+26,
+        "block_height": 104009281,
+        "epoch_id": "641dmDs9kztD2xkQfoLbf72HEbGtqk96x2PwDvSpLMXF",
+        "next_epoch_id": "5dCFhmP6r8WRSkQTiALZRBkf2jdHFyfGfv3HKJgjHbDS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3466696167215998e+22
+    },
+    {
+        "timestamp": "2023-10-23T01:16:41.956Z",
+        "balance": 1.076122443035421e+26,
+        "block_height": 103996295,
+        "epoch_id": "4WFawBvVLC4xWuWLGufr1qMkXvgiv3a1GNSEZkkWLT6n",
+        "next_epoch_id": "641dmDs9kztD2xkQfoLbf72HEbGtqk96x2PwDvSpLMXF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4392824031985212e+22
+    },
+    {
+        "timestamp": "2023-10-22T11:46:16.850Z",
+        "balance": 1.0759785147951011e+26,
+        "block_height": 103953095,
+        "epoch_id": "7DYdDGBo5gXLZTjxnvEgwNJQq2npnWxRRHJnEbKdqdqR",
+        "next_epoch_id": "4WFawBvVLC4xWuWLGufr1qMkXvgiv3a1GNSEZkkWLT6n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4065960981204245e+22
+    },
+    {
+        "timestamp": "2023-10-21T21:59:40.919Z",
+        "balance": 1.075837855185289e+26,
+        "block_height": 103909895,
+        "epoch_id": "5n9giJjpMMLFjEqzfCPHf89LBkDZHYHng6r5UqJEBDBh",
+        "next_epoch_id": "7DYdDGBo5gXLZTjxnvEgwNJQq2npnWxRRHJnEbKdqdqR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4376804913790681e+22
+    },
+    {
+        "timestamp": "2023-10-21T08:30:49.869Z",
+        "balance": 1.0756940871361512e+26,
+        "block_height": 103866695,
+        "epoch_id": "7xauZAB7D2puRxTYWTgyCX3U8MwQpwBAWMzSkUMKLKV9",
+        "next_epoch_id": "5n9giJjpMMLFjEqzfCPHf89LBkDZHYHng6r5UqJEBDBh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4839451930513e+22
+    },
+    {
+        "timestamp": "2023-10-20T18:37:05.326Z",
+        "balance": 1.075545692616846e+26,
+        "block_height": 103823495,
+        "epoch_id": "2jBAqak9qszpRfgdR2xg5RrMGccNNyif8mFtUK1tXRC8",
+        "next_epoch_id": "7xauZAB7D2puRxTYWTgyCX3U8MwQpwBAWMzSkUMKLKV9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4715772108183387e+22
+    },
+    {
+        "timestamp": "2023-10-20T04:14:44.224Z",
+        "balance": 1.0753985348957642e+26,
+        "block_height": 103780295,
+        "epoch_id": "GYi3SRbWY3onrAKUwnYXo7xM1tMkz7y9Hmo1d9KHfWxY",
+        "next_epoch_id": "2jBAqak9qszpRfgdR2xg5RrMGccNNyif8mFtUK1tXRC8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3289661120397688e+22
+    },
+    {
+        "timestamp": "2023-10-19T13:51:16.420Z",
+        "balance": 1.0752656382845602e+26,
+        "block_height": 103737095,
+        "epoch_id": "AJF8xJm5vEDTaJd4CLrf19zKK8mWAJRKyfkKVMWVJp9F",
+        "next_epoch_id": "GYi3SRbWY3onrAKUwnYXo7xM1tMkz7y9Hmo1d9KHfWxY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3206449137782538e+22
+    },
+    {
+        "timestamp": "2023-10-19T00:07:51.042Z",
+        "balance": 1.0751335737931824e+26,
+        "block_height": 103693895,
+        "epoch_id": "3nho9d3838BLyb8DDHoKWhnkomsK31DVNBu9NVAFP3PT",
+        "next_epoch_id": "AJF8xJm5vEDTaJd4CLrf19zKK8mWAJRKyfkKVMWVJp9F",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3610353909079755e+22
+    },
+    {
+        "timestamp": "2023-10-18T10:28:51.193Z",
+        "balance": 1.0749974702540916e+26,
+        "block_height": 103650695,
+        "epoch_id": "ESpVQK2aRhCtZkem1itzvhyfpzeW48TmRiwEDFrfausQ",
+        "next_epoch_id": "3nho9d3838BLyb8DDHoKWhnkomsK31DVNBu9NVAFP3PT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3206702386852655e+22
+    },
+    {
+        "timestamp": "2023-10-17T20:24:54.758Z",
+        "balance": 1.074865403230223e+26,
+        "block_height": 103607495,
+        "epoch_id": "4v1bbCE1FqmiWtGecAciXvEDNunS51PwoTk7Ba2PnXk8",
+        "next_epoch_id": "ESpVQK2aRhCtZkem1itzvhyfpzeW48TmRiwEDFrfausQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3376703590847274e+22
+    },
+    {
+        "timestamp": "2023-10-17T06:32:26.087Z",
+        "balance": 1.0747316361943146e+26,
+        "block_height": 103564295,
+        "epoch_id": "HWuZwyrDesgyTwcdHnYJutCLYdvTMd3fep9XQfdHPqh3",
+        "next_epoch_id": "4v1bbCE1FqmiWtGecAciXvEDNunS51PwoTk7Ba2PnXk8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3351836194592478e+22
+    },
+    {
+        "timestamp": "2023-10-16T16:29:10.863Z",
+        "balance": 1.0745981178323687e+26,
+        "block_height": 103521095,
+        "epoch_id": "4HxpJMnt286Z15wQyqx2Qjnq9dkCe4Gn9gBoVwxh536J",
+        "next_epoch_id": "HWuZwyrDesgyTwcdHnYJutCLYdvTMd3fep9XQfdHPqh3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.262777038704087e+22
+    },
+    {
+        "timestamp": "2023-10-16T02:28:25.444Z",
+        "balance": 1.0744718401284983e+26,
+        "block_height": 103477895,
+        "epoch_id": "9VkgYTM8cyhJDDcHzss8FtrimoUNoZetgM4iv2gQyEMN",
+        "next_epoch_id": "4HxpJMnt286Z15wQyqx2Qjnq9dkCe4Gn9gBoVwxh536J",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3133409825838355e+22
+    },
+    {
+        "timestamp": "2023-10-15T13:11:23.375Z",
+        "balance": 1.0743405060302399e+26,
+        "block_height": 103434695,
+        "epoch_id": "CBkQQVqyQsAfqhcAJBAWzJnwwUhqpRZvr7rzYJrN9LHL",
+        "next_epoch_id": "9VkgYTM8cyhJDDcHzss8FtrimoUNoZetgM4iv2gQyEMN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2757552130396445e+22
+    },
+    {
+        "timestamp": "2023-10-14T23:22:27.425Z",
+        "balance": 1.074212930508936e+26,
+        "block_height": 103391495,
+        "epoch_id": "2inr9SLexJEJkmvAVu66q5xnrzcac8u9SJahBd9TVVzN",
+        "next_epoch_id": "CBkQQVqyQsAfqhcAJBAWzJnwwUhqpRZvr7rzYJrN9LHL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2877504962196022e+22
+    },
+    {
+        "timestamp": "2023-10-14T10:05:50.593Z",
+        "balance": 1.074084155459314e+26,
+        "block_height": 103348295,
+        "epoch_id": "E53mXPYvFSSLh7WiyQjBm1f8eXSWju73ts3SPvV1r1NG",
+        "next_epoch_id": "2inr9SLexJEJkmvAVu66q5xnrzcac8u9SJahBd9TVVzN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3030247923182159e+22
+    },
+    {
+        "timestamp": "2023-10-13T20:41:33.965Z",
+        "balance": 1.0739538529800821e+26,
+        "block_height": 103305095,
+        "epoch_id": "H5eeTE4gSnbyRM74pvALXDPqtnj56UihSr69pWVqvZcj",
+        "next_epoch_id": "E53mXPYvFSSLh7WiyQjBm1f8eXSWju73ts3SPvV1r1NG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.301112680323792e+22
+    },
+    {
+        "timestamp": "2023-10-13T07:06:54.536Z",
+        "balance": 1.0738237417120498e+26,
+        "block_height": 103261895,
+        "epoch_id": "9FvVNfvwHedRx1p7ecHv82j5eWzdhmf6et5Zz1N9VdCH",
+        "next_epoch_id": "H5eeTE4gSnbyRM74pvALXDPqtnj56UihSr69pWVqvZcj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3303922413893644e+22
+    },
+    {
+        "timestamp": "2023-10-12T17:34:11.937Z",
+        "balance": 1.0736907024879108e+26,
+        "block_height": 103218695,
+        "epoch_id": "AQwyVUzBDaAtDUaD6wh4PCWvpQh8gpiD46kH4PermPSx",
+        "next_epoch_id": "9FvVNfvwHedRx1p7ecHv82j5eWzdhmf6et5Zz1N9VdCH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.295819865414806e+22
+    },
+    {
+        "timestamp": "2023-10-12T03:42:06.067Z",
+        "balance": 1.0735611205013694e+26,
+        "block_height": 103175495,
+        "epoch_id": "CeAzbUa8odFqUznW6Vbt8HCXvabBM2XNhkrSmfJ4ZT5t",
+        "next_epoch_id": "AQwyVUzBDaAtDUaD6wh4PCWvpQh8gpiD46kH4PermPSx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3105467692698562e+22
+    },
+    {
+        "timestamp": "2023-10-11T14:11:07.090Z",
+        "balance": 1.0734300658244424e+26,
+        "block_height": 103132295,
+        "epoch_id": "GAXYJ2YvdQnYPgUqSikJtRKEndX3ZDGdCguTA2qhGQZr",
+        "next_epoch_id": "CeAzbUa8odFqUznW6Vbt8HCXvabBM2XNhkrSmfJ4ZT5t",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2953470371518577e+22
+    },
+    {
+        "timestamp": "2023-10-11T00:35:30.439Z",
+        "balance": 1.0733005311207272e+26,
+        "block_height": 103089095,
+        "epoch_id": "GPgmf1kKFPqmbxXQexnH2ZFPX8FG3StMQjLuL7Rjhesq",
+        "next_epoch_id": "GAXYJ2YvdQnYPgUqSikJtRKEndX3ZDGdCguTA2qhGQZr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3585632602976437e+22
+    },
+    {
+        "timestamp": "2023-10-10T10:56:36.114Z",
+        "balance": 1.0731646747946974e+26,
+        "block_height": 103045895,
+        "epoch_id": "ATocmfYagxFxUyVgNtqKtVSSyEjjhVRN6UyEyPk2xPuJ",
+        "next_epoch_id": "GPgmf1kKFPqmbxXQexnH2ZFPX8FG3StMQjLuL7Rjhesq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3074511184865706e+22
+    },
+    {
+        "timestamp": "2023-10-09T20:38:01.427Z",
+        "balance": 1.0730339296828488e+26,
+        "block_height": 103002695,
+        "epoch_id": "Cd2wHdPkxV6ogcqXRr37kZECVx2Fhu559htByMFdGawZ",
+        "next_epoch_id": "ATocmfYagxFxUyVgNtqKtVSSyEjjhVRN6UyEyPk2xPuJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2916947667915001e+22
+    },
+    {
+        "timestamp": "2023-10-09T06:46:48.969Z",
+        "balance": 1.0729047602061696e+26,
+        "block_height": 102959495,
+        "epoch_id": "8apFPV3ucTgNgi88GGRDw2BziDk6xAhKqpa2ayUMMM3o",
+        "next_epoch_id": "Cd2wHdPkxV6ogcqXRr37kZECVx2Fhu559htByMFdGawZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.1556427722649904e+22
+    },
+    {
+        "timestamp": "2023-10-08T17:04:28.668Z",
+        "balance": 1.0727891959289431e+26,
+        "block_height": 102916295,
+        "epoch_id": "3rV9rL4aKq9JvW5cjetjYXhkLGnPCfmsuQHKwXqW3JxD",
+        "next_epoch_id": "8apFPV3ucTgNgi88GGRDw2BziDk6xAhKqpa2ayUMMM3o",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.1269204256621022e+22
+    },
+    {
+        "timestamp": "2023-10-08T03:15:26.515Z",
+        "balance": 1.0726765038863769e+26,
+        "block_height": 102873095,
+        "epoch_id": "J1rE45u3brwE645FNDymDVXtj3PG4VoJEBqk2UQZ82G4",
+        "next_epoch_id": "3rV9rL4aKq9JvW5cjetjYXhkLGnPCfmsuQHKwXqW3JxD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.1889312470188641e+22
+    },
+    {
+        "timestamp": "2023-10-07T13:52:23.685Z",
+        "balance": 1.072557610761675e+26,
+        "block_height": 102829895,
+        "epoch_id": "BPq4Kvz5brSf4zXWozVuyRpGiWajzQf2jNG1UGfAtqSf",
+        "next_epoch_id": "J1rE45u3brwE645FNDymDVXtj3PG4VoJEBqk2UQZ82G4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.226826146664104e+22
+    },
+    {
+        "timestamp": "2023-10-07T00:12:37.263Z",
+        "balance": 1.0724349281470086e+26,
+        "block_height": 102786695,
+        "epoch_id": "Gfj8xePVu39ZXYk2upfKpYDzomGyPYnUGDcQvjjijjbW",
+        "next_epoch_id": "BPq4Kvz5brSf4zXWozVuyRpGiWajzQf2jNG1UGfAtqSf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2849720817005852e+22
+    },
+    {
+        "timestamp": "2023-10-06T10:47:24.700Z",
+        "balance": 1.0723064309388385e+26,
+        "block_height": 102743495,
+        "epoch_id": "581DEMZcCYRRcMKbpNCc5EuvhPJuE1xEBvfoFbksvcWd",
+        "next_epoch_id": "Gfj8xePVu39ZXYk2upfKpYDzomGyPYnUGDcQvjjijjbW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3049326560058685e+22
+    },
+    {
+        "timestamp": "2023-10-05T21:07:57.288Z",
+        "balance": 1.072175937673238e+26,
+        "block_height": 102700295,
+        "epoch_id": "3HKLLD8tW2HfHhMfHYVpcxsnm4sJ6pvot49zQ1UQWnFc",
+        "next_epoch_id": "581DEMZcCYRRcMKbpNCc5EuvhPJuE1xEBvfoFbksvcWd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.267305975461946e+22
+    },
+    {
+        "timestamp": "2023-10-05T07:15:14.912Z",
+        "balance": 1.0720492070756918e+26,
+        "block_height": 102657095,
+        "epoch_id": "A3KTb4tBN1UW7q5fYkzwsTJBfg1x6HjGkMbb9Cr3MGXp",
+        "next_epoch_id": "3HKLLD8tW2HfHhMfHYVpcxsnm4sJ6pvot49zQ1UQWnFc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.175355494720988e+22
+    },
+    {
+        "timestamp": "2023-10-04T17:45:18.499Z",
+        "balance": 1.0719316715262197e+26,
+        "block_height": 102613895,
+        "epoch_id": "4BRi8TmwddYLLFBSHsRbYAwezeASpdhSsi9s4ApEtkHD",
+        "next_epoch_id": "A3KTb4tBN1UW7q5fYkzwsTJBfg1x6HjGkMbb9Cr3MGXp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2898597588608639e+22
+    },
+    {
+        "timestamp": "2023-10-04T03:50:22.960Z",
+        "balance": 1.0718026855503336e+26,
+        "block_height": 102570695,
+        "epoch_id": "ELQbbiFrH3zgYM3dEBojtePTq48v5t4hEo5Q6W3MiLo7",
+        "next_epoch_id": "4BRi8TmwddYLLFBSHsRbYAwezeASpdhSsi9s4ApEtkHD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3082599204081937e+22
+    },
+    {
+        "timestamp": "2023-10-03T14:04:39.584Z",
+        "balance": 1.0716718595582928e+26,
+        "block_height": 102527495,
+        "epoch_id": "6RHK2Lg6D4vyavxvmXT3hnswcZcToLikqucQzivepKu1",
+        "next_epoch_id": "ELQbbiFrH3zgYM3dEBojtePTq48v5t4hEo5Q6W3MiLo7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.31287867204296e+22
+    },
+    {
+        "timestamp": "2023-10-03T00:07:08.613Z",
+        "balance": 1.0715405716910885e+26,
+        "block_height": 102484295,
+        "epoch_id": "8Pbz4SAdgjsF6ro4FtpFpt3FP92kncMSjKVkVDwurd2N",
+        "next_epoch_id": "6RHK2Lg6D4vyavxvmXT3hnswcZcToLikqucQzivepKu1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.29731104828211e+22
+    },
+    {
+        "timestamp": "2023-10-02T10:10:09.978Z",
+        "balance": 1.0714108405862603e+26,
+        "block_height": 102441095,
+        "epoch_id": "JDNZPRK2oqrQ9A6s9edr2X3vvw2cKc9VhFZopajLTXiJ",
+        "next_epoch_id": "8Pbz4SAdgjsF6ro4FtpFpt3FP92kncMSjKVkVDwurd2N",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3136893001365738e+22
+    },
+    {
+        "timestamp": "2023-10-01T20:23:03.345Z",
+        "balance": 1.0712794716562466e+26,
+        "block_height": 102397895,
+        "epoch_id": "EXW1iUMXX5rBVqjotMYSuEUUTjn84FRjcTG6PH6mr8dK",
+        "next_epoch_id": "JDNZPRK2oqrQ9A6s9edr2X3vvw2cKc9VhFZopajLTXiJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.285543792262009e+22
+    },
+    {
+        "timestamp": "2023-10-01T06:25:28.793Z",
+        "balance": 1.0711509172770204e+26,
+        "block_height": 102354695,
+        "epoch_id": "AQpqn7LUjtwqtbfezsB9WNLetuXu62MqMAUV1VqycbpE",
+        "next_epoch_id": "EXW1iUMXX5rBVqjotMYSuEUUTjn84FRjcTG6PH6mr8dK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.321165824717195e+22
+    },
+    {
+        "timestamp": "2023-09-30T16:45:38.169Z",
+        "balance": 1.0710188006945487e+26,
+        "block_height": 102311495,
+        "epoch_id": "8xNC6CTh3ar5q4kprpQqE6t2wZbNDV4XBf4Nhjobiexk",
+        "next_epoch_id": "AQpqn7LUjtwqtbfezsB9WNLetuXu62MqMAUV1VqycbpE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2734627576908825e+22
+    },
+    {
+        "timestamp": "2023-09-30T02:43:14.804Z",
+        "balance": 1.0708914544187796e+26,
+        "block_height": 102268295,
+        "epoch_id": "ASNHqLGctjVU1GCYzBmmKG3Czwx1SR1RK7B1AHqbDjsW",
+        "next_epoch_id": "8xNC6CTh3ar5q4kprpQqE6t2wZbNDV4XBf4Nhjobiexk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2889956971821998e+22
+    },
+    {
+        "timestamp": "2023-09-29T13:11:31.868Z",
+        "balance": 1.0707625548490614e+26,
+        "block_height": 102225095,
+        "epoch_id": "C9TDDYthANoduoTBZS7WYDsBSe9XCm4M2F9hRoVXVXWY",
+        "next_epoch_id": "ASNHqLGctjVU1GCYzBmmKG3Czwx1SR1RK7B1AHqbDjsW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2957011480210548e+22
+    },
+    {
+        "timestamp": "2023-09-28T23:29:37.704Z",
+        "balance": 1.0706329847342593e+26,
+        "block_height": 102181895,
+        "epoch_id": "2RMQiomr6CSSwUWpmB62YohxHbfadrHfcsaa3FVb4J9x",
+        "next_epoch_id": "C9TDDYthANoduoTBZS7WYDsBSe9XCm4M2F9hRoVXVXWY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2641974790121576e+22
+    },
+    {
+        "timestamp": "2023-09-28T09:44:05.514Z",
+        "balance": 1.070506564986358e+26,
+        "block_height": 102138695,
+        "epoch_id": "FePmx4MgMDCyWffnt5BEhgXnRuKL7VqSLrniaaBfsmq9",
+        "next_epoch_id": "2RMQiomr6CSSwUWpmB62YohxHbfadrHfcsaa3FVb4J9x",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3083585203125694e+22
+    },
+    {
+        "timestamp": "2023-09-27T20:18:24.567Z",
+        "balance": 1.0703757291343268e+26,
+        "block_height": 102095495,
+        "epoch_id": "2S6BVRy5d3Dam9HoUEMNvAuwhCgNodpUwo3hhLxdGBq9",
+        "next_epoch_id": "FePmx4MgMDCyWffnt5BEhgXnRuKL7VqSLrniaaBfsmq9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2931859252840057e+22
+    },
+    {
+        "timestamp": "2023-09-27T06:25:32.079Z",
+        "balance": 1.0702464105417984e+26,
+        "block_height": 102052295,
+        "epoch_id": "9CG91yVxDbW1S9dGyARxxuw2KWU6VhUbNdYwyuCq7WgY",
+        "next_epoch_id": "2S6BVRy5d3Dam9HoUEMNvAuwhCgNodpUwo3hhLxdGBq9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3503903719418099e+22
+    },
+    {
+        "timestamp": "2023-09-26T16:42:59.317Z",
+        "balance": 1.0701113715046042e+26,
+        "block_height": 102009095,
+        "epoch_id": "8HpHnWmXiXPBgkiDDiSymZw14TGUDsC66k9Qmzh2oTmo",
+        "next_epoch_id": "9CG91yVxDbW1S9dGyARxxuw2KWU6VhUbNdYwyuCq7WgY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3122485864558666e+22
+    },
+    {
+        "timestamp": "2023-09-26T02:20:13.273Z",
+        "balance": 1.0699801466459586e+26,
+        "block_height": 101965895,
+        "epoch_id": "DPLpycd9tU6xhtpm8kkdmMfDaWsZ4j5tdYkdAm8db1t5",
+        "next_epoch_id": "8HpHnWmXiXPBgkiDDiSymZw14TGUDsC66k9Qmzh2oTmo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3015161874486517e+22
+    },
+    {
+        "timestamp": "2023-09-25T12:20:37.261Z",
+        "balance": 1.0698499950272138e+26,
+        "block_height": 101922695,
+        "epoch_id": "7KQcMo7hKcNbYz8RX76k5iUCFDBXxJDTUYZWaFMvprJV",
+        "next_epoch_id": "DPLpycd9tU6xhtpm8kkdmMfDaWsZ4j5tdYkdAm8db1t5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.282954238733581e+22
+    },
+    {
+        "timestamp": "2023-09-24T22:27:35.111Z",
+        "balance": 1.0697216996033404e+26,
+        "block_height": 101879495,
+        "epoch_id": "FPho7WucSwLqCD8Dyb62b6FDoqx8BX88SFHsszhT5K9D",
+        "next_epoch_id": "7KQcMo7hKcNbYz8RX76k5iUCFDBXxJDTUYZWaFMvprJV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3042389808028737e+22
+    },
+    {
+        "timestamp": "2023-09-24T08:46:28.747Z",
+        "balance": 1.0695912757052601e+26,
+        "block_height": 101836295,
+        "epoch_id": "FLXMaP1caeMQw3arXzxtaU3LmpWRfo1W5YbRh4rebkKz",
+        "next_epoch_id": "FPho7WucSwLqCD8Dyb62b6FDoqx8BX88SFHsszhT5K9D",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3390199706490331e+22
+    },
+    {
+        "timestamp": "2023-09-23T15:30:12.843Z",
+        "balance": 1.0694573737081952e+26,
+        "block_height": 101782714,
+        "epoch_id": "317TEBw3BBo7wEQEv2YkjmmajiDpFGjNsoTsR1tSkdHi",
+        "next_epoch_id": "FLXMaP1caeMQw3arXzxtaU3LmpWRfo1W5YbRh4rebkKz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2784433511411327e+22
+    },
+    {
+        "timestamp": "2023-09-23T04:34:26.875Z",
+        "balance": 1.0693295293730811e+26,
+        "block_height": 101749895,
+        "epoch_id": "FdQEkavzT5rvg519wANZbT5H6YbLQwiPDNHWjGZ9AUff",
+        "next_epoch_id": "317TEBw3BBo7wEQEv2YkjmmajiDpFGjNsoTsR1tSkdHi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3328126879145983e+22
+    },
+    {
+        "timestamp": "2023-09-22T14:55:34.642Z",
+        "balance": 1.0691962481042896e+26,
+        "block_height": 101706695,
+        "epoch_id": "DnwrSRbbxXSdQRUE5dosn4Nu1NWg8Yxp9MfcmhM7pGB8",
+        "next_epoch_id": "FdQEkavzT5rvg519wANZbT5H6YbLQwiPDNHWjGZ9AUff",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2826247341116978e+22
+    },
+    {
+        "timestamp": "2023-09-22T00:42:23.148Z",
+        "balance": 1.0690679856308785e+26,
+        "block_height": 101663495,
+        "epoch_id": "5YpBVBDx2e7HzbRgNpmoUhdE6217hnEqftuhhXN2Eb76",
+        "next_epoch_id": "DnwrSRbbxXSdQRUE5dosn4Nu1NWg8Yxp9MfcmhM7pGB8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2037107838959586e+22
+    },
+    {
+        "timestamp": "2023-09-21T11:01:19.623Z",
+        "balance": 1.0689476145524889e+26,
+        "block_height": 101620295,
+        "epoch_id": "BymwaahPJGU9sDcqc1yTfkTUVLd6m9hBaEJGdGQZrfDt",
+        "next_epoch_id": "5YpBVBDx2e7HzbRgNpmoUhdE6217hnEqftuhhXN2Eb76",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3091594066695956e+22
+    },
+    {
+        "timestamp": "2023-09-20T21:19:23.508Z",
+        "balance": 1.0688166986118219e+26,
+        "block_height": 101577095,
+        "epoch_id": "4Yait96feKATCdH3KeQREtKpDuuqh6BQRY7XFV5ocyJz",
+        "next_epoch_id": "BymwaahPJGU9sDcqc1yTfkTUVLd6m9hBaEJGdGQZrfDt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2798564834403722e+22
+    },
+    {
+        "timestamp": "2023-09-20T07:20:13.081Z",
+        "balance": 1.0686887129634779e+26,
+        "block_height": 101533895,
+        "epoch_id": "2ZpTDBCeQ3XBcXjEnsZgWBdRNXZPmtPq1U4oZWbJrQUu",
+        "next_epoch_id": "4Yait96feKATCdH3KeQREtKpDuuqh6BQRY7XFV5ocyJz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3017610279572092e+22
+    },
+    {
+        "timestamp": "2023-09-19T17:42:17.137Z",
+        "balance": 1.0685585368606821e+26,
+        "block_height": 101490695,
+        "epoch_id": "DDpNZrX1p6swwvNWB7orn8A8mkEVvtyQYacMZ9NLZsbj",
+        "next_epoch_id": "2ZpTDBCeQ3XBcXjEnsZgWBdRNXZPmtPq1U4oZWbJrQUu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.34170144900172e+22
+    },
+    {
+        "timestamp": "2023-09-19T03:48:16.940Z",
+        "balance": 1.068424366715782e+26,
+        "block_height": 101447495,
+        "epoch_id": "5neaV4TWTwaBgXoq3HyZi41hW6n6z6uyK75ieSD13gSQ",
+        "next_epoch_id": "DDpNZrX1p6swwvNWB7orn8A8mkEVvtyQYacMZ9NLZsbj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3252905723265676e+22
+    },
+    {
+        "timestamp": "2023-09-18T13:29:00.322Z",
+        "balance": 1.0682918376585493e+26,
+        "block_height": 101404295,
+        "epoch_id": "Ce3iGv8nDhww18ieWV4V5AnCpWwPEbRWmkMqGvuVqkPA",
+        "next_epoch_id": "5neaV4TWTwaBgXoq3HyZi41hW6n6z6uyK75ieSD13gSQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3274093489130954e+22
+    },
+    {
+        "timestamp": "2023-09-17T23:23:57.994Z",
+        "balance": 1.068159096723658e+26,
+        "block_height": 101361095,
+        "epoch_id": "ADB25spsjY5EB7Mm64YJEQNWcwxnJYT87S8oG1VRwkjj",
+        "next_epoch_id": "Ce3iGv8nDhww18ieWV4V5AnCpWwPEbRWmkMqGvuVqkPA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2976475358164419e+22
+    },
+    {
+        "timestamp": "2023-09-17T09:18:01.877Z",
+        "balance": 1.0680293319700764e+26,
+        "block_height": 101317895,
+        "epoch_id": "3LrNa6ciEzntmZLbGBK2wj7Dome53XLKLH2uL1KfJUU4",
+        "next_epoch_id": "ADB25spsjY5EB7Mm64YJEQNWcwxnJYT87S8oG1VRwkjj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3257628195594682e+22
+    },
+    {
+        "timestamp": "2023-09-16T19:32:13.012Z",
+        "balance": 1.0678967556881204e+26,
+        "block_height": 101274695,
+        "epoch_id": "J6iUpd89oaysr42KGD13AGDPqMzrDn7aokS7Qt3r8NAB",
+        "next_epoch_id": "3LrNa6ciEzntmZLbGBK2wj7Dome53XLKLH2uL1KfJUU4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3479028281541415e+22
+    },
+    {
+        "timestamp": "2023-09-16T05:27:58.229Z",
+        "balance": 1.067761965405305e+26,
+        "block_height": 101231495,
+        "epoch_id": "GABeMMm9HncoePJdCHqAkY3cZLX3UyhfpUxYVjKMSSYk",
+        "next_epoch_id": "J6iUpd89oaysr42KGD13AGDPqMzrDn7aokS7Qt3r8NAB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.365584722924489e+22
+    },
+    {
+        "timestamp": "2023-09-15T15:12:52.901Z",
+        "balance": 1.0676254069330126e+26,
+        "block_height": 101188295,
+        "epoch_id": "C7ggKzrbgKcgQT9tgFa2HmtK2RAW3i9GQCcr7WLKTYVF",
+        "next_epoch_id": "GABeMMm9HncoePJdCHqAkY3cZLX3UyhfpUxYVjKMSSYk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3247959978796955e+22
+    },
+    {
+        "timestamp": "2023-09-14T19:38:19.505Z",
+        "balance": 1.0674929273332246e+26,
+        "block_height": 101128579,
+        "epoch_id": "DkHDoCSUQCUj5u6y4251DJnErsdRbRTjBYEDgs3EZHdC",
+        "next_epoch_id": "C7ggKzrbgKcgQT9tgFa2HmtK2RAW3i9GQCcr7WLKTYVF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3261085258562719e+22
+    },
+    {
+        "timestamp": "2023-09-14T10:41:49.123Z",
+        "balance": 1.067360316480639e+26,
+        "block_height": 101101895,
+        "epoch_id": "2v4fC712vbLUaNEq8vpx1TQQKcRDY2EUU3LxXwvDye1R",
+        "next_epoch_id": "DkHDoCSUQCUj5u6y4251DJnErsdRbRTjBYEDgs3EZHdC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3081433721653416e+22
+    },
+    {
+        "timestamp": "2023-09-13T20:36:20.758Z",
+        "balance": 1.0672295021434224e+26,
+        "block_height": 101058695,
+        "epoch_id": "CKTimDySSPoVYSfKPAZsEDfVoMVXD9SduQkVGSf1QoBd",
+        "next_epoch_id": "2v4fC712vbLUaNEq8vpx1TQQKcRDY2EUU3LxXwvDye1R",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.299927646649229e+22
+    },
+    {
+        "timestamp": "2023-09-13T06:42:03.925Z",
+        "balance": 1.0670995093787575e+26,
+        "block_height": 101015495,
+        "epoch_id": "8LWp9FvUoSKzGchRQMjspmp3262FcoShugJcDG4dPTSM",
+        "next_epoch_id": "CKTimDySSPoVYSfKPAZsEDfVoMVXD9SduQkVGSf1QoBd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3217670520548134e+22
+    },
+    {
+        "timestamp": "2023-09-12T16:53:57.386Z",
+        "balance": 1.066967332673552e+26,
+        "block_height": 100972295,
+        "epoch_id": "EfkKwBeEJScwEHJC1QsUohnQqPey3CtFt7K8hS6GAfvZ",
+        "next_epoch_id": "8LWp9FvUoSKzGchRQMjspmp3262FcoShugJcDG4dPTSM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2860811586002045e+22
+    },
+    {
+        "timestamp": "2023-09-12T02:52:27.816Z",
+        "balance": 1.066838724557692e+26,
+        "block_height": 100929095,
+        "epoch_id": "91xf4anmftn1rM4ay9mFDdLmxWPm4TB7ukNttSeBtyJS",
+        "next_epoch_id": "EfkKwBeEJScwEHJC1QsUohnQqPey3CtFt7K8hS6GAfvZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3213002910190042e+22
+    },
+    {
+        "timestamp": "2023-09-11T13:12:56.998Z",
+        "balance": 1.0667065945285901e+26,
+        "block_height": 100885895,
+        "epoch_id": "Ek9d3AP7xgQXc1Zsy13kcJrwu7fmfMduC6hYJgSHtaZp",
+        "next_epoch_id": "91xf4anmftn1rM4ay9mFDdLmxWPm4TB7ukNttSeBtyJS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3054610254132171e+22
+    },
+    {
+        "timestamp": "2023-09-10T23:10:39.061Z",
+        "balance": 1.0665760484260488e+26,
+        "block_height": 100842695,
+        "epoch_id": "21xvXqN4dejSsreNxHVzqzN7gDX5bnz1shjb4WtCXXF4",
+        "next_epoch_id": "Ek9d3AP7xgQXc1Zsy13kcJrwu7fmfMduC6hYJgSHtaZp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.322332520310769e+22
+    },
+    {
+        "timestamp": "2023-09-10T09:19:24.322Z",
+        "balance": 1.0664438151740177e+26,
+        "block_height": 100799495,
+        "epoch_id": "3W49t9j5g1wb228NgD6F61eK47zthDTPvGutzAarehQQ",
+        "next_epoch_id": "21xvXqN4dejSsreNxHVzqzN7gDX5bnz1shjb4WtCXXF4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3205116243490233e+22
+    },
+    {
+        "timestamp": "2023-09-09T19:18:55.921Z",
+        "balance": 1.0663117640115828e+26,
+        "block_height": 100756295,
+        "epoch_id": "CgJkXs96WhpW9KYxWGJn4mppWHwnW1HE8J15vY453JtT",
+        "next_epoch_id": "3W49t9j5g1wb228NgD6F61eK47zthDTPvGutzAarehQQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3149122809759143e+22
+    },
+    {
+        "timestamp": "2023-09-09T05:19:49.225Z",
+        "balance": 1.0661802727834852e+26,
+        "block_height": 100713095,
+        "epoch_id": "5LndKLFDRTA9W9uGr3MH7zJTtoYDcKn3oJETa9wLEoLz",
+        "next_epoch_id": "CgJkXs96WhpW9KYxWGJn4mppWHwnW1HE8J15vY453JtT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.354658414239014e+22
+    },
+    {
+        "timestamp": "2023-09-08T15:17:51.016Z",
+        "balance": 1.0660448069420613e+26,
+        "block_height": 100669895,
+        "epoch_id": "7XY3WEXy1oQsQhFyys3tFa7CYgm8Bd6bNVFkWyc1Sy65",
+        "next_epoch_id": "5LndKLFDRTA9W9uGr3MH7zJTtoYDcKn3oJETa9wLEoLz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3378805606768888e+22
+    },
+    {
+        "timestamp": "2023-09-08T00:51:00.908Z",
+        "balance": 1.0659110188859936e+26,
+        "block_height": 100626695,
+        "epoch_id": "89apPFfAL7ffQDYBxL4j8UaGWzuRpL3ds4uR3XRqhYkG",
+        "next_epoch_id": "7XY3WEXy1oQsQhFyys3tFa7CYgm8Bd6bNVFkWyc1Sy65",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3504252343579962e+22
+    },
+    {
+        "timestamp": "2023-09-07T10:34:31.315Z",
+        "balance": 1.0657759763625578e+26,
+        "block_height": 100583495,
+        "epoch_id": "GLio6GPMmHzNqUzJEaCiN5WAgv1BTJXbEf6Dop5KKVqY",
+        "next_epoch_id": "89apPFfAL7ffQDYBxL4j8UaGWzuRpL3ds4uR3XRqhYkG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.389685238756683e+22
+    },
+    {
+        "timestamp": "2023-09-06T20:13:39.044Z",
+        "balance": 1.0656370078386821e+26,
+        "block_height": 100540295,
+        "epoch_id": "94rdnY3fY6qvgM5bYopnh2Na6gPMhz9KS8463YuPw92N",
+        "next_epoch_id": "GLio6GPMmHzNqUzJEaCiN5WAgv1BTJXbEf6Dop5KKVqY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3152898227248032e+22
+    },
+    {
+        "timestamp": "2023-09-06T05:26:26.019Z",
+        "balance": 1.0655054788564097e+26,
+        "block_height": 100497095,
+        "epoch_id": "D9TbTYV18N3pXS8GMtZshiC2ikS8fPswYLuPsQNDTkKJ",
+        "next_epoch_id": "94rdnY3fY6qvgM5bYopnh2Na6gPMhz9KS8463YuPw92N",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3988813158881067e+22
+    },
+    {
+        "timestamp": "2023-09-05T15:25:51.183Z",
+        "balance": 1.0653655907248209e+26,
+        "block_height": 100453895,
+        "epoch_id": "HCLc5revQXzx8fTU1Tq7gyL4QYV3CHbef84iq89FKTuz",
+        "next_epoch_id": "D9TbTYV18N3pXS8GMtZshiC2ikS8fPswYLuPsQNDTkKJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.343851123596719e+22
+    },
+    {
+        "timestamp": "2023-09-05T00:29:20.733Z",
+        "balance": 1.0652312056124612e+26,
+        "block_height": 100410695,
+        "epoch_id": "GH8K8PVGXvjRvQ98mxJikaHVadidvEQqTrGa6fK4BikG",
+        "next_epoch_id": "HCLc5revQXzx8fTU1Tq7gyL4QYV3CHbef84iq89FKTuz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3208117435640175e+22
+    },
+    {
+        "timestamp": "2023-09-04T10:07:04.618Z",
+        "balance": 1.0650991244381048e+26,
+        "block_height": 100367495,
+        "epoch_id": "C29sq5qnTvAsgPVNXiYB8MRF3dh6kzB9eCBNSTke7w5u",
+        "next_epoch_id": "GH8K8PVGXvjRvQ98mxJikaHVadidvEQqTrGa6fK4BikG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3355229442713093e+22
+    },
+    {
+        "timestamp": "2023-09-03T19:59:23.819Z",
+        "balance": 1.0649655721436777e+26,
+        "block_height": 100324295,
+        "epoch_id": "4LypgvNUatTmYJrZc68GCM7sP7RQHSjRJWNZsUKwydkq",
+        "next_epoch_id": "C29sq5qnTvAsgPVNXiYB8MRF3dh6kzB9eCBNSTke7w5u",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2472792018086812e+22
+    },
+    {
+        "timestamp": "2023-09-03T05:43:20.614Z",
+        "balance": 1.0648408442234968e+26,
+        "block_height": 100281095,
+        "epoch_id": "GgZFRWa3wYU3onArX3W1EvDU6rAnNA1e6w1GAH9MGrPG",
+        "next_epoch_id": "4LypgvNUatTmYJrZc68GCM7sP7RQHSjRJWNZsUKwydkq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.1609164238115857e+22
+    },
+    {
+        "timestamp": "2023-09-02T15:30:51.850Z",
+        "balance": 1.0647247525811156e+26,
+        "block_height": 100237895,
+        "epoch_id": "tt3Q9pYZtEPPautdXBVBYKbQBNsB481AV3isGt5YtaF",
+        "next_epoch_id": "GgZFRWa3wYU3onArX3W1EvDU6rAnNA1e6w1GAH9MGrPG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.0879785077319221e+22
+    },
+    {
+        "timestamp": "2023-09-02T01:24:04.483Z",
+        "balance": 1.0646159547303424e+26,
+        "block_height": 100194695,
+        "epoch_id": "L66Umxg3B6WoBrdhoBfV9amhH5KARzoYx3RGL3r9f9g",
+        "next_epoch_id": "tt3Q9pYZtEPPautdXBVBYKbQBNsB481AV3isGt5YtaF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2505940679271951e+22
+    },
+    {
+        "timestamp": "2023-09-01T11:36:30.768Z",
+        "balance": 1.0644908953235497e+26,
+        "block_height": 100151495,
+        "epoch_id": "FN9rbjn3kNbEMXobuf5MYNVnokGhddD4NfxBJdgmQPoa",
+        "next_epoch_id": "L66Umxg3B6WoBrdhoBfV9amhH5KARzoYx3RGL3r9f9g",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.192192119923243e+22
+    },
+    {
+        "timestamp": "2023-08-31T21:49:07.308Z",
+        "balance": 1.0643716761115574e+26,
+        "block_height": 100108295,
+        "epoch_id": "3GG5J89DxWDDRsKkwGVbHPF6NTGFoTdJDEe2awka6Eph",
+        "next_epoch_id": "FN9rbjn3kNbEMXobuf5MYNVnokGhddD4NfxBJdgmQPoa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2622246579968842e+22
+    },
+    {
+        "timestamp": "2023-08-31T08:07:49.571Z",
+        "balance": 1.0642454536457577e+26,
+        "block_height": 100065095,
+        "epoch_id": "2rZGzEXGHDGf1zf3oy4CELZLk4L9aLe9DTnXJk7XdgGn",
+        "next_epoch_id": "3GG5J89DxWDDRsKkwGVbHPF6NTGFoTdJDEe2awka6Eph",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.20742882909832e+22
+    },
+    {
+        "timestamp": "2023-08-30T18:36:33.793Z",
+        "balance": 1.0641247107628479e+26,
+        "block_height": 100021895,
+        "epoch_id": "9n8aatTSFqqVgHaCE78Rs19q2z6a5bMhhAezZsdSE8VQ",
+        "next_epoch_id": "2rZGzEXGHDGf1zf3oy4CELZLk4L9aLe9DTnXJk7XdgGn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.268160129984216e+22
+    },
+    {
+        "timestamp": "2023-08-30T04:46:03.039Z",
+        "balance": 1.0639978947498494e+26,
+        "block_height": 99978695,
+        "epoch_id": "4ntNYZVYq3TNRKpDWCfvAGJ2R9QzYbHuJ8G9t5bCwbmX",
+        "next_epoch_id": "9n8aatTSFqqVgHaCE78Rs19q2z6a5bMhhAezZsdSE8VQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2974277451033428e+22
+    },
+    {
+        "timestamp": "2023-08-29T15:11:34.944Z",
+        "balance": 1.0638681519753391e+26,
+        "block_height": 99935495,
+        "epoch_id": "CRnv4iJMgg6zgv8Aq84UgaAJe6VbCn9MLFDyY25N8yc3",
+        "next_epoch_id": "4ntNYZVYq3TNRKpDWCfvAGJ2R9QzYbHuJ8G9t5bCwbmX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2175342808939943e+22
+    },
+    {
+        "timestamp": "2023-08-29T01:18:40.172Z",
+        "balance": 1.0637463985472497e+26,
+        "block_height": 99892295,
+        "epoch_id": "GgxCjeXgDuK8t5ZET4ugdavXpPnfENGXcssudCBzXzfq",
+        "next_epoch_id": "CRnv4iJMgg6zgv8Aq84UgaAJe6VbCn9MLFDyY25N8yc3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2788213967137372e+22
+    },
+    {
+        "timestamp": "2023-08-28T11:34:21.434Z",
+        "balance": 1.0636185164075783e+26,
+        "block_height": 99849095,
+        "epoch_id": "DeUcMR2y5NQTczuoFoPATw9xDYb8ahJsusHmQjAaQbiH",
+        "next_epoch_id": "GgxCjeXgDuK8t5ZET4ugdavXpPnfENGXcssudCBzXzfq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2594699099983625e+22
+    },
+    {
+        "timestamp": "2023-08-27T18:40:49.515Z",
+        "balance": 1.0634925694165785e+26,
+        "block_height": 99796052,
+        "epoch_id": "HnMFcAAMnphzKf8R94VNLj2DLPnMfNVVxyaT2dSHG5H7",
+        "next_epoch_id": "DeUcMR2y5NQTczuoFoPATw9xDYb8ahJsusHmQjAaQbiH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2834789406511758e+22
+    },
+    {
+        "timestamp": "2023-08-27T07:51:37.942Z",
+        "balance": 1.0633642215225134e+26,
+        "block_height": 99762695,
+        "epoch_id": "BkHwFzkzgieP64XAQ6t4oTcTRbXvwQAwXRZbXR3e3f8K",
+        "next_epoch_id": "HnMFcAAMnphzKf8R94VNLj2DLPnMfNVVxyaT2dSHG5H7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2657154957957449e+22
+    },
+    {
+        "timestamp": "2023-08-26T18:07:33.982Z",
+        "balance": 1.0632376499729338e+26,
+        "block_height": 99719495,
+        "epoch_id": "6uJ1r7rGZXcqdZ17n7XxvoMHbntoNgcp2kZ4jJpZ96m4",
+        "next_epoch_id": "BkHwFzkzgieP64XAQ6t4oTcTRbXvwQAwXRZbXR3e3f8K",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2706294486914851e+22
+    },
+    {
+        "timestamp": "2023-08-26T04:33:21.063Z",
+        "balance": 1.0631105870280647e+26,
+        "block_height": 99676295,
+        "epoch_id": "CJcq2xdYJxVtuDsFwVVtmJPrUXCsosV2Le8HPDNRAKY5",
+        "next_epoch_id": "6uJ1r7rGZXcqdZ17n7XxvoMHbntoNgcp2kZ4jJpZ96m4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2340130884005518e+22
+    },
+    {
+        "timestamp": "2023-08-25T14:56:17.487Z",
+        "balance": 1.0629871857192246e+26,
+        "block_height": 99633095,
+        "epoch_id": "2X7cTDfE5dfNKJRSPXbr7kV3kbxNPfKRBaV1YQ99giGx",
+        "next_epoch_id": "CJcq2xdYJxVtuDsFwVVtmJPrUXCsosV2Le8HPDNRAKY5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2378189231038107e+22
+    },
+    {
+        "timestamp": "2023-08-25T01:19:13.729Z",
+        "balance": 1.0628634038269142e+26,
+        "block_height": 99589895,
+        "epoch_id": "CBRftMBkrNaQzdGS6eaogYHm5W87n3gwPfYwf2ds6NKt",
+        "next_epoch_id": "2X7cTDfE5dfNKJRSPXbr7kV3kbxNPfKRBaV1YQ99giGx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.274752255511652e+22
+    },
+    {
+        "timestamp": "2023-08-24T11:43:36.205Z",
+        "balance": 1.062735928601363e+26,
+        "block_height": 99546695,
+        "epoch_id": "EFoCWoNqt3Y15GXqz6L6gsYrgMX3aRysHUPqB9e9yjyU",
+        "next_epoch_id": "CBRftMBkrNaQzdGS6eaogYHm5W87n3gwPfYwf2ds6NKt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.281550165413722e+22
+    },
+    {
+        "timestamp": "2023-08-23T22:14:03.236Z",
+        "balance": 1.0626077735848217e+26,
+        "block_height": 99503495,
+        "epoch_id": "D6kHHbWo5qRS5KSbZ2dsEYRR1HgRpk4UUhVTFF6Ucddf",
+        "next_epoch_id": "EFoCWoNqt3Y15GXqz6L6gsYrgMX3aRysHUPqB9e9yjyU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3017636948398423e+22
+    },
+    {
+        "timestamp": "2023-08-23T08:38:28.149Z",
+        "balance": 1.0624775972153377e+26,
+        "block_height": 99460295,
+        "epoch_id": "nNZV13LazX6YYJ9ru4JKMFCvrDoigBTnbuZaiZToNez",
+        "next_epoch_id": "D6kHHbWo5qRS5KSbZ2dsEYRR1HgRpk4UUhVTFF6Ucddf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3792710456730412e+22
+    },
+    {
+        "timestamp": "2023-08-22T19:16:05.609Z",
+        "balance": 1.0623396701107704e+26,
+        "block_height": 99417095,
+        "epoch_id": "3AowhNYFEPYZQSg1Yfwv11ZkYQDc6CB7DvVgoZ7QbTDH",
+        "next_epoch_id": "nNZV13LazX6YYJ9ru4JKMFCvrDoigBTnbuZaiZToNez",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3615824703971744e+22
+    },
+    {
+        "timestamp": "2023-08-22T05:43:06.502Z",
+        "balance": 1.0622035118637307e+26,
+        "block_height": 99373895,
+        "epoch_id": "8x4fAerzGPd1x5a18ujPYLukf4NACVh9ifQCAKGnPC6c",
+        "next_epoch_id": "3AowhNYFEPYZQSg1Yfwv11ZkYQDc6CB7DvVgoZ7QbTDH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3102177668928587e+22
+    },
+    {
+        "timestamp": "2023-08-21T16:19:39.528Z",
+        "balance": 1.0620724900870414e+26,
+        "block_height": 99330695,
+        "epoch_id": "E4uMDDxocRuCase1NAyK3CXveynLCBzCQZXXo2xBCCME",
+        "next_epoch_id": "8x4fAerzGPd1x5a18ujPYLukf4NACVh9ifQCAKGnPC6c",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3194288905333888e+22
+    },
+    {
+        "timestamp": "2023-08-21T02:45:47.677Z",
+        "balance": 1.061940547197988e+26,
+        "block_height": 99287495,
+        "epoch_id": "5WH3cdYbgfYyE19impvhws8Nx9kdWQAymD9mmSn5fLFC",
+        "next_epoch_id": "E4uMDDxocRuCase1NAyK3CXveynLCBzCQZXXo2xBCCME",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.297802638295365e+22
+    },
+    {
+        "timestamp": "2023-08-20T13:12:25.207Z",
+        "balance": 1.0618107669341585e+26,
+        "block_height": 99244295,
+        "epoch_id": "3HsJyUXjs9CKyRP8Q37xj5gbQAr81VVxqu5frxfyRkzx",
+        "next_epoch_id": "5WH3cdYbgfYyE19impvhws8Nx9kdWQAymD9mmSn5fLFC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3379336363228006e+22
+    },
+    {
+        "timestamp": "2023-08-19T23:53:23.005Z",
+        "balance": 1.0616769735705262e+26,
+        "block_height": 99201095,
+        "epoch_id": "CUAAtYGaPkj18pRvKAAUED1miRuGRs9b6VHJNMazJqvT",
+        "next_epoch_id": "3HsJyUXjs9CKyRP8Q37xj5gbQAr81VVxqu5frxfyRkzx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3081778477166437e+22
+    },
+    {
+        "timestamp": "2023-08-19T10:08:25.082Z",
+        "balance": 1.0615461557857546e+26,
+        "block_height": 99157895,
+        "epoch_id": "5GENxjLa414B3ANSVwxDmJC7u5kCPfg1MKCfKPxaYdMK",
+        "next_epoch_id": "CUAAtYGaPkj18pRvKAAUED1miRuGRs9b6VHJNMazJqvT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3263618896277851e+22
+    },
+    {
+        "timestamp": "2023-08-18T20:40:53.423Z",
+        "balance": 1.0614135195967918e+26,
+        "block_height": 99114695,
+        "epoch_id": "58yECAoDxRUydEe197LX2Ej1CpyicjRGuHvQHVzfyBU6",
+        "next_epoch_id": "5GENxjLa414B3ANSVwxDmJC7u5kCPfg1MKCfKPxaYdMK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3256805147386797e+22
+    },
+    {
+        "timestamp": "2023-08-18T06:58:16.003Z",
+        "balance": 1.061280951545318e+26,
+        "block_height": 99071495,
+        "epoch_id": "CWwhgePhYSiCNUz6wwZrQXKLsrnof3zRKvmguVLwLvXu",
+        "next_epoch_id": "58yECAoDxRUydEe197LX2Ej1CpyicjRGuHvQHVzfyBU6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3265903149087763e+22
+    },
+    {
+        "timestamp": "2023-08-17T17:20:19.040Z",
+        "balance": 1.061148292513827e+26,
+        "block_height": 99028295,
+        "epoch_id": "Ans9AmeRBtGBPz6EokwM5QJsZb3HMDc1iBpBLmdbmdbz",
+        "next_epoch_id": "CWwhgePhYSiCNUz6wwZrQXKLsrnof3zRKvmguVLwLvXu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.325898000612555e+22
+    },
+    {
+        "timestamp": "2023-08-16T16:36:15.384Z",
+        "balance": 1.0610157027137658e+26,
+        "block_height": 98949760,
+        "epoch_id": "2GtG4z91sdCQTP8LH5g1kau2FV8cP2Su5ENnFjcmGxao",
+        "next_epoch_id": "Ans9AmeRBtGBPz6EokwM5QJsZb3HMDc1iBpBLmdbmdbz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3106450180400396e+22
+    },
+    {
+        "timestamp": "2023-08-16T13:55:36.608Z",
+        "balance": 1.0608846382119618e+26,
+        "block_height": 98941895,
+        "epoch_id": "FaYGkMoWKFPeE7udF7QRNBFCJTCfz7aNbHYmpWgfc2hj",
+        "next_epoch_id": "2GtG4z91sdCQTP8LH5g1kau2FV8cP2Su5ENnFjcmGxao",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3301676628047785e+22
+    },
+    {
+        "timestamp": "2023-08-16T00:26:18.141Z",
+        "balance": 1.0607516214456813e+26,
+        "block_height": 98898695,
+        "epoch_id": "7M7qpKxfTjypBAfCqkyLW75n8DfptNgbsNcYMbENxEAi",
+        "next_epoch_id": "FaYGkMoWKFPeE7udF7QRNBFCJTCfz7aNbHYmpWgfc2hj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2998766770748905e+22
+    },
+    {
+        "timestamp": "2023-08-15T10:49:16.611Z",
+        "balance": 1.0606216337779738e+26,
+        "block_height": 98855495,
+        "epoch_id": "4mKpkfKaznoyoo6QyvoJ8ytm2Npepkjaoq9GkEFf3w6h",
+        "next_epoch_id": "7M7qpKxfTjypBAfCqkyLW75n8DfptNgbsNcYMbENxEAi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.382301662430898e+22
+    },
+    {
+        "timestamp": "2023-08-14T21:24:06.547Z",
+        "balance": 1.0604834036117307e+26,
+        "block_height": 98812295,
+        "epoch_id": "cjd4UXVpJRpyYfNmHJzhhVBaxiQtLb77rRx2W87sWJG",
+        "next_epoch_id": "4mKpkfKaznoyoo6QyvoJ8ytm2Npepkjaoq9GkEFf3w6h",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3124365024213657e+22
+    },
+    {
+        "timestamp": "2023-08-14T07:08:17.946Z",
+        "balance": 1.0603521599614886e+26,
+        "block_height": 98769095,
+        "epoch_id": "5vYm97W8SQAHAEo39jQ1RremGAGQuhrFJNUS9SGa3xFW",
+        "next_epoch_id": "cjd4UXVpJRpyYfNmHJzhhVBaxiQtLb77rRx2W87sWJG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3530636640713687e+22
+    },
+    {
+        "timestamp": "2023-08-13T17:41:55.960Z",
+        "balance": 1.0602168535950815e+26,
+        "block_height": 98725895,
+        "epoch_id": "EAZF7Gq17AtNkE5kKiNE7YRxMUncC9EUpj7nBCx1Aoq7",
+        "next_epoch_id": "5vYm97W8SQAHAEo39jQ1RremGAGQuhrFJNUS9SGa3xFW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4312651996349946e+22
+    },
+    {
+        "timestamp": "2023-08-13T03:50:55.736Z",
+        "balance": 1.060073727075118e+26,
+        "block_height": 98682695,
+        "epoch_id": "2noD4kyA6a5iwojfxPdABA2LNqRtrqY1kUDmpu94Tth7",
+        "next_epoch_id": "EAZF7Gq17AtNkE5kKiNE7YRxMUncC9EUpj7nBCx1Aoq7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.423902371447531e+22
+    },
+    {
+        "timestamp": "2023-08-12T13:05:14.060Z",
+        "balance": 1.0599313368379732e+26,
+        "block_height": 98639495,
+        "epoch_id": "BRhr4jg4xhYJAVCzHkAsduSeQjkJwd17Smef42ExN4uo",
+        "next_epoch_id": "2noD4kyA6a5iwojfxPdABA2LNqRtrqY1kUDmpu94Tth7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2883606115058494e+22
+    },
+    {
+        "timestamp": "2023-08-11T22:24:30.266Z",
+        "balance": 1.0598025007768226e+26,
+        "block_height": 98596295,
+        "epoch_id": "73mPwzPk9XMe2ppbrTLWbdJGMWefFn4Gn66GnQVTxkER",
+        "next_epoch_id": "BRhr4jg4xhYJAVCzHkAsduSeQjkJwd17Smef42ExN4uo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.224709483725472e+22
+    },
+    {
+        "timestamp": "2023-08-11T08:33:46.520Z",
+        "balance": 1.05968002982845e+26,
+        "block_height": 98553095,
+        "epoch_id": "71Kd9r8ivviYEVwESLqFiF81gnbWNyvqGR3y3gRj43CT",
+        "next_epoch_id": "73mPwzPk9XMe2ppbrTLWbdJGMWefFn4Gn66GnQVTxkER",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.316410971143686e+22
+    },
+    {
+        "timestamp": "2023-08-10T18:53:11.982Z",
+        "balance": 1.0595483887313357e+26,
+        "block_height": 98509581,
+        "epoch_id": "8qDGzWHHbWfW2JaEFfQbMGWVmosV1ecdnH6iZrjSTsyW",
+        "next_epoch_id": "71Kd9r8ivviYEVwESLqFiF81gnbWNyvqGR3y3gRj43CT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4480265143518048e+22
+    },
+    {
+        "timestamp": "2023-08-10T04:02:55.264Z",
+        "balance": 1.0594035860799005e+26,
+        "block_height": 98466695,
+        "epoch_id": "7WAWWFLhrAEdE51dn2kBganC6JChXMRF88Hc6hGjA2oQ",
+        "next_epoch_id": "8qDGzWHHbWfW2JaEFfQbMGWVmosV1ecdnH6iZrjSTsyW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3193417809051985e+22
+    },
+    {
+        "timestamp": "2023-08-09T13:10:26.583Z",
+        "balance": 1.05927165190181e+26,
+        "block_height": 98423495,
+        "epoch_id": "48fsk8XhxZ4rnruG7iNMeK7kftJ2oEzrhJc3mRAK8MkX",
+        "next_epoch_id": "7WAWWFLhrAEdE51dn2kBganC6JChXMRF88Hc6hGjA2oQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.337305240040834e+22
+    },
+    {
+        "timestamp": "2023-08-08T23:44:14.271Z",
+        "balance": 1.059137921377806e+26,
+        "block_height": 98380295,
+        "epoch_id": "4b8sbCTdPrxbWy4MBSxCnyJYcyHpWFTn3Hi1H5Ppj26Y",
+        "next_epoch_id": "48fsk8XhxZ4rnruG7iNMeK7kftJ2oEzrhJc3mRAK8MkX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.43784457086019e+22
+    },
+    {
+        "timestamp": "2023-08-08T10:07:11.800Z",
+        "balance": 1.0589941369207199e+26,
+        "block_height": 98337095,
+        "epoch_id": "9s7fYFhayZK69kLSU1Ahvkukex3nPHUMCrZ5svu69Zsa",
+        "next_epoch_id": "4b8sbCTdPrxbWy4MBSxCnyJYcyHpWFTn3Hi1H5Ppj26Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.441601918012915e+22
+    },
+    {
+        "timestamp": "2023-08-07T19:17:19.818Z",
+        "balance": 1.0588499767289186e+26,
+        "block_height": 98293895,
+        "epoch_id": "2ecgMwsMGdWBdfFzc211LJCzQ6KwiFFQrEfSPnicjmae",
+        "next_epoch_id": "9s7fYFhayZK69kLSU1Ahvkukex3nPHUMCrZ5svu69Zsa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3421807159137073e+22
+    },
+    {
+        "timestamp": "2023-08-07T04:23:53.920Z",
+        "balance": 1.0587157586573272e+26,
+        "block_height": 98250695,
+        "epoch_id": "UuYssXwxFmu55V3bDovqhxJ8wPpGxPrx6CpmqctHcPS",
+        "next_epoch_id": "2ecgMwsMGdWBdfFzc211LJCzQ6KwiFFQrEfSPnicjmae",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3366796210668275e+22
+    },
+    {
+        "timestamp": "2023-08-06T14:39:15.520Z",
+        "balance": 1.0585820906952206e+26,
+        "block_height": 98207495,
+        "epoch_id": "H4yiwRfrsQqZTXJCUFnUvWMGNuycy7w3XR8XSvnMQcNM",
+        "next_epoch_id": "UuYssXwxFmu55V3bDovqhxJ8wPpGxPrx6CpmqctHcPS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4460987978495593e+22
+    },
+    {
+        "timestamp": "2023-08-06T00:59:00.588Z",
+        "balance": 1.0584374808154356e+26,
+        "block_height": 98164295,
+        "epoch_id": "DZmyFt6R5NZ5ze5bn9Z7Xdz2ApCHUmw5hZ7iUJghS3JX",
+        "next_epoch_id": "H4yiwRfrsQqZTXJCUFnUvWMGNuycy7w3XR8XSvnMQcNM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4244693149405715e+22
+    },
+    {
+        "timestamp": "2023-08-05T10:02:53.763Z",
+        "balance": 1.0582950338839416e+26,
+        "block_height": 98121095,
+        "epoch_id": "7nyaixzip8iFRR1yvwpzTTme9BbPgFUeVahkr3BsxFxX",
+        "next_epoch_id": "DZmyFt6R5NZ5ze5bn9Z7Xdz2ApCHUmw5hZ7iUJghS3JX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3460155752706541e+22
+    },
+    {
+        "timestamp": "2023-08-04T19:19:15.288Z",
+        "balance": 1.0581604323264145e+26,
+        "block_height": 98077895,
+        "epoch_id": "64NED9VeWrkXmMnZ9MrkXaXngcQLMViJ48p63QNXjbNA",
+        "next_epoch_id": "7nyaixzip8iFRR1yvwpzTTme9BbPgFUeVahkr3BsxFxX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.376493776101252e+22
+    },
+    {
+        "timestamp": "2023-08-04T05:33:29.820Z",
+        "balance": 1.0580227829488044e+26,
+        "block_height": 98034695,
+        "epoch_id": "475MQYzy2Sx86acsCAo9q58H3jDXUSMKXUA4GaWbDive",
+        "next_epoch_id": "64NED9VeWrkXmMnZ9MrkXaXngcQLMViJ48p63QNXjbNA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4570270039210187e+22
+    },
+    {
+        "timestamp": "2023-08-03T16:05:21.026Z",
+        "balance": 1.0578770802484123e+26,
+        "block_height": 97991495,
+        "epoch_id": "HN8cpm6TLDYHScK4aN5TtkRB4DAmje8jCAn2UUjbyrWG",
+        "next_epoch_id": "475MQYzy2Sx86acsCAo9q58H3jDXUSMKXUA4GaWbDive",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5402676216775546e+22
+    },
+    {
+        "timestamp": "2023-08-02T18:10:39.979Z",
+        "balance": 1.0577230534862445e+26,
+        "block_height": 97929428,
+        "epoch_id": "4WpSuocLbFvTgFpt9Am8BsSwrKPymykXZqtnakkMBHRi",
+        "next_epoch_id": "HN8cpm6TLDYHScK4aN5TtkRB4DAmje8jCAn2UUjbyrWG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.303177315512941e+22
+    },
+    {
+        "timestamp": "2023-08-02T09:03:08.750Z",
+        "balance": 1.0575927357546932e+26,
+        "block_height": 97905095,
+        "epoch_id": "4VFLmmagNDBMWEaLU6pJx3uB5hykhqtdy7aezXx6rnz4",
+        "next_epoch_id": "4WpSuocLbFvTgFpt9Am8BsSwrKPymykXZqtnakkMBHRi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.327332535321382e+22
+    },
+    {
+        "timestamp": "2023-08-01T19:41:37.444Z",
+        "balance": 1.057460002501161e+26,
+        "block_height": 97861895,
+        "epoch_id": "8aGPHV3DLmqcZYhGztJZVriL8uEJDmMXreL9M1GboARb",
+        "next_epoch_id": "4VFLmmagNDBMWEaLU6pJx3uB5hykhqtdy7aezXx6rnz4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3257029641513428e+22
+    },
+    {
+        "timestamp": "2023-08-01T06:05:36.357Z",
+        "balance": 1.057327432204746e+26,
+        "block_height": 97818695,
+        "epoch_id": "4Kgkx1FBg1PmpFDhf47z9VkmwNGmKj5yhvgqEYepLrvH",
+        "next_epoch_id": "8aGPHV3DLmqcZYhGztJZVriL8uEJDmMXreL9M1GboARb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3228780512477914e+22
+    },
+    {
+        "timestamp": "2023-07-31T16:35:16.799Z",
+        "balance": 1.0571951443996212e+26,
+        "block_height": 97775495,
+        "epoch_id": "BeairHWLBmt8Y1ezZWhL96Zft8TpHKTuwezCV3pPzp7t",
+        "next_epoch_id": "4Kgkx1FBg1PmpFDhf47z9VkmwNGmKj5yhvgqEYepLrvH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3104038149719268e+22
+    },
+    {
+        "timestamp": "2023-07-31T03:06:14.685Z",
+        "balance": 1.057064104018124e+26,
+        "block_height": 97732295,
+        "epoch_id": "8qTVTm4q2XK1oaABrJKi364skXToyBVDttzgp1qFNLJB",
+        "next_epoch_id": "BeairHWLBmt8Y1ezZWhL96Zft8TpHKTuwezCV3pPzp7t",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3038616176559049e+22
+    },
+    {
+        "timestamp": "2023-07-30T13:45:38.786Z",
+        "balance": 1.0569337178563584e+26,
+        "block_height": 97689095,
+        "epoch_id": "9JrnFmZrMmTMSaxk63NCJSxr8caVZPmKdCuFoLcPPRRm",
+        "next_epoch_id": "8qTVTm4q2XK1oaABrJKi364skXToyBVDttzgp1qFNLJB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3138500091146223e+22
+    },
+    {
+        "timestamp": "2023-07-30T00:27:59.991Z",
+        "balance": 1.0568023328554469e+26,
+        "block_height": 97645895,
+        "epoch_id": "6tBSLkmvnVZDLh5U3kgbjXRQmgvXz3DhVL1k39FtvK6U",
+        "next_epoch_id": "9JrnFmZrMmTMSaxk63NCJSxr8caVZPmKdCuFoLcPPRRm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3712213716825924e+22
+    },
+    {
+        "timestamp": "2023-07-29T11:03:28.657Z",
+        "balance": 1.0566652107182787e+26,
+        "block_height": 97602695,
+        "epoch_id": "7appb59vhAmdn7qNdnYjkZyHcAEQgNs15UCbc2yk3E2V",
+        "next_epoch_id": "6tBSLkmvnVZDLh5U3kgbjXRQmgvXz3DhVL1k39FtvK6U",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3952675356451124e+22
+    },
+    {
+        "timestamp": "2023-07-28T18:52:13.241Z",
+        "balance": 1.0565256839647141e+26,
+        "block_height": 97550394,
+        "epoch_id": "9MxJA9FxdnJAuksShU87omdfRBRVSrTKeHiVrXYkCQkB",
+        "next_epoch_id": "7appb59vhAmdn7qNdnYjkZyHcAEQgNs15UCbc2yk3E2V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3874983415132216e+22
+    },
+    {
+        "timestamp": "2023-07-28T08:13:22.367Z",
+        "balance": 1.0563869341305628e+26,
+        "block_height": 97516295,
+        "epoch_id": "9K1wjQFnxQGxgwg4io48CzegFTvJRaVd76oNX28X8yug",
+        "next_epoch_id": "9MxJA9FxdnJAuksShU87omdfRBRVSrTKeHiVrXYkCQkB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3989904779674667e+22
+    },
+    {
+        "timestamp": "2023-07-27T18:51:16.454Z",
+        "balance": 1.056247035082766e+26,
+        "block_height": 97473095,
+        "epoch_id": "12t1en4ptFywv3criNhG3ARvtEWrWNudJqccRUU7sK5L",
+        "next_epoch_id": "9K1wjQFnxQGxgwg4io48CzegFTvJRaVd76oNX28X8yug",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3976145833301773e+22
+    },
+    {
+        "timestamp": "2023-07-27T05:23:18.464Z",
+        "balance": 1.056107273624433e+26,
+        "block_height": 97429895,
+        "epoch_id": "5Zr4JP7Gky6ie7NyGJPtMHsHPKJK8JjYfyPJDiFaEJP",
+        "next_epoch_id": "12t1en4ptFywv3criNhG3ARvtEWrWNudJqccRUU7sK5L",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4297276013413086e+22
+    },
+    {
+        "timestamp": "2023-07-26T15:53:21.849Z",
+        "balance": 1.055964300864299e+26,
+        "block_height": 97386695,
+        "epoch_id": "FgPi74FdgS4swH5PVbe1ripFqYPZ6oFjUR8MREs49VMi",
+        "next_epoch_id": "5Zr4JP7Gky6ie7NyGJPtMHsHPKJK8JjYfyPJDiFaEJP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4043528346573193e+22
+    },
+    {
+        "timestamp": "2023-07-26T02:11:45.170Z",
+        "balance": 1.0558238655808332e+26,
+        "block_height": 97343495,
+        "epoch_id": "22rUR8e8nHNGioWtJkhG4bT4ZEpmX5reYPKbuhwVTWC3",
+        "next_epoch_id": "FgPi74FdgS4swH5PVbe1ripFqYPZ6oFjUR8MREs49VMi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3935148090675633e+22
+    },
+    {
+        "timestamp": "2023-07-25T12:44:27.242Z",
+        "balance": 1.0556845140999264e+26,
+        "block_height": 97300295,
+        "epoch_id": "7k6PBNQ3A9e127Ms9eoeihGqyx5C2fzqKFwM7MM2KvxA",
+        "next_epoch_id": "22rUR8e8nHNGioWtJkhG4bT4ZEpmX5reYPKbuhwVTWC3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4012243611103284e+22
+    },
+    {
+        "timestamp": "2023-07-24T23:22:29.730Z",
+        "balance": 1.0555443916638154e+26,
+        "block_height": 97257095,
+        "epoch_id": "DnwDhLXtAWZqCDbHxAggtbW42j1iVHU77E29tcNhAMS7",
+        "next_epoch_id": "7k6PBNQ3A9e127Ms9eoeihGqyx5C2fzqKFwM7MM2KvxA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3957077728166094e+22
+    },
+    {
+        "timestamp": "2023-07-24T09:56:30.359Z",
+        "balance": 1.0554048208865337e+26,
+        "block_height": 97213895,
+        "epoch_id": "AwAEE7VvXtRVMjisivVJmdhuqmbNbL45d9gR3nY9PNRd",
+        "next_epoch_id": "DnwDhLXtAWZqCDbHxAggtbW42j1iVHU77E29tcNhAMS7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4081271239854302e+22
+    },
+    {
+        "timestamp": "2023-07-23T20:34:06.583Z",
+        "balance": 1.0552640081741352e+26,
+        "block_height": 97170695,
+        "epoch_id": "HjmGaEGNocC641htyJgJqnnbfo5V1dvgybH5ayko9whU",
+        "next_epoch_id": "AwAEE7VvXtRVMjisivVJmdhuqmbNbL45d9gR3nY9PNRd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4135418946144812e+22
+    },
+    {
+        "timestamp": "2023-07-23T07:05:09.977Z",
+        "balance": 1.0551226539846738e+26,
+        "block_height": 97127495,
+        "epoch_id": "8czQ2o1aSHVtftHUHhnwwj3a5vX8ERzemS2AyeAhE4fT",
+        "next_epoch_id": "HjmGaEGNocC641htyJgJqnnbfo5V1dvgybH5ayko9whU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4141694450129468e+22
+    },
+    {
+        "timestamp": "2023-07-22T10:18:16.077Z",
+        "balance": 1.0549812370401725e+26,
+        "block_height": 97061370,
+        "epoch_id": "u1vhZ44ybxbf8TvS9oE4HZnq8Yh74R42VKSBW4o54eA",
+        "next_epoch_id": "8czQ2o1aSHVtftHUHhnwwj3a5vX8ERzemS2AyeAhE4fT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4006370294522014e+22
+    },
+    {
+        "timestamp": "2023-07-22T03:58:53.420Z",
+        "balance": 1.0548411733372272e+26,
+        "block_height": 97041095,
+        "epoch_id": "8fsjJpuszoY3ArfhGvbpJPEj6VV9QfRY29Y7dagGZKmZ",
+        "next_epoch_id": "u1vhZ44ybxbf8TvS9oE4HZnq8Yh74R42VKSBW4o54eA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3368605810871186e+22
+    },
+    {
+        "timestamp": "2023-07-21T14:32:39.994Z",
+        "balance": 1.0547074872791185e+26,
+        "block_height": 96997895,
+        "epoch_id": "HN1pppK3yMNXTYQ1cdQMPftTPsrGLutKsn5P1Ho4b5vt",
+        "next_epoch_id": "8fsjJpuszoY3ArfhGvbpJPEj6VV9QfRY29Y7dagGZKmZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2332774888398058e+22
+    },
+    {
+        "timestamp": "2023-07-21T01:11:11.050Z",
+        "balance": 1.0545841595302345e+26,
+        "block_height": 96954695,
+        "epoch_id": "J9LdeJd22Sccxf8uSV15EPSB3MsrpToW4dMRHP7sYGhU",
+        "next_epoch_id": "HN1pppK3yMNXTYQ1cdQMPftTPsrGLutKsn5P1Ho4b5vt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3997999060850137e+22
+    },
+    {
+        "timestamp": "2023-07-20T11:23:28.557Z",
+        "balance": 1.054444179539626e+26,
+        "block_height": 96910488,
+        "epoch_id": "C34mTetDSGWXiDkDfd6nEf6zH3Q2rQMnzowvVrx2ZbjB",
+        "next_epoch_id": "J9LdeJd22Sccxf8uSV15EPSB3MsrpToW4dMRHP7sYGhU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4152983493318764e+22
+    },
+    {
+        "timestamp": "2023-07-19T22:16:02.336Z",
+        "balance": 1.0543026497046929e+26,
+        "block_height": 96868295,
+        "epoch_id": "6ZU5JMm1cwsTmDQSD1gNxiMXQgJuct3gbVMMjXg2HdLp",
+        "next_epoch_id": "C34mTetDSGWXiDkDfd6nEf6zH3Q2rQMnzowvVrx2ZbjB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.395655036327085e+22
+    },
+    {
+        "timestamp": "2023-07-19T08:41:24.244Z",
+        "balance": 1.0541630842010601e+26,
+        "block_height": 96825095,
+        "epoch_id": "E9aR677vWBmjVch7rY95oVQbHAf6eatwEPktzD77pLGW",
+        "next_epoch_id": "6ZU5JMm1cwsTmDQSD1gNxiMXQgJuct3gbVMMjXg2HdLp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.370393963179241e+22
+    },
+    {
+        "timestamp": "2023-07-18T19:19:04.152Z",
+        "balance": 1.0540260448047422e+26,
+        "block_height": 96781895,
+        "epoch_id": "ARM7YfXgAgdernetnWtHscu8Nw19spSEAWARSFAjCwxm",
+        "next_epoch_id": "E9aR677vWBmjVch7rY95oVQbHAf6eatwEPktzD77pLGW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.428830151569574e+22
+    },
+    {
+        "timestamp": "2023-07-18T05:09:08.232Z",
+        "balance": 1.0538831617895853e+26,
+        "block_height": 96736455,
+        "epoch_id": "4q2ipMr4nQQfexmEzdinhjRE92SKSsFTYwAm5cDUKNDY",
+        "next_epoch_id": "ARM7YfXgAgdernetnWtHscu8Nw19spSEAWARSFAjCwxm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4326036080571405e+22
+    },
+    {
+        "timestamp": "2023-07-17T16:09:42.390Z",
+        "balance": 1.0537399014287796e+26,
+        "block_height": 96695495,
+        "epoch_id": "7p1S4pYHKStuGeRDsH58AstgC1nuBoR58uJmwE4khS5N",
+        "next_epoch_id": "4q2ipMr4nQQfexmEzdinhjRE92SKSsFTYwAm5cDUKNDY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.88553990347526e+22
+    },
+    {
+        "timestamp": "2023-07-16T15:50:53.449Z",
+        "balance": 1.053551347438432e+26,
+        "block_height": 96618049,
+        "epoch_id": "FV1doHy8zZv2znLYSdw1YDyeQPsyGqA1FmE3XkG2Th1n",
+        "next_epoch_id": "7p1S4pYHKStuGeRDsH58AstgC1nuBoR58uJmwE4khS5N",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8831283026293047e+22
+    },
+    {
+        "timestamp": "2023-07-16T13:03:02.608Z",
+        "balance": 1.0533630346081691e+26,
+        "block_height": 96609095,
+        "epoch_id": "6Tiwj36A5PQjibqG1vykEEzHa6ATG6qd5MhAGpG53g7j",
+        "next_epoch_id": "FV1doHy8zZv2znLYSdw1YDyeQPsyGqA1FmE3XkG2Th1n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4012639410309753e+22
+    },
+    {
+        "timestamp": "2023-07-15T23:39:58.636Z",
+        "balance": 1.053222908214066e+26,
+        "block_height": 96565895,
+        "epoch_id": "2rvJXida3G6LQ1uB3zubN1XavoHEGe3Hhwyzx8yySskf",
+        "next_epoch_id": "6Tiwj36A5PQjibqG1vykEEzHa6ATG6qd5MhAGpG53g7j",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.401443062913497e+22
+    },
+    {
+        "timestamp": "2023-07-15T06:38:30.141Z",
+        "balance": 1.0530827639077746e+26,
+        "block_height": 96511157,
+        "epoch_id": "F1aJs24CqYA1fu2NJs3xeLa4zmDe5BYWJ8YURPa2AnRD",
+        "next_epoch_id": "2rvJXida3G6LQ1uB3zubN1XavoHEGe3Hhwyzx8yySskf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.385534943061772e+22
+    },
+    {
+        "timestamp": "2023-07-14T20:47:09.648Z",
+        "balance": 1.0529442104134685e+26,
+        "block_height": 96479495,
+        "epoch_id": "6gxVz7mV7SxughMjh7VQ5tqxTYWh1fHpVEZ7mt3t313X",
+        "next_epoch_id": "F1aJs24CqYA1fu2NJs3xeLa4zmDe5BYWJ8YURPa2AnRD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.39593744158684e+22
+    },
+    {
+        "timestamp": "2023-07-14T07:20:31.125Z",
+        "balance": 1.0528046166693098e+26,
+        "block_height": 96436295,
+        "epoch_id": "FQDnstBdj7WoJxhof3jYAdXEtSR5F6xhasV9BSAbNiHV",
+        "next_epoch_id": "6gxVz7mV7SxughMjh7VQ5tqxTYWh1fHpVEZ7mt3t313X",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4019819713304944e+22
+    },
+    {
+        "timestamp": "2023-07-13T17:15:50.639Z",
+        "balance": 1.0526644184721767e+26,
+        "block_height": 96390912,
+        "epoch_id": "AnFNPP1FPyuGZHQjk5hfTEBhzDRcoJN6noEJ4s8tgX9x",
+        "next_epoch_id": "FQDnstBdj7WoJxhof3jYAdXEtSR5F6xhasV9BSAbNiHV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4072607429831946e+22
+    },
+    {
+        "timestamp": "2023-07-13T04:27:41.995Z",
+        "balance": 1.0525236923978784e+26,
+        "block_height": 96349895,
+        "epoch_id": "AcRbTn754y4GFXAK7whdisM5CdZKhD167XryG35u1JA2",
+        "next_epoch_id": "AnFNPP1FPyuGZHQjk5hfTEBhzDRcoJN6noEJ4s8tgX9x",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.395781791717771e+22
+    },
+    {
+        "timestamp": "2023-07-12T12:09:14.864Z",
+        "balance": 1.0523841142187066e+26,
+        "block_height": 96297799,
+        "epoch_id": "5ubZ8bcMKfxf73MEdmAECVnwMK4DEraitLBGv51DAXCi",
+        "next_epoch_id": "AcRbTn754y4GFXAK7whdisM5CdZKhD167XryG35u1JA2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3966386855152068e+22
+    },
+    {
+        "timestamp": "2023-07-12T01:34:04.214Z",
+        "balance": 1.0522444503501551e+26,
+        "block_height": 96263495,
+        "epoch_id": "3jv3vJZwj1QRff1zc3bVmsBioF9EvGiGfjiGaLieXD8z",
+        "next_epoch_id": "5ubZ8bcMKfxf73MEdmAECVnwMK4DEraitLBGv51DAXCi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4116010049871184e+22
+    },
+    {
+        "timestamp": "2023-07-11T11:57:19.696Z",
+        "balance": 1.0521032902496564e+26,
+        "block_height": 96220295,
+        "epoch_id": "9iTVrcwp9ozw3aqoZef48tSV1EehCopP6vvyTeeaQQp9",
+        "next_epoch_id": "3jv3vJZwj1QRff1zc3bVmsBioF9EvGiGfjiGaLieXD8z",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.402047827094836e+22
+    },
+    {
+        "timestamp": "2023-07-10T22:20:42.384Z",
+        "balance": 1.051963085466947e+26,
+        "block_height": 96177095,
+        "epoch_id": "D2eU4ZhJcCtK3N6jGhUcj6ARQWRKuPdg46iaj4ZV4MyN",
+        "next_epoch_id": "9iTVrcwp9ozw3aqoZef48tSV1EehCopP6vvyTeeaQQp9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3898534303219575e+22
+    },
+    {
+        "timestamp": "2023-07-10T08:50:04.800Z",
+        "balance": 1.0518241001239147e+26,
+        "block_height": 96133895,
+        "epoch_id": "A4HFnMw2ckQ3X9A98Rrga4hP8CzqTg4DtiYzUFyCTVYx",
+        "next_epoch_id": "D2eU4ZhJcCtK3N6jGhUcj6ARQWRKuPdg46iaj4ZV4MyN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4015239245891962e+22
+    },
+    {
+        "timestamp": "2023-07-09T19:26:37.795Z",
+        "balance": 1.0516839477314558e+26,
+        "block_height": 96090695,
+        "epoch_id": "4Y3tfnoNyZpTRvvAxQ51AjjJ9C85pWbb2mcAnLjte1cf",
+        "next_epoch_id": "A4HFnMw2ckQ3X9A98Rrga4hP8CzqTg4DtiYzUFyCTVYx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.417645685992649e+22
+    },
+    {
+        "timestamp": "2023-07-08T17:59:27.679Z",
+        "balance": 1.0515421831628565e+26,
+        "block_height": 96009929,
+        "epoch_id": "G8S1ivZEzEwZwkPD6ZasHAomrpjHz6uiM4RWn9mSCMSQ",
+        "next_epoch_id": "4Y3tfnoNyZpTRvvAxQ51AjjJ9C85pWbb2mcAnLjte1cf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.391660316718859e+22
+    },
+    {
+        "timestamp": "2023-07-08T16:14:46.128Z",
+        "balance": 1.0514030171311847e+26,
+        "block_height": 96004295,
+        "epoch_id": "4sLyVWca5HCv77daRmwGL9pNTRm8ZCSfr2HhFev4kaY2",
+        "next_epoch_id": "G8S1ivZEzEwZwkPD6ZasHAomrpjHz6uiM4RWn9mSCMSQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3868708956834657e+22
+    },
+    {
+        "timestamp": "2023-07-08T02:51:01.912Z",
+        "balance": 1.0512643300416163e+26,
+        "block_height": 95961095,
+        "epoch_id": "2z5shiFjhpUHKUgE79J3qxgyQrTZHwQVSJJ4wMvetq6i",
+        "next_epoch_id": "4sLyVWca5HCv77daRmwGL9pNTRm8ZCSfr2HhFev4kaY2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3899528928344368e+22
+    },
+    {
+        "timestamp": "2023-07-07T05:09:34.748Z",
+        "balance": 1.0511253347523329e+26,
+        "block_height": 95891103,
+        "epoch_id": "jRZdRPTSGuVvesj4TEMcd6bUEp8BK5eU8BS5Jtx1rPv",
+        "next_epoch_id": "2z5shiFjhpUHKUgE79J3qxgyQrTZHwQVSJJ4wMvetq6i",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3950500877250041e+22
+    },
+    {
+        "timestamp": "2023-07-07T00:06:29.458Z",
+        "balance": 1.0509858297435604e+26,
+        "block_height": 95874695,
+        "epoch_id": "2bWW8xbB5Tcs4WNZUkyP2ep27T2nzAr8mTKzKX4WEc3a",
+        "next_epoch_id": "jRZdRPTSGuVvesj4TEMcd6bUEp8BK5eU8BS5Jtx1rPv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.379340216167729e+22
+    },
+    {
+        "timestamp": "2023-07-06T10:38:20.979Z",
+        "balance": 1.0508478957219436e+26,
+        "block_height": 95831495,
+        "epoch_id": "3HazcyGQPpqoFivhuFBgPmCKDZGveA6wSGumxGcBXsrB",
+        "next_epoch_id": "2bWW8xbB5Tcs4WNZUkyP2ep27T2nzAr8mTKzKX4WEc3a",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3964744175022005e+22
+    },
+    {
+        "timestamp": "2023-07-05T21:19:24.176Z",
+        "balance": 1.0507082482801934e+26,
+        "block_height": 95788295,
+        "epoch_id": "BaMztNk6GzcvJRZYdMRBnbi9Wq3F6sADAsha6SgBysvE",
+        "next_epoch_id": "3HazcyGQPpqoFivhuFBgPmCKDZGveA6wSGumxGcBXsrB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.37976727399156e+22
+    },
+    {
+        "timestamp": "2023-07-05T07:50:46.026Z",
+        "balance": 1.0505702715527942e+26,
+        "block_height": 95745095,
+        "epoch_id": "7Wk5kXbeUz7nG672x2xTGmyr86Fokxze8nZvJ7FAMvMJ",
+        "next_epoch_id": "BaMztNk6GzcvJRZYdMRBnbi9Wq3F6sADAsha6SgBysvE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.424765913612105e+22
+    },
+    {
+        "timestamp": "2023-07-04T18:31:09.599Z",
+        "balance": 1.050427794961433e+26,
+        "block_height": 95701895,
+        "epoch_id": "G4sdHjLcfYcKD32uCWJnhhb4fQp5mumpkLEAp7urrZjD",
+        "next_epoch_id": "7Wk5kXbeUz7nG672x2xTGmyr86Fokxze8nZvJ7FAMvMJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3987998681022723e+22
+    },
+    {
+        "timestamp": "2023-07-04T04:43:44.428Z",
+        "balance": 1.0502879149746228e+26,
+        "block_height": 95658695,
+        "epoch_id": "7yLG4psegTTCDgp9iBb7GKkg3HdbYLRArQ7CEUcvrCE9",
+        "next_epoch_id": "G4sdHjLcfYcKD32uCWJnhhb4fQp5mumpkLEAp7urrZjD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4014663897089512e+22
+    },
+    {
+        "timestamp": "2023-07-03T15:12:27.902Z",
+        "balance": 1.0501477683356519e+26,
+        "block_height": 95615495,
+        "epoch_id": "tocHaBAYLkxKV8iNwYYSc8VgRgjxgvdV6ZNabbyXwkH",
+        "next_epoch_id": "7yLG4psegTTCDgp9iBb7GKkg3HdbYLRArQ7CEUcvrCE9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4182777044541825e+22
+    },
+    {
+        "timestamp": "2023-07-03T01:38:55.311Z",
+        "balance": 1.0500059405652065e+26,
+        "block_height": 95572295,
+        "epoch_id": "FMMmvkZzvAbQn94Dpw4uQE5uRXx9rKqp79uxtU9abAAJ",
+        "next_epoch_id": "tocHaBAYLkxKV8iNwYYSc8VgRgjxgvdV6ZNabbyXwkH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3950734628835081e+22
+    },
+    {
+        "timestamp": "2023-07-02T11:54:38.622Z",
+        "balance": 1.0498664332189181e+26,
+        "block_height": 95529095,
+        "epoch_id": "ES1jngLFuoLvu3n5ksuscCBxf7RskTypMpTKoMcDJTav",
+        "next_epoch_id": "FMMmvkZzvAbQn94Dpw4uQE5uRXx9rKqp79uxtU9abAAJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4277818665149535e+22
+    },
+    {
+        "timestamp": "2023-07-01T22:23:39.300Z",
+        "balance": 1.0497236550322666e+26,
+        "block_height": 95485895,
+        "epoch_id": "21Vxv51R3FTkoEqhP8Z2sBps81u9HshuJ7HZjAvwp5np",
+        "next_epoch_id": "ES1jngLFuoLvu3n5ksuscCBxf7RskTypMpTKoMcDJTav",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.412003716515672e+22
+    },
+    {
+        "timestamp": "2023-07-01T08:34:33.489Z",
+        "balance": 1.049582454660615e+26,
+        "block_height": 95442695,
+        "epoch_id": "A8bftA85dfCTewxH5hD8hago6egmFuFiw5MnsnjDcuvB",
+        "next_epoch_id": "21Vxv51R3FTkoEqhP8Z2sBps81u9HshuJ7HZjAvwp5np",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4281498560624436e+22
+    },
+    {
+        "timestamp": "2023-06-30T19:01:06.747Z",
+        "balance": 1.0494396396750088e+26,
+        "block_height": 95399495,
+        "epoch_id": "WVYZc9QxW3xKpEkrdDG4DQarKtsDXoedzCot78pfh1k",
+        "next_epoch_id": "A8bftA85dfCTewxH5hD8hago6egmFuFiw5MnsnjDcuvB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4113786610929145e+22
+    },
+    {
+        "timestamp": "2023-06-30T05:17:39.062Z",
+        "balance": 1.0492985018088995e+26,
+        "block_height": 95356295,
+        "epoch_id": "4eri1pe32asoUCi7k1nu2eim1D27qKMMnPz1zurgFd72",
+        "next_epoch_id": "WVYZc9QxW3xKpEkrdDG4DQarKtsDXoedzCot78pfh1k",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4219257093725673e+22
+    },
+    {
+        "timestamp": "2023-06-29T15:42:39.680Z",
+        "balance": 1.0491563092379623e+26,
+        "block_height": 95313095,
+        "epoch_id": "DF56SjKRrBBav2KU9qpMX6kiHW436q7gPN3iWfm4c5N2",
+        "next_epoch_id": "4eri1pe32asoUCi7k1nu2eim1D27qKMMnPz1zurgFd72",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4160378137069178e+22
+    },
+    {
+        "timestamp": "2023-06-28T19:24:40.656Z",
+        "balance": 1.0490147054565916e+26,
+        "block_height": 95248689,
+        "epoch_id": "Asw6fcztBJCbwzS1PThV7pEDUSJjR8cDdQytTJnFs22D",
+        "next_epoch_id": "DF56SjKRrBBav2KU9qpMX6kiHW436q7gPN3iWfm4c5N2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4044775936441268e+22
+    },
+    {
+        "timestamp": "2023-06-28T12:25:18.276Z",
+        "balance": 1.0488742576972272e+26,
+        "block_height": 95226695,
+        "epoch_id": "3V2ETyui4skDkJmmAEeWxGZbRCvXxs1ZWP6FXUKaQGrD",
+        "next_epoch_id": "Asw6fcztBJCbwzS1PThV7pEDUSJjR8cDdQytTJnFs22D",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3466483858547241e+22
+    },
+    {
+        "timestamp": "2023-06-27T22:53:58.397Z",
+        "balance": 1.0487395928586417e+26,
+        "block_height": 95183495,
+        "epoch_id": "AfG5H9Nujz5jW8Gh6LXwRpnzAX7zLc1yenujgXnjQqi9",
+        "next_epoch_id": "3V2ETyui4skDkJmmAEeWxGZbRCvXxs1ZWP6FXUKaQGrD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3966458858131302e+22
+    },
+    {
+        "timestamp": "2023-06-27T09:17:36.990Z",
+        "balance": 1.0485999282700604e+26,
+        "block_height": 95140295,
+        "epoch_id": "JBG7wKWDzAkcpU84bXvktjNvTh2f4R136j8K24fPvNW9",
+        "next_epoch_id": "AfG5H9Nujz5jW8Gh6LXwRpnzAX7zLc1yenujgXnjQqi9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4183814762671228e+22
+    },
+    {
+        "timestamp": "2023-06-26T19:49:30.662Z",
+        "balance": 1.0484580901224337e+26,
+        "block_height": 95097095,
+        "epoch_id": "3NtDSwiZyrK4jyM9vJA1wiMz5cNVaoWbkXcbbRLqSLU3",
+        "next_epoch_id": "JBG7wKWDzAkcpU84bXvktjNvTh2f4R136j8K24fPvNW9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3874561410320229e+22
+    },
+    {
+        "timestamp": "2023-06-26T06:09:38.870Z",
+        "balance": 1.0483193445083305e+26,
+        "block_height": 95053895,
+        "epoch_id": "8kawAuAzncMKtLXz3LGFsZXiArD61rTjfgkJ22Dh7Xqn",
+        "next_epoch_id": "3NtDSwiZyrK4jyM9vJA1wiMz5cNVaoWbkXcbbRLqSLU3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4032048719570257e+22
+    },
+    {
+        "timestamp": "2023-06-25T16:45:48.456Z",
+        "balance": 1.0481790240211348e+26,
+        "block_height": 95010695,
+        "epoch_id": "FBBb9doaEk4BYNNWSVfgYR96htsVN1474Y1rcyAayWZs",
+        "next_epoch_id": "8kawAuAzncMKtLXz3LGFsZXiArD61rTjfgkJ22Dh7Xqn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3949351617170694e+22
+    },
+    {
+        "timestamp": "2023-06-25T03:12:29.601Z",
+        "balance": 1.048039530504963e+26,
+        "block_height": 94967495,
+        "epoch_id": "DfsTWJQnY9k6Ytii1JEBtvJUna41UJQqas2KRsu3Wuxu",
+        "next_epoch_id": "FBBb9doaEk4BYNNWSVfgYR96htsVN1474Y1rcyAayWZs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3995753616608797e+22
+    },
+    {
+        "timestamp": "2023-06-24T13:42:00.276Z",
+        "balance": 1.047899572968797e+26,
+        "block_height": 94924295,
+        "epoch_id": "3gFJLxoLutQksv9UVVEyr8jwZGKYZjriceYaCWVF39pP",
+        "next_epoch_id": "DfsTWJQnY9k6Ytii1JEBtvJUna41UJQqas2KRsu3Wuxu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.421565543214522e+22
+    },
+    {
+        "timestamp": "2023-06-24T00:19:59.937Z",
+        "balance": 1.0477574164144755e+26,
+        "block_height": 94881095,
+        "epoch_id": "AmU92Z24VRJgGVZPinPVQYun4KZGr3apsBEHYr8A6PZy",
+        "next_epoch_id": "3gFJLxoLutQksv9UVVEyr8jwZGKYZjriceYaCWVF39pP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4066833769342486e+22
+    },
+    {
+        "timestamp": "2023-06-23T10:43:18.234Z",
+        "balance": 1.047616748076782e+26,
+        "block_height": 94837895,
+        "epoch_id": "Bm82mXPVxeh7RKggiBZZvVJCQvPgDR8ZAsZdGi2kRwqm",
+        "next_epoch_id": "AmU92Z24VRJgGVZPinPVQYun4KZGr3apsBEHYr8A6PZy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.381786137123248e+22
+    },
+    {
+        "timestamp": "2023-06-22T21:14:22.418Z",
+        "balance": 1.0474785694630698e+26,
+        "block_height": 94794695,
+        "epoch_id": "CYRuXWyBuu9RxZtqxNXgeRWCqxrVP5qMeExRnb2agg63",
+        "next_epoch_id": "Bm82mXPVxeh7RKggiBZZvVJCQvPgDR8ZAsZdGi2kRwqm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3978919430874093e+22
+    },
+    {
+        "timestamp": "2023-06-22T07:40:50.200Z",
+        "balance": 1.047338780268761e+26,
+        "block_height": 94751495,
+        "epoch_id": "8JJMziTHhGiRUek9smAxJoHkyoFsu3mEf7gbLytanZHe",
+        "next_epoch_id": "CYRuXWyBuu9RxZtqxNXgeRWCqxrVP5qMeExRnb2agg63",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3929635180176153e+22
+    },
+    {
+        "timestamp": "2023-06-21T18:17:52.563Z",
+        "balance": 1.0471994839169593e+26,
+        "block_height": 94708295,
+        "epoch_id": "EkvVLWmme9WRkMQonaQ6YWMqECkupVoc9p3dUsc1xVAd",
+        "next_epoch_id": "8JJMziTHhGiRUek9smAxJoHkyoFsu3mEf7gbLytanZHe",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4186203006328822e+22
+    },
+    {
+        "timestamp": "2023-06-21T04:29:57.465Z",
+        "balance": 1.047057621886896e+26,
+        "block_height": 94665095,
+        "epoch_id": "KXFdMGBEKrW9eKnTxak8ykU4hxPedZuqNV5MHBsz7TW",
+        "next_epoch_id": "EkvVLWmme9WRkMQonaQ6YWMqECkupVoc9p3dUsc1xVAd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4261693494402761e+22
+    },
+    {
+        "timestamp": "2023-06-20T14:53:50.406Z",
+        "balance": 1.046915004951952e+26,
+        "block_height": 94621895,
+        "epoch_id": "5m3jHDuGHB9rFyE164s1UVeZNajep76ue4i9TRWixG8q",
+        "next_epoch_id": "KXFdMGBEKrW9eKnTxak8ykU4hxPedZuqNV5MHBsz7TW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4409109813944553e+22
+    },
+    {
+        "timestamp": "2023-06-20T01:15:00.518Z",
+        "balance": 1.0467709138538125e+26,
+        "block_height": 94578695,
+        "epoch_id": "FX3gZ3SYgaiEDSJKme6u1Gns1UKotyCg6yi3i1KXqgp6",
+        "next_epoch_id": "5m3jHDuGHB9rFyE164s1UVeZNajep76ue4i9TRWixG8q",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.414004200913647e+22
+    },
+    {
+        "timestamp": "2023-06-19T11:29:01.989Z",
+        "balance": 1.0466295134337211e+26,
+        "block_height": 94535495,
+        "epoch_id": "8LSXbhpJN78m1whnttKZtqBp7FYFQNcmSjay42pNLQ7V",
+        "next_epoch_id": "FX3gZ3SYgaiEDSJKme6u1Gns1UKotyCg6yi3i1KXqgp6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.420000351511742e+22
+    },
+    {
+        "timestamp": "2023-06-18T21:56:50.046Z",
+        "balance": 1.04648751339857e+26,
+        "block_height": 94492295,
+        "epoch_id": "2AGkZkGRUpQrUc2zHBUijyHbCZfAYejpfnDp7aVwcL7q",
+        "next_epoch_id": "8LSXbhpJN78m1whnttKZtqBp7FYFQNcmSjay42pNLQ7V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4123965892293514e+22
+    },
+    {
+        "timestamp": "2023-06-18T08:20:48.143Z",
+        "balance": 1.046346273739647e+26,
+        "block_height": 94449095,
+        "epoch_id": "4smLJYpw61FyErnom8EvmSEhR37aWrkjtfD47bcUa97h",
+        "next_epoch_id": "2AGkZkGRUpQrUc2zHBUijyHbCZfAYejpfnDp7aVwcL7q",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4601301576960608e+22
+    },
+    {
+        "timestamp": "2023-06-17T18:16:31.353Z",
+        "balance": 1.0462002607238774e+26,
+        "block_height": 94404052,
+        "epoch_id": "885SYjPabFBYZwcA3WQK5dVBYHxN3XjkoT8tiS3RKojS",
+        "next_epoch_id": "4smLJYpw61FyErnom8EvmSEhR37aWrkjtfD47bcUa97h",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4335416119391582e+22
+    },
+    {
+        "timestamp": "2023-06-17T05:01:30.067Z",
+        "balance": 1.0460569065626835e+26,
+        "block_height": 94362695,
+        "epoch_id": "5gWLofLUhoAmPLydzj22K9ojeRkhf14gSfyy29TLBiLQ",
+        "next_epoch_id": "885SYjPabFBYZwcA3WQK5dVBYHxN3XjkoT8tiS3RKojS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5134106821516046e+22
+    },
+    {
+        "timestamp": "2023-06-16T15:21:18.913Z",
+        "balance": 1.0459055654944683e+26,
+        "block_height": 94319495,
+        "epoch_id": "BW45iZ1kmz83KoKbWxB8SkdmQfff9TUaxG6aPMFAKqVv",
+        "next_epoch_id": "5gWLofLUhoAmPLydzj22K9ojeRkhf14gSfyy29TLBiLQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3453369166820754e+22
+    },
+    {
+        "timestamp": "2023-06-16T00:55:37.895Z",
+        "balance": 1.0457710318028001e+26,
+        "block_height": 94276295,
+        "epoch_id": "BmwPw3NdZRyf2KXQSfXGQ81F8vuY2eyQs7ZPK7pp8weU",
+        "next_epoch_id": "BW45iZ1kmz83KoKbWxB8SkdmQfff9TUaxG6aPMFAKqVv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 9.67831388628534e+21
+    },
+    {
+        "timestamp": "2023-06-15T09:44:49.987Z",
+        "balance": 1.0456742486639373e+26,
+        "block_height": 94233095,
+        "epoch_id": "B7JKGZEjuLXBqm8WHAWYG2QNMZaPfzDEa5CXCZZRcpaQ",
+        "next_epoch_id": "BmwPw3NdZRyf2KXQSfXGQ81F8vuY2eyQs7ZPK7pp8weU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.481416508988238e+22
+    },
+    {
+        "timestamp": "2023-06-14T16:28:50.234Z",
+        "balance": 1.0455261070130385e+26,
+        "block_height": 94189895,
+        "epoch_id": "6MeENtVMmfzgW9xu3bDKXqffTH5ztkkqhucQTkidcG2L",
+        "next_epoch_id": "B7JKGZEjuLXBqm8WHAWYG2QNMZaPfzDEa5CXCZZRcpaQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5544183368613257e+22
+    },
+    {
+        "timestamp": "2023-06-14T00:46:37.370Z",
+        "balance": 1.0453706651793523e+26,
+        "block_height": 94146695,
+        "epoch_id": "6HCSZVZP5qqh26cjfAXoeivZVzEGChrwKYNPPybC5WSg",
+        "next_epoch_id": "6MeENtVMmfzgW9xu3bDKXqffTH5ztkkqhucQTkidcG2L",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4393075428979531e+22
+    },
+    {
+        "timestamp": "2023-06-13T08:46:29.277Z",
+        "balance": 1.0452267344250625e+26,
+        "block_height": 94103495,
+        "epoch_id": "9PL1SQfjoJGeEw7XiUnXGRWxhKxcxJM9fFLpSu3dd2vq",
+        "next_epoch_id": "6HCSZVZP5qqh26cjfAXoeivZVzEGChrwKYNPPybC5WSg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.461008081878171e+22
+    },
+    {
+        "timestamp": "2023-06-12T19:17:07.846Z",
+        "balance": 1.0450806336168747e+26,
+        "block_height": 94060295,
+        "epoch_id": "HkcBgUjzYUR83tmqmRUJtCEqsYG47ECN2RG18hKYEV4J",
+        "next_epoch_id": "9PL1SQfjoJGeEw7XiUnXGRWxhKxcxJM9fFLpSu3dd2vq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4199592106556687e+22
+    },
+    {
+        "timestamp": "2023-06-12T05:19:21.998Z",
+        "balance": 1.0449386376958091e+26,
+        "block_height": 94017095,
+        "epoch_id": "9sAN9vwKjxC8Tz1Xpy9AAuXSmP9MAnSd8fULfhwioWu8",
+        "next_epoch_id": "HkcBgUjzYUR83tmqmRUJtCEqsYG47ECN2RG18hKYEV4J",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4514927730681608e+22
+    },
+    {
+        "timestamp": "2023-06-11T15:44:23.115Z",
+        "balance": 1.0447934884185023e+26,
+        "block_height": 93973895,
+        "epoch_id": "5zyz6LqDh9fiAW3wM3bTasHJrZJ2cGPVFUTKJ4D8U5Wp",
+        "next_epoch_id": "9sAN9vwKjxC8Tz1Xpy9AAuXSmP9MAnSd8fULfhwioWu8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.429625925331534e+22
+    },
+    {
+        "timestamp": "2023-06-11T01:53:25.404Z",
+        "balance": 1.0446505258259692e+26,
+        "block_height": 93930695,
+        "epoch_id": "H6YfyjPPuPWWEMzg3qF5JfzGXJpn61RN9AFszHfZUQeJ",
+        "next_epoch_id": "5zyz6LqDh9fiAW3wM3bTasHJrZJ2cGPVFUTKJ4D8U5Wp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4119912088630955e+22
+    },
+    {
+        "timestamp": "2023-06-10T12:14:27.660Z",
+        "balance": 1.0445093267050829e+26,
+        "block_height": 93887495,
+        "epoch_id": "5a6s7gGMQGifmWVnGMER5fbKm3LXLu4dVMtnpgKSz9cS",
+        "next_epoch_id": "H6YfyjPPuPWWEMzg3qF5JfzGXJpn61RN9AFszHfZUQeJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.448120146681544e+22
+    },
+    {
+        "timestamp": "2023-06-09T14:39:41.429Z",
+        "balance": 1.0443645146904147e+26,
+        "block_height": 93819163,
+        "epoch_id": "9ks2Q9jaufbH7e26XWmWqhe5q6LJgAqU49nSnWMQMuLi",
+        "next_epoch_id": "5a6s7gGMQGifmWVnGMER5fbKm3LXLu4dVMtnpgKSz9cS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4170131019182822e+22
+    },
+    {
+        "timestamp": "2023-06-09T08:54:31.086Z",
+        "balance": 1.0442228133802229e+26,
+        "block_height": 93801095,
+        "epoch_id": "qSZSoT3p5Q8DREuYCGUiEHb8JrS6qXq5LHykW6YuH5e",
+        "next_epoch_id": "9ks2Q9jaufbH7e26XWmWqhe5q6LJgAqU49nSnWMQMuLi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4158413045134457e+22
+    },
+    {
+        "timestamp": "2023-06-08T19:24:27.478Z",
+        "balance": 1.0440812292497715e+26,
+        "block_height": 93757895,
+        "epoch_id": "9CMyy7QdA6waKbYgDbyUzz7WhSw2JGmyjxVMZe2ZcMCq",
+        "next_epoch_id": "qSZSoT3p5Q8DREuYCGUiEHb8JrS6qXq5LHykW6YuH5e",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3786383817432065e+22
+    },
+    {
+        "timestamp": "2023-06-08T05:30:38.885Z",
+        "balance": 1.0439433654115972e+26,
+        "block_height": 93714695,
+        "epoch_id": "9W1otdjXFyGQiQ5ZgRqAJmAXu3aYsdL5j6AeaSeBSUbP",
+        "next_epoch_id": "9CMyy7QdA6waKbYgDbyUzz7WhSw2JGmyjxVMZe2ZcMCq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.45003263112866e+22
+    },
+    {
+        "timestamp": "2023-06-07T15:53:00.223Z",
+        "balance": 1.0437983621484843e+26,
+        "block_height": 93671495,
+        "epoch_id": "BsLxRSzUfWvVvG1MQmXhFjXBSg9Vz8UPYPGhUc2fbDEb",
+        "next_epoch_id": "9W1otdjXFyGQiQ5ZgRqAJmAXu3aYsdL5j6AeaSeBSUbP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4549516715265494e+22
+    },
+    {
+        "timestamp": "2023-06-07T02:05:02.045Z",
+        "balance": 1.0436528669813317e+26,
+        "block_height": 93628295,
+        "epoch_id": "D5WaMSKd66Jr9Nsw4ypb29Zdz7g7QrPqXx5tYFpM8aAo",
+        "next_epoch_id": "BsLxRSzUfWvVvG1MQmXhFjXBSg9Vz8UPYPGhUc2fbDEb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4414073358647535e+22
+    },
+    {
+        "timestamp": "2023-06-06T12:12:44.179Z",
+        "balance": 1.0435087262477452e+26,
+        "block_height": 93585095,
+        "epoch_id": "8eR9TFNrChLFtSDcztQxCGeA5MAgo2tpoxrPgDDvv51X",
+        "next_epoch_id": "D5WaMSKd66Jr9Nsw4ypb29Zdz7g7QrPqXx5tYFpM8aAo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.458197796408305e+22
+    },
+    {
+        "timestamp": "2023-06-05T22:26:34.734Z",
+        "balance": 1.0433629064681044e+26,
+        "block_height": 93541895,
+        "epoch_id": "9JKRH6b3YNgK7LSvcSm1K5G857BKhT7GHnYkwQqzoka3",
+        "next_epoch_id": "8eR9TFNrChLFtSDcztQxCGeA5MAgo2tpoxrPgDDvv51X",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4344488587786851e+22
+    },
+    {
+        "timestamp": "2023-06-05T08:33:15.518Z",
+        "balance": 1.0432194615822265e+26,
+        "block_height": 93498695,
+        "epoch_id": "AtPsUGUioyamaSzm2YAgFSDB9ZbBYJFoGfpw1HhV9NZZ",
+        "next_epoch_id": "9JKRH6b3YNgK7LSvcSm1K5G857BKhT7GHnYkwQqzoka3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4514382353191741e+22
+    },
+    {
+        "timestamp": "2023-06-04T18:53:11.404Z",
+        "balance": 1.0430743177586946e+26,
+        "block_height": 93455495,
+        "epoch_id": "Hm7dGAKZ9JyUP4tjWxPCQjjuokggHn4e4KmFxCAxhBgf",
+        "next_epoch_id": "AtPsUGUioyamaSzm2YAgFSDB9ZbBYJFoGfpw1HhV9NZZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4365679689828105e+22
+    },
+    {
+        "timestamp": "2023-06-04T05:02:59.472Z",
+        "balance": 1.0429306609617963e+26,
+        "block_height": 93412295,
+        "epoch_id": "ARrKH7m7wYZCHGkJbYqGQrJsb4s5DhoKNuprPv7X2n6t",
+        "next_epoch_id": "Hm7dGAKZ9JyUP4tjWxPCQjjuokggHn4e4KmFxCAxhBgf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.431595413672088e+22
+    },
+    {
+        "timestamp": "2023-06-03T15:21:49.259Z",
+        "balance": 1.0427875014204291e+26,
+        "block_height": 93369095,
+        "epoch_id": "8SwCVftduNMc98aLetE4BBqhK3Y6Y38vLzpinskBUhCj",
+        "next_epoch_id": "ARrKH7m7wYZCHGkJbYqGQrJsb4s5DhoKNuprPv7X2n6t",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4272465808324328e+22
+    },
+    {
+        "timestamp": "2023-06-03T01:43:22.518Z",
+        "balance": 1.0426447767623459e+26,
+        "block_height": 93325895,
+        "epoch_id": "CW1qVtq1kZD95WnAZ8ar9juPenGqf4Smas8WhEWcVUDU",
+        "next_epoch_id": "8SwCVftduNMc98aLetE4BBqhK3Y6Y38vLzpinskBUhCj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4229921723333841e+22
+    },
+    {
+        "timestamp": "2023-06-02T12:06:53.924Z",
+        "balance": 1.0425024775451125e+26,
+        "block_height": 93282695,
+        "epoch_id": "AiuFgRFgPh7t41mU9V6tSQnpejAnCnjMqAx9Sf4cVEbA",
+        "next_epoch_id": "CW1qVtq1kZD95WnAZ8ar9juPenGqf4Smas8WhEWcVUDU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4329920930373842e+22
+    },
+    {
+        "timestamp": "2023-06-01T22:30:03.996Z",
+        "balance": 1.0423591783358088e+26,
+        "block_height": 93239495,
+        "epoch_id": "34fF8W9FyBDJezT5rvVoyiYckwhbVbaGQQBuoFtRFqRA",
+        "next_epoch_id": "AiuFgRFgPh7t41mU9V6tSQnpejAnCnjMqAx9Sf4cVEbA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4401585652448851e+22
+    },
+    {
+        "timestamp": "2023-06-01T08:47:25.085Z",
+        "balance": 1.0422151624792843e+26,
+        "block_height": 93196295,
+        "epoch_id": "3kKD4fKgXRWAUqFmrgE6LXwivcSZUP1FkAhLSzfRdmNk",
+        "next_epoch_id": "34fF8W9FyBDJezT5rvVoyiYckwhbVbaGQQBuoFtRFqRA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.472835056631948e+22
+    },
+    {
+        "timestamp": "2023-05-31T19:03:16.667Z",
+        "balance": 1.0420678789736211e+26,
+        "block_height": 93153095,
+        "epoch_id": "D6cyJc97ZjLR8NJ3h2Aj8KpRCVR3sAxVMRVrcS26JZN7",
+        "next_epoch_id": "3kKD4fKgXRWAUqFmrgE6LXwivcSZUP1FkAhLSzfRdmNk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4217636780788855e+22
+    },
+    {
+        "timestamp": "2023-05-31T05:06:57.831Z",
+        "balance": 1.0419257026058132e+26,
+        "block_height": 93109895,
+        "epoch_id": "EPL23Ar1bvVjULauPNbD8MjB9eDtoN6Ji7kmvpQVhCpE",
+        "next_epoch_id": "D6cyJc97ZjLR8NJ3h2Aj8KpRCVR3sAxVMRVrcS26JZN7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4181291462908017e+22
+    },
+    {
+        "timestamp": "2023-05-30T15:34:08.215Z",
+        "balance": 1.0417838896911841e+26,
+        "block_height": 93066695,
+        "epoch_id": "DcBeKHFCeVcozQP2BLiD4pa41pfwk5Qmt9c7grcrGkTp",
+        "next_epoch_id": "EPL23Ar1bvVjULauPNbD8MjB9eDtoN6Ji7kmvpQVhCpE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.419066072012333e+22
+    },
+    {
+        "timestamp": "2023-05-30T01:58:30.472Z",
+        "balance": 1.0416419830839829e+26,
+        "block_height": 93023495,
+        "epoch_id": "DqwZxZzNyedqXTz1aEHfseUr3wRBqav5HgV4WM2Xdjf1",
+        "next_epoch_id": "DcBeKHFCeVcozQP2BLiD4pa41pfwk5Qmt9c7grcrGkTp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4054838611814373e+22
+    },
+    {
+        "timestamp": "2023-05-29T12:21:53.906Z",
+        "balance": 1.0415014346978648e+26,
+        "block_height": 92980295,
+        "epoch_id": "CUVfDMumWHyJw2PizMzeyvGVnau2YyvvvTaNzEwgMmiP",
+        "next_epoch_id": "DqwZxZzNyedqXTz1aEHfseUr3wRBqav5HgV4WM2Xdjf1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4075951597059167e+22
+    },
+    {
+        "timestamp": "2023-05-28T22:50:55.085Z",
+        "balance": 1.0413606751818942e+26,
+        "block_height": 92937095,
+        "epoch_id": "GoEQdvP6cyjRG5BgoZvTNetdz71HXocr4WEk2pwLnyLd",
+        "next_epoch_id": "CUVfDMumWHyJw2PizMzeyvGVnau2YyvvvTaNzEwgMmiP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.414956729528092e+22
+    },
+    {
+        "timestamp": "2023-05-28T07:28:57.317Z",
+        "balance": 1.0412191795089414e+26,
+        "block_height": 92888046,
+        "epoch_id": "8B9oY9yWzRtdjkA3vrykqyLqK13TkTCyYEjCMGqwm6eL",
+        "next_epoch_id": "GoEQdvP6cyjRG5BgoZvTNetdz71HXocr4WEk2pwLnyLd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4170997592400306e+22
+    },
+    {
+        "timestamp": "2023-05-27T19:41:52.000Z",
+        "balance": 1.0410774695330174e+26,
+        "block_height": 92850695,
+        "epoch_id": "2XQVEh6YG1DergPk89PNBQdMQpFZG51iqrA66q43392Q",
+        "next_epoch_id": "8B9oY9yWzRtdjkA3vrykqyLqK13TkTCyYEjCMGqwm6eL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.426497241142167e+22
+    },
+    {
+        "timestamp": "2023-05-27T06:04:27.399Z",
+        "balance": 1.0409348198089031e+26,
+        "block_height": 92807495,
+        "epoch_id": "AcySQ4RQTqSHu5nScK67GgRDjjbWhi8hyhTZgonA6qMX",
+        "next_epoch_id": "2XQVEh6YG1DergPk89PNBQdMQpFZG51iqrA66q43392Q",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4425983357522608e+22
+    },
+    {
+        "timestamp": "2023-05-26T16:21:58.805Z",
+        "balance": 1.040790559975328e+26,
+        "block_height": 92764295,
+        "epoch_id": "5bPr9rQ8mUMMbhLgFYKAayEaiNYvK1zmDPLS6ckrF1pf",
+        "next_epoch_id": "AcySQ4RQTqSHu5nScK67GgRDjjbWhi8hyhTZgonA6qMX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4271251756429938e+22
+    },
+    {
+        "timestamp": "2023-05-26T02:32:12.163Z",
+        "balance": 1.0406478474577636e+26,
+        "block_height": 92721095,
+        "epoch_id": "2cnffWh3oFhCCFHxcSQFunmrQVszuqeqXQxFdxcxzd57",
+        "next_epoch_id": "5bPr9rQ8mUMMbhLgFYKAayEaiNYvK1zmDPLS6ckrF1pf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4182035008127337e+22
+    },
+    {
+        "timestamp": "2023-05-25T12:54:18.207Z",
+        "balance": 1.0405060271076823e+26,
+        "block_height": 92677895,
+        "epoch_id": "48hgmZ6mg1y2dHVfir2t8V26bWsSsNUHkW8AVQjVayGP",
+        "next_epoch_id": "2cnffWh3oFhCCFHxcSQFunmrQVszuqeqXQxFdxcxzd57",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.0676788820132976e+22
+    },
+    {
+        "timestamp": "2023-05-24T23:18:33.332Z",
+        "balance": 1.040399259219481e+26,
+        "block_height": 92634695,
+        "epoch_id": "7hYu1yD78gpVpgSqg4kwWr2ttunPbXyFbpr7YnEy6UQW",
+        "next_epoch_id": "48hgmZ6mg1y2dHVfir2t8V26bWsSsNUHkW8AVQjVayGP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2938411367750961e+22
+    },
+    {
+        "timestamp": "2023-05-24T09:36:24.424Z",
+        "balance": 1.0402698751058035e+26,
+        "block_height": 92591495,
+        "epoch_id": "GRpMV8BcRUnkYLb4cQYUPaiKC8iQt2gwYtUwuGpekQBK",
+        "next_epoch_id": "7hYu1yD78gpVpgSqg4kwWr2ttunPbXyFbpr7YnEy6UQW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.1426665934210602e+22
+    },
+    {
+        "timestamp": "2023-05-23T19:43:27.081Z",
+        "balance": 1.0401556084464614e+26,
+        "block_height": 92547358,
+        "epoch_id": "9YMs1G19Dr4b9xmRZpkqBxc59Kq15jkh6MTChJzqtrdc",
+        "next_epoch_id": "GRpMV8BcRUnkYLb4cQYUPaiKC8iQt2gwYtUwuGpekQBK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.247686420661458e+22
+    },
+    {
+        "timestamp": "2023-05-23T06:18:27.964Z",
+        "balance": 1.0400308398043953e+26,
+        "block_height": 92505095,
+        "epoch_id": "GbhrVXj5tvXeRJndHgN1S6Th4GkR3BbJLCkUan6rxFe8",
+        "next_epoch_id": "9YMs1G19Dr4b9xmRZpkqBxc59Kq15jkh6MTChJzqtrdc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3223863172277188e+22
+    },
+    {
+        "timestamp": "2023-05-22T16:37:29.487Z",
+        "balance": 1.0398986011726725e+26,
+        "block_height": 92461895,
+        "epoch_id": "GhovdKhcT5xTUx5Ln55mXpFCYvUe12yH7mNq9TQ4FgE3",
+        "next_epoch_id": "GbhrVXj5tvXeRJndHgN1S6Th4GkR3BbJLCkUan6rxFe8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3169239236267687e+22
+    },
+    {
+        "timestamp": "2023-05-22T02:55:34.058Z",
+        "balance": 1.0397669087803098e+26,
+        "block_height": 92418695,
+        "epoch_id": "DbeZd38y1odZTSStUtkFc1fRqF2hAb6D642R1fVWsGse",
+        "next_epoch_id": "GhovdKhcT5xTUx5Ln55mXpFCYvUe12yH7mNq9TQ4FgE3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3434778646844205e+22
+    },
+    {
+        "timestamp": "2023-05-21T13:16:34.868Z",
+        "balance": 1.0396325609938414e+26,
+        "block_height": 92375495,
+        "epoch_id": "A6U12yLXxWmiwbNPPNN3YrJmr8R7KbYUh3oUqqLeXjui",
+        "next_epoch_id": "DbeZd38y1odZTSStUtkFc1fRqF2hAb6D642R1fVWsGse",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3220076864606663e+22
+    },
+    {
+        "timestamp": "2023-05-20T23:42:25.309Z",
+        "balance": 1.0395003602251953e+26,
+        "block_height": 92332295,
+        "epoch_id": "DStywuguRnarAyZxckRQ2oCFQCkZGb6c2ksKqF3JJvkB",
+        "next_epoch_id": "A6U12yLXxWmiwbNPPNN3YrJmr8R7KbYUh3oUqqLeXjui",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4098259771990477e+22
+    },
+    {
+        "timestamp": "2023-05-20T10:07:16.344Z",
+        "balance": 1.0393593776274754e+26,
+        "block_height": 92289095,
+        "epoch_id": "AtehSZ4aCrvg9bMjcf21srco5jEhZmGaRwpjeZ7dzXqg",
+        "next_epoch_id": "DStywuguRnarAyZxckRQ2oCFQCkZGb6c2ksKqF3JJvkB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2210447948279552e+22
+    },
+    {
+        "timestamp": "2023-05-19T20:30:04.985Z",
+        "balance": 1.0392372731479926e+26,
+        "block_height": 92245895,
+        "epoch_id": "6GLaQyBfxPwgyRm3bRU7Dsy4tWyYKhRqawN1s42ifL25",
+        "next_epoch_id": "AtehSZ4aCrvg9bMjcf21srco5jEhZmGaRwpjeZ7dzXqg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3853350366007085e+22
+    },
+    {
+        "timestamp": "2023-05-19T06:54:38.318Z",
+        "balance": 1.0390987396443325e+26,
+        "block_height": 92202695,
+        "epoch_id": "9vYeoUipbLd324P3W4xqwbizMS6x76nwJumYER6NWWRf",
+        "next_epoch_id": "6GLaQyBfxPwgyRm3bRU7Dsy4tWyYKhRqawN1s42ifL25",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.393384101920418e+22
+    },
+    {
+        "timestamp": "2023-05-18T17:07:55.430Z",
+        "balance": 1.0389594012341405e+26,
+        "block_height": 92158332,
+        "epoch_id": "Ap8GbMq8Qcikf8konAgn44caygi3kCxmdiFQaJjVQqAH",
+        "next_epoch_id": "9vYeoUipbLd324P3W4xqwbizMS6x76nwJumYER6NWWRf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3723724642526857e+22
+    },
+    {
+        "timestamp": "2023-05-18T04:00:28.763Z",
+        "balance": 1.0388221639877152e+26,
+        "block_height": 92116295,
+        "epoch_id": "9kNhxf2TyBCdoCL6KLwh1LcwFMrA7JpqA7i4JeE9h2MM",
+        "next_epoch_id": "Ap8GbMq8Qcikf8konAgn44caygi3kCxmdiFQaJjVQqAH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3927432040830103e+22
+    },
+    {
+        "timestamp": "2023-05-17T14:27:37.128Z",
+        "balance": 1.0386828896673069e+26,
+        "block_height": 92073095,
+        "epoch_id": "5L65ErVVy2YiVhqm28wv2PVDC2ashBLUXReSF7qWS3ZE",
+        "next_epoch_id": "9kNhxf2TyBCdoCL6KLwh1LcwFMrA7JpqA7i4JeE9h2MM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6035360568509725e+22
+    },
+    {
+        "timestamp": "2023-05-17T00:58:12.429Z",
+        "balance": 1.0385225360616218e+26,
+        "block_height": 92029895,
+        "epoch_id": "DgFv2U7BxAo7ENZfjexxp3npGXiB9RmiryBde3X6DqL3",
+        "next_epoch_id": "5L65ErVVy2YiVhqm28wv2PVDC2ashBLUXReSF7qWS3ZE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6906263866416877e+22
+    },
+    {
+        "timestamp": "2023-05-16T11:29:29.965Z",
+        "balance": 1.0383534734229576e+26,
+        "block_height": 91986695,
+        "epoch_id": "2ci6ynBWbzi3wFc4vYCHynfUbaL7gLty8H8nknVnH58r",
+        "next_epoch_id": "DgFv2U7BxAo7ENZfjexxp3npGXiB9RmiryBde3X6DqL3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2243472709588166e+22
+    },
+    {
+        "timestamp": "2023-05-15T22:03:13.662Z",
+        "balance": 1.0382310386958618e+26,
+        "block_height": 91943495,
+        "epoch_id": "WrJCxcDui746mhF9LbGwdf6uQ2zZJqaQcrzquuhzXD4",
+        "next_epoch_id": "2ci6ynBWbzi3wFc4vYCHynfUbaL7gLty8H8nknVnH58r",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3899191009113612e+22
+    },
+    {
+        "timestamp": "2023-05-15T08:30:11.857Z",
+        "balance": 1.0380920467857706e+26,
+        "block_height": 91900295,
+        "epoch_id": "2ET9ekmaHy6ofmvxWgQGE2AdELSvsxCHbumrWSonmiLk",
+        "next_epoch_id": "WrJCxcDui746mhF9LbGwdf6uQ2zZJqaQcrzquuhzXD4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.0972248166052525e+22
+    },
+    {
+        "timestamp": "2023-05-14T19:04:30.399Z",
+        "balance": 1.0379823243041101e+26,
+        "block_height": 91857095,
+        "epoch_id": "Qh7WHVMWqTzrLZ5QPLLRfKp1mkbp4TpLSwWrXpkT5oJ",
+        "next_epoch_id": "2ET9ekmaHy6ofmvxWgQGE2AdELSvsxCHbumrWSonmiLk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.383574789667709e+22
+    },
+    {
+        "timestamp": "2023-05-14T05:30:35.297Z",
+        "balance": 1.0378439668251433e+26,
+        "block_height": 91813895,
+        "epoch_id": "AYYYjNdEezbTmaGeSq75m2GM1tDdB9ZVV1BYJHXRwqFT",
+        "next_epoch_id": "Qh7WHVMWqTzrLZ5QPLLRfKp1mkbp4TpLSwWrXpkT5oJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3039005950733856e+22
+    },
+    {
+        "timestamp": "2023-05-13T16:05:02.008Z",
+        "balance": 1.037713576765636e+26,
+        "block_height": 91770695,
+        "epoch_id": "ATKWVDbGKpB1qg7TBgAXLCrkbPqsfVcKkX18sh2TrGKv",
+        "next_epoch_id": "AYYYjNdEezbTmaGeSq75m2GM1tDdB9ZVV1BYJHXRwqFT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3368944454284968e+22
+    },
+    {
+        "timestamp": "2023-05-12T20:27:49.664Z",
+        "balance": 1.0375798873210931e+26,
+        "block_height": 91708002,
+        "epoch_id": "6KDnPzXgrL53yjphedpD9ou7LUBhzLEHrFhmU7QrhVqV",
+        "next_epoch_id": "ATKWVDbGKpB1qg7TBgAXLCrkbPqsfVcKkX18sh2TrGKv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3924806219235464e+22
+    },
+    {
+        "timestamp": "2023-05-12T12:56:44.487Z",
+        "balance": 1.0374406392589008e+26,
+        "block_height": 91684295,
+        "epoch_id": "7Tpcmvo8Z6VaCPc37gYv6RUT9KiTcDRDbwDJH7hAd6KY",
+        "next_epoch_id": "6KDnPzXgrL53yjphedpD9ou7LUBhzLEHrFhmU7QrhVqV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2375687158085605e+22
+    },
+    {
+        "timestamp": "2023-05-11T23:29:04.151Z",
+        "balance": 1.03731688238732e+26,
+        "block_height": 91641095,
+        "epoch_id": "7hmapZ3h4GphaNdAvisr48mG7aiNkg2zdZ9N8Lw2uAn5",
+        "next_epoch_id": "7Tpcmvo8Z6VaCPc37gYv6RUT9KiTcDRDbwDJH7hAd6KY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3959184929058126e+22
+    },
+    {
+        "timestamp": "2023-05-11T09:44:39.274Z",
+        "balance": 1.0371772905380294e+26,
+        "block_height": 91597895,
+        "epoch_id": "BgKytezdDtWYo4xRhCdKniaiBKCeTRFf4wyXem6K6PXj",
+        "next_epoch_id": "7hmapZ3h4GphaNdAvisr48mG7aiNkg2zdZ9N8Lw2uAn5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.395227078894866e+22
+    },
+    {
+        "timestamp": "2023-05-10T20:10:00.686Z",
+        "balance": 1.0370377678301399e+26,
+        "block_height": 91554392,
+        "epoch_id": "658x3BmdfXa5H1QszavHGPUyWkUCtat4jMtBfPLWob3",
+        "next_epoch_id": "BgKytezdDtWYo4xRhCdKniaiBKCeTRFf4wyXem6K6PXj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.404225116159731e+22
+    },
+    {
+        "timestamp": "2023-05-10T06:33:15.803Z",
+        "balance": 1.0368973453185239e+26,
+        "block_height": 91511495,
+        "epoch_id": "tsPMhdFeUmds33DaboC3Uj3dmyrEvKs6jaPPk6LkEkw",
+        "next_epoch_id": "658x3BmdfXa5H1QszavHGPUyWkUCtat4jMtBfPLWob3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.45226644986591e+22
+    },
+    {
+        "timestamp": "2023-05-09T17:00:05.861Z",
+        "balance": 1.0367521186735373e+26,
+        "block_height": 91468295,
+        "epoch_id": "9wMQBfojfSW1xTN1rDHi3EsMa94HacEGmUraR6CF5X5p",
+        "next_epoch_id": "tsPMhdFeUmds33DaboC3Uj3dmyrEvKs6jaPPk6LkEkw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.415750542302474e+22
+    },
+    {
+        "timestamp": "2023-05-09T02:54:35.847Z",
+        "balance": 1.036610543619307e+26,
+        "block_height": 91425095,
+        "epoch_id": "HYepSDXk5URDiAPz1xAmsmWTY6HJgVtfhQHcJzJM9gnb",
+        "next_epoch_id": "9wMQBfojfSW1xTN1rDHi3EsMa94HacEGmUraR6CF5X5p",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3935122503184629e+22
+    },
+    {
+        "timestamp": "2023-05-08T13:10:50.076Z",
+        "balance": 1.0364711923942752e+26,
+        "block_height": 91381895,
+        "epoch_id": "78RfjqwzyUaq6g3ngPYWsQ5ZYiD3JnviWgNKz73moryb",
+        "next_epoch_id": "HYepSDXk5URDiAPz1xAmsmWTY6HJgVtfhQHcJzJM9gnb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4079969389362274e+22
+    },
+    {
+        "timestamp": "2023-05-07T19:32:59.882Z",
+        "balance": 1.0363303927003816e+26,
+        "block_height": 91325669,
+        "epoch_id": "8XXLi7eA4mG4S126dMB2gGyjeco6rHJvzw9Mt5D8ALJR",
+        "next_epoch_id": "78RfjqwzyUaq6g3ngPYWsQ5ZYiD3JnviWgNKz73moryb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4226114386575722e+22
+    },
+    {
+        "timestamp": "2023-05-07T09:52:21.713Z",
+        "balance": 1.0361881315565158e+26,
+        "block_height": 91295495,
+        "epoch_id": "FqsTEfqwVXCuFr2UfqEsAvNHaQkZtmyKSwQNx6jEJ7Z4",
+        "next_epoch_id": "8XXLi7eA4mG4S126dMB2gGyjeco6rHJvzw9Mt5D8ALJR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2868965200930938e+22
+    },
+    {
+        "timestamp": "2023-05-06T13:58:51.343Z",
+        "balance": 1.0360594419045065e+26,
+        "block_height": 91233217,
+        "epoch_id": "73BYE2JDx9zF6NnAfmcRozXbAFQ8r5dSjCa5J3C67MQ2",
+        "next_epoch_id": "FqsTEfqwVXCuFr2UfqEsAvNHaQkZtmyKSwQNx6jEJ7Z4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4051818074461715e+22
+    },
+    {
+        "timestamp": "2023-05-06T06:22:38.811Z",
+        "balance": 1.0359189237237619e+26,
+        "block_height": 91209095,
+        "epoch_id": "DxS7ejnzNgxKGNDNL17w13MzVfvNbCpv1mrLDzEHcH1d",
+        "next_epoch_id": "73BYE2JDx9zF6NnAfmcRozXbAFQ8r5dSjCa5J3C67MQ2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4338712201384727e+22
+    },
+    {
+        "timestamp": "2023-05-05T16:44:40.501Z",
+        "balance": 1.035775536601748e+26,
+        "block_height": 91165895,
+        "epoch_id": "8QEiqPeMiQ2sihwNn414VUJTQ9kLDuteLVmw3Fj8R3hj",
+        "next_epoch_id": "DxS7ejnzNgxKGNDNL17w13MzVfvNbCpv1mrLDzEHcH1d",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3973781211723789e+22
+    },
+    {
+        "timestamp": "2023-05-05T02:48:30.224Z",
+        "balance": 1.0356357987896308e+26,
+        "block_height": 91122695,
+        "epoch_id": "CLQwxxb3Qx1sWp2vHR5tifPLdTVLpjbGLQXhCGwwX4ED",
+        "next_epoch_id": "8QEiqPeMiQ2sihwNn414VUJTQ9kLDuteLVmw3Fj8R3hj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4046765081550056e+22
+    },
+    {
+        "timestamp": "2023-05-04T12:48:30.170Z",
+        "balance": 1.0354953311388153e+26,
+        "block_height": 91079495,
+        "epoch_id": "3QB2aqvvTATDsjZc1HMURnqZguqQxubZvSbt9GEieThu",
+        "next_epoch_id": "CLQwxxb3Qx1sWp2vHR5tifPLdTVLpjbGLQXhCGwwX4ED",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4364635400158222e+22
+    },
+    {
+        "timestamp": "2023-05-03T19:41:04.653Z",
+        "balance": 1.0353516847848137e+26,
+        "block_height": 91025350,
+        "epoch_id": "2es8v78VMVA7tNWdLJn8ULEpn4k7u3kUnjQutRgD3Byq",
+        "next_epoch_id": "3QB2aqvvTATDsjZc1HMURnqZguqQxubZvSbt9GEieThu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.429866320420091e+22
+    },
+    {
+        "timestamp": "2023-05-03T09:12:20.794Z",
+        "balance": 1.0352086981527717e+26,
+        "block_height": 90993095,
+        "epoch_id": "CcoN4mn76eKZ14uus7FuWpboBZv5Jyg1wJCFFvvibdNz",
+        "next_epoch_id": "2es8v78VMVA7tNWdLJn8ULEpn4k7u3kUnjQutRgD3Byq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4249478937335145e+22
+    },
+    {
+        "timestamp": "2023-05-02T19:18:51.743Z",
+        "balance": 1.0350662033633984e+26,
+        "block_height": 90949895,
+        "epoch_id": "DV8eQwgrZ6B1BiEGsnMkbgPpFxvHPJtzyiUuLQh87LG2",
+        "next_epoch_id": "CcoN4mn76eKZ14uus7FuWpboBZv5Jyg1wJCFFvvibdNz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3971590139809911e+22
+    },
+    {
+        "timestamp": "2023-05-02T05:29:19.518Z",
+        "balance": 1.0349264874620003e+26,
+        "block_height": 90906695,
+        "epoch_id": "A4eY6y5Xp3uauBQ1WpSpHdaQUtWkDQ1j3yaiwW52UjxA",
+        "next_epoch_id": "DV8eQwgrZ6B1BiEGsnMkbgPpFxvHPJtzyiUuLQh87LG2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4205619370949282e+22
+    },
+    {
+        "timestamp": "2023-05-01T15:54:50.885Z",
+        "balance": 1.0347844312682908e+26,
+        "block_height": 90863495,
+        "epoch_id": "FnvXm18YFzzKAD4AYCyxa8bUhYw9LrfPaHWKLKUzjAwH",
+        "next_epoch_id": "A4eY6y5Xp3uauBQ1WpSpHdaQUtWkDQ1j3yaiwW52UjxA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4205159999045647e+22
+    },
+    {
+        "timestamp": "2023-05-01T02:06:23.765Z",
+        "balance": 1.0346423796683003e+26,
+        "block_height": 90820295,
+        "epoch_id": "8rm2hVqh4hVpENnCooGknMY4oqQTeZahe23oo2NbX1hK",
+        "next_epoch_id": "FnvXm18YFzzKAD4AYCyxa8bUhYw9LrfPaHWKLKUzjAwH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3951692398141133e+22
+    },
+    {
+        "timestamp": "2023-04-30T09:41:31.827Z",
+        "balance": 1.0345028627443189e+26,
+        "block_height": 90768756,
+        "epoch_id": "7UWENUWBrAtzZFBFLmVY2PP11qmQL48c6oz2kv5aW1n4",
+        "next_epoch_id": "8rm2hVqh4hVpENnCooGknMY4oqQTeZahe23oo2NbX1hK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4024064336815366e+22
+    },
+    {
+        "timestamp": "2023-04-29T22:46:06.276Z",
+        "balance": 1.0343626221009508e+26,
+        "block_height": 90733895,
+        "epoch_id": "D1Z4JKrLmH8Q3TqhkSDSFG2Q9exXstE4BoyooHBGSppP",
+        "next_epoch_id": "7UWENUWBrAtzZFBFLmVY2PP11qmQL48c6oz2kv5aW1n4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3987555847509136e+22
+    },
+    {
+        "timestamp": "2023-04-29T09:09:09.004Z",
+        "balance": 1.0342227465424757e+26,
+        "block_height": 90690695,
+        "epoch_id": "FsfCAdGbXj3mDuorV4Gp9MZ1RRV7JFirEBebwd8QBmwR",
+        "next_epoch_id": "D1Z4JKrLmH8Q3TqhkSDSFG2Q9exXstE4BoyooHBGSppP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3998468143314052e+22
+    },
+    {
+        "timestamp": "2023-04-28T19:33:46.780Z",
+        "balance": 1.0340827618610425e+26,
+        "block_height": 90647495,
+        "epoch_id": "E4H6KJpW7jsHwFYg9Lqtkk5uxZKTfvrDPvyhuNo24M8h",
+        "next_epoch_id": "FsfCAdGbXj3mDuorV4Gp9MZ1RRV7JFirEBebwd8QBmwR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.390679351766756e+22
+    },
+    {
+        "timestamp": "2023-04-28T05:58:10.249Z",
+        "balance": 1.0339436939258659e+26,
+        "block_height": 90604295,
+        "epoch_id": "2ZWECQKtAVh8rXeLQDWasEQ5FSPakZBrA1xVrkTEvJmH",
+        "next_epoch_id": "E4H6KJpW7jsHwFYg9Lqtkk5uxZKTfvrDPvyhuNo24M8h",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4054265827158938e+22
+    },
+    {
+        "timestamp": "2023-04-27T16:28:12.251Z",
+        "balance": 1.0338031512675943e+26,
+        "block_height": 90561095,
+        "epoch_id": "GmSew1RAfpUyceqDJAdLqNx5yZEiNpFEkKxG8iREfwjv",
+        "next_epoch_id": "2ZWECQKtAVh8rXeLQDWasEQ5FSPakZBrA1xVrkTEvJmH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4205023246857445e+22
+    },
+    {
+        "timestamp": "2023-04-27T02:40:06.258Z",
+        "balance": 1.0336611010351257e+26,
+        "block_height": 90517895,
+        "epoch_id": "7U8iJuqo9AJXbTLHQJYyci5XcRuJ7UpDsc18Q6McAzAs",
+        "next_epoch_id": "GmSew1RAfpUyceqDJAdLqNx5yZEiNpFEkKxG8iREfwjv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3894037574131128e+22
+    },
+    {
+        "timestamp": "2023-04-26T12:45:32.993Z",
+        "balance": 1.0335221606593844e+26,
+        "block_height": 90474695,
+        "epoch_id": "9qsQ8PpsjZeaCqV8BgnSZFp5sJjdrfTxxNoJpXav2MBn",
+        "next_epoch_id": "7U8iJuqo9AJXbTLHQJYyci5XcRuJ7UpDsc18Q6McAzAs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.371885133697655e+22
+    },
+    {
+        "timestamp": "2023-04-25T23:15:07.575Z",
+        "balance": 1.0333849721460146e+26,
+        "block_height": 90431495,
+        "epoch_id": "EUs4L8ZydyGKzWCnRkAXKNaeP3Fk5PLX69pXx67Att51",
+        "next_epoch_id": "9qsQ8PpsjZeaCqV8BgnSZFp5sJjdrfTxxNoJpXav2MBn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.410340363589604e+22
+    },
+    {
+        "timestamp": "2023-04-25T09:42:05.344Z",
+        "balance": 1.0332439381096557e+26,
+        "block_height": 90388295,
+        "epoch_id": "9ZKDrbSp74XsqHUcNVH2Ecy5M1wtS4RuiebwEjzuPReY",
+        "next_epoch_id": "EUs4L8ZydyGKzWCnRkAXKNaeP3Fk5PLX69pXx67Att51",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3687228640202385e+22
+    },
+    {
+        "timestamp": "2023-04-24T19:58:56.658Z",
+        "balance": 1.0331070658232536e+26,
+        "block_height": 90345095,
+        "epoch_id": "F4ifUuJpPXM2R7zVk3QnVuDS32fZgz2bU4uL1JCuP9jn",
+        "next_epoch_id": "9ZKDrbSp74XsqHUcNVH2Ecy5M1wtS4RuiebwEjzuPReY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4077251460527525e+22
+    },
+    {
+        "timestamp": "2023-04-24T06:01:43.291Z",
+        "balance": 1.0329662933086484e+26,
+        "block_height": 90301895,
+        "epoch_id": "udo4xyyWHNDwgVa5rALzsV25pFai55rHhTW8CFNKP57",
+        "next_epoch_id": "F4ifUuJpPXM2R7zVk3QnVuDS32fZgz2bU4uL1JCuP9jn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.350727342611859e+22
+    },
+    {
+        "timestamp": "2023-04-23T16:19:19.784Z",
+        "balance": 1.0328312205743872e+26,
+        "block_height": 90258695,
+        "epoch_id": "5sdrCmTEyZvU1LskTHVuAC2wuGu944bpS6YTdVtubaA3",
+        "next_epoch_id": "udo4xyyWHNDwgVa5rALzsV25pFai55rHhTW8CFNKP57",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3833715386709445e+22
+    },
+    {
+        "timestamp": "2023-04-23T02:32:14.332Z",
+        "balance": 1.03269288342052e+26,
+        "block_height": 90215495,
+        "epoch_id": "8hQT4rXYi4PeSBidFNkJkRViTiqNiNKjXvvLUHdkQaNL",
+        "next_epoch_id": "5sdrCmTEyZvU1LskTHVuAC2wuGu944bpS6YTdVtubaA3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3839330537204598e+22
+    },
+    {
+        "timestamp": "2023-04-22T09:01:25.787Z",
+        "balance": 1.032554490115148e+26,
+        "block_height": 90159375,
+        "epoch_id": "9K7mCSERPUrGvMWeyjp7nFwibT1H2q2PVRRDtEcu2jvS",
+        "next_epoch_id": "8hQT4rXYi4PeSBidFNkJkRViTiqNiNKjXvvLUHdkQaNL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3859395164380328e+22
+    },
+    {
+        "timestamp": "2023-04-21T23:36:30.120Z",
+        "balance": 1.0324158961635042e+26,
+        "block_height": 90129095,
+        "epoch_id": "4859SA5Y1K8gj6jVuygQ9Yr4zaZgfKSNSz4Au83Mo3Ua",
+        "next_epoch_id": "9K7mCSERPUrGvMWeyjp7nFwibT1H2q2PVRRDtEcu2jvS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3929731083892475e+22
+    },
+    {
+        "timestamp": "2023-04-21T10:07:00.535Z",
+        "balance": 1.0322765988526653e+26,
+        "block_height": 90085895,
+        "epoch_id": "Etg5bZHUnhewUdtr8EZCtJHh4i7aRuvTuWbC9mAEtLxC",
+        "next_epoch_id": "4859SA5Y1K8gj6jVuygQ9Yr4zaZgfKSNSz4Au83Mo3Ua",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4045339832747783e+22
+    },
+    {
+        "timestamp": "2023-04-20T20:33:38.882Z",
+        "balance": 1.0321361454543378e+26,
+        "block_height": 90042695,
+        "epoch_id": "4PyqJvVC9JK2hrc7Uo2SiZoEERvRPB9v99EvDGmxDRVH",
+        "next_epoch_id": "Etg5bZHUnhewUdtr8EZCtJHh4i7aRuvTuWbC9mAEtLxC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3899828215615607e+22
+    },
+    {
+        "timestamp": "2023-04-20T06:53:12.193Z",
+        "balance": 1.0319971471721817e+26,
+        "block_height": 89999495,
+        "epoch_id": "7BKwvqWon4AxgCXNCVZcDa9sQ1Hj2Evd5ponwi6B9ZN5",
+        "next_epoch_id": "4PyqJvVC9JK2hrc7Uo2SiZoEERvRPB9v99EvDGmxDRVH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4153514469680208e+22
+    },
+    {
+        "timestamp": "2023-04-19T17:20:54.723Z",
+        "balance": 1.0318556120274849e+26,
+        "block_height": 89956295,
+        "epoch_id": "7QFUoitVXqDVLVK9K9D66b79DsJ3WgAdsZvZVKDyBaT6",
+        "next_epoch_id": "7BKwvqWon4AxgCXNCVZcDa9sQ1Hj2Evd5ponwi6B9ZN5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.407156306300727e+22
+    },
+    {
+        "timestamp": "2023-04-19T03:33:32.742Z",
+        "balance": 1.0317148963968548e+26,
+        "block_height": 89913095,
+        "epoch_id": "Fn2M2VLrsWaJkJdZJdV9i4rzbZiXtCAQp4NnD3RyPiL3",
+        "next_epoch_id": "7QFUoitVXqDVLVK9K9D66b79DsJ3WgAdsZvZVKDyBaT6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.406615202932103e+22
+    },
+    {
+        "timestamp": "2023-04-18T13:51:11.190Z",
+        "balance": 1.0315742348765616e+26,
+        "block_height": 89869895,
+        "epoch_id": "5LGBov9sB5BZbdyPvt7sfXkzsy2jc56d8a2D3sK2ZLgs",
+        "next_epoch_id": "Fn2M2VLrsWaJkJdZJdV9i4rzbZiXtCAQp4NnD3RyPiL3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.410455714266725e+22
+    },
+    {
+        "timestamp": "2023-04-18T00:08:49.201Z",
+        "balance": 1.0314331893051349e+26,
+        "block_height": 89826695,
+        "epoch_id": "1eJMNeuDG2pCcJCwaAi7UdcZgTSCjTbYBvnMLHeHzAo",
+        "next_epoch_id": "5LGBov9sB5BZbdyPvt7sfXkzsy2jc56d8a2D3sK2ZLgs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3925950370434033e+22
+    },
+    {
+        "timestamp": "2023-04-17T10:23:54.616Z",
+        "balance": 1.0312939298014306e+26,
+        "block_height": 89783495,
+        "epoch_id": "Ese4v3X7KdqCNvkCAzbW9Apdshn9ehiTivMG5RRVBBby",
+        "next_epoch_id": "1eJMNeuDG2pCcJCwaAi7UdcZgTSCjTbYBvnMLHeHzAo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.404738326909505e+22
+    },
+    {
+        "timestamp": "2023-04-16T20:49:14.135Z",
+        "balance": 1.0311534559687396e+26,
+        "block_height": 89740295,
+        "epoch_id": "FSp66Z9vpfzFwpugZKPgxSeVsmcLX3sSPWVaC6pdq17z",
+        "next_epoch_id": "Ese4v3X7KdqCNvkCAzbW9Apdshn9ehiTivMG5RRVBBby",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3909860124093567e+22
+    },
+    {
+        "timestamp": "2023-04-16T07:07:35.650Z",
+        "balance": 1.0310143573674987e+26,
+        "block_height": 89697095,
+        "epoch_id": "7ekdMAVr3FSJjnSwuwaFX2iQEP5WnFB8TnLNWvTw25i5",
+        "next_epoch_id": "FSp66Z9vpfzFwpugZKPgxSeVsmcLX3sSPWVaC6pdq17z",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.447072891846985e+22
+    },
+    {
+        "timestamp": "2023-04-15T09:12:55.928Z",
+        "balance": 1.030869650078314e+26,
+        "block_height": 89628822,
+        "epoch_id": "CL9zx2jR5Y7d8bFbyqC1ar2GHCmkPvSJRHExJPPVcdGo",
+        "next_epoch_id": "7ekdMAVr3FSJjnSwuwaFX2iQEP5WnFB8TnLNWvTw25i5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.404359276476044e+22
+    },
+    {
+        "timestamp": "2023-04-15T03:26:01.300Z",
+        "balance": 1.0307292141506664e+26,
+        "block_height": 89610695,
+        "epoch_id": "EekSY7Ewigtccqo9FYteqC9hhg5hk32wQWKR9VFNCrg1",
+        "next_epoch_id": "CL9zx2jR5Y7d8bFbyqC1ar2GHCmkPvSJRHExJPPVcdGo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.410508026748488e+22
+    },
+    {
+        "timestamp": "2023-04-14T13:44:04.764Z",
+        "balance": 1.0305881633479915e+26,
+        "block_height": 89567495,
+        "epoch_id": "5iwoZc3Kvnz8qeKSfBLCfNfc56eeSCisVWL7kZZ72gdD",
+        "next_epoch_id": "EekSY7Ewigtccqo9FYteqC9hhg5hk32wQWKR9VFNCrg1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4039589567237242e+22
+    },
+    {
+        "timestamp": "2023-04-13T23:58:58.003Z",
+        "balance": 1.0304477674523192e+26,
+        "block_height": 89524295,
+        "epoch_id": "6k5qcqxnR9tSQgsECs4VEhsFVN55YPFqp8oA4xZKdJKU",
+        "next_epoch_id": "5iwoZc3Kvnz8qeKSfBLCfNfc56eeSCisVWL7kZZ72gdD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3783914422360278e+22
+    },
+    {
+        "timestamp": "2023-04-13T10:17:31.182Z",
+        "balance": 1.0303099283080956e+26,
+        "block_height": 89481095,
+        "epoch_id": "Dc68GLGToGso8hpKSugY3duY2DtBUVzzasAhzL9F3nu",
+        "next_epoch_id": "6k5qcqxnR9tSQgsECs4VEhsFVN55YPFqp8oA4xZKdJKU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.390787579984505e+22
+    },
+    {
+        "timestamp": "2023-04-12T20:51:48.655Z",
+        "balance": 1.0301708495500971e+26,
+        "block_height": 89437895,
+        "epoch_id": "CrkLa21EHgYMMLfgcCLNgYvnCZibH3cVvEft71iVkCDW",
+        "next_epoch_id": "Dc68GLGToGso8hpKSugY3duY2DtBUVzzasAhzL9F3nu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3841852588678514e+22
+    },
+    {
+        "timestamp": "2023-04-11T19:31:16.181Z",
+        "balance": 1.0300324310242103e+26,
+        "block_height": 89356856,
+        "epoch_id": "GxmHbLJ4h6yhaZmmW4DjaQXyiQQpehsqsJ9Yr1Yk4M6n",
+        "next_epoch_id": "CrkLa21EHgYMMLfgcCLNgYvnCZibH3cVvEft71iVkCDW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4226468476890923e+22
+    },
+    {
+        "timestamp": "2023-04-11T17:50:19.600Z",
+        "balance": 1.0298901663394414e+26,
+        "block_height": 89351495,
+        "epoch_id": "SEnm26eZ7BjFNZ99TeN3RESag65xqisouDGJfa4TWmU",
+        "next_epoch_id": "GxmHbLJ4h6yhaZmmW4DjaQXyiQQpehsqsJ9Yr1Yk4M6n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4026953999041272e+22
+    },
+    {
+        "timestamp": "2023-04-10T17:49:48.622Z",
+        "balance": 1.029749896799451e+26,
+        "block_height": 89276268,
+        "epoch_id": "4KJBhq8EMWdq6AmNBpJUm3vHv1tGWmxMz9ZxJ4Q6gd25",
+        "next_epoch_id": "SEnm26eZ7BjFNZ99TeN3RESag65xqisouDGJfa4TWmU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3832256497352488e+22
+    },
+    {
+        "timestamp": "2023-04-10T14:17:56.973Z",
+        "balance": 1.0296115742344775e+26,
+        "block_height": 89265095,
+        "epoch_id": "4DfJ1xHzwyCNTbRJCM4Zum746rADpNgHdrBELzUQUBAL",
+        "next_epoch_id": "4KJBhq8EMWdq6AmNBpJUm3vHv1tGWmxMz9ZxJ4Q6gd25",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3892449624047764e+22
+    },
+    {
+        "timestamp": "2023-04-10T00:51:32.316Z",
+        "balance": 1.029472649738237e+26,
+        "block_height": 89221895,
+        "epoch_id": "6WctN5Tm38TcnY5EbxUVzUDetT41MhH1Z9FkitwYCBT3",
+        "next_epoch_id": "4DfJ1xHzwyCNTbRJCM4Zum746rADpNgHdrBELzUQUBAL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.379838384552181e+22
+    },
+    {
+        "timestamp": "2023-04-09T11:21:38.980Z",
+        "balance": 1.0293346658997818e+26,
+        "block_height": 89178695,
+        "epoch_id": "HCB4L1vnymqnzkq629Uhmg5tb6sUaeiifNzn1SDrvkXY",
+        "next_epoch_id": "6WctN5Tm38TcnY5EbxUVzUDetT41MhH1Z9FkitwYCBT3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3904366281685513e+22
+    },
+    {
+        "timestamp": "2023-04-08T16:03:25.441Z",
+        "balance": 1.029195622236965e+26,
+        "block_height": 89116875,
+        "epoch_id": "GRXwXrZabQxcPPKt1zxdsw1EgtpZVhL9LXUpYufYaKcV",
+        "next_epoch_id": "HCB4L1vnymqnzkq629Uhmg5tb6sUaeiifNzn1SDrvkXY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3799185400579475e+22
+    },
+    {
+        "timestamp": "2023-04-08T08:21:01.622Z",
+        "balance": 1.0290576303829591e+26,
+        "block_height": 89092295,
+        "epoch_id": "F3iTHScVnwxZF6Cp7pTGkAHSyc1hTGh4DQcAJ8bwPfGN",
+        "next_epoch_id": "GRXwXrZabQxcPPKt1zxdsw1EgtpZVhL9LXUpYufYaKcV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4018727201769486e+22
+    },
+    {
+        "timestamp": "2023-04-07T15:47:59.865Z",
+        "balance": 1.0289174431109414e+26,
+        "block_height": 89039329,
+        "epoch_id": "FXDntP6eKsCp2qVhmyNiRzqqYxHbzHxHjzCy49tv4VBQ",
+        "next_epoch_id": "F3iTHScVnwxZF6Cp7pTGkAHSyc1hTGh4DQcAJ8bwPfGN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3818809294480625e+22
+    },
+    {
+        "timestamp": "2023-04-07T05:13:14.136Z",
+        "balance": 1.0287792550179966e+26,
+        "block_height": 89005895,
+        "epoch_id": "9EaU8Qe192P5Hs5xPssCNuF2MKeVxMp7fZ81TrPuhhek",
+        "next_epoch_id": "FXDntP6eKsCp2qVhmyNiRzqqYxHbzHxHjzCy49tv4VBQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3943982844811596e+22
+    },
+    {
+        "timestamp": "2023-04-06T15:43:42.602Z",
+        "balance": 1.0286398151895485e+26,
+        "block_height": 88962695,
+        "epoch_id": "9xq2tTnAAqdpg1iVA1GFNx1qM9sZ4Q4jVCUmwmzpcR23",
+        "next_epoch_id": "9EaU8Qe192P5Hs5xPssCNuF2MKeVxMp7fZ81TrPuhhek",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.432046033401319e+22
+    },
+    {
+        "timestamp": "2023-04-06T02:06:36.619Z",
+        "balance": 1.0284966105862084e+26,
+        "block_height": 88919495,
+        "epoch_id": "4McVrNRmmzWyJeEcV513yyh3er9BgucyU3kFcfQm2PXx",
+        "next_epoch_id": "9xq2tTnAAqdpg1iVA1GFNx1qM9sZ4Q4jVCUmwmzpcR23",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4132459423870654e+22
+    },
+    {
+        "timestamp": "2023-04-05T12:26:42.195Z",
+        "balance": 1.0283552859919697e+26,
+        "block_height": 88876295,
+        "epoch_id": "7kzmYo1DxC3ooXgKgGxVHePfZfrLVnmQtqKkr1Gmq7C9",
+        "next_epoch_id": "4McVrNRmmzWyJeEcV513yyh3er9BgucyU3kFcfQm2PXx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4278825896931056e+22
+    },
+    {
+        "timestamp": "2023-04-04T22:58:26.827Z",
+        "balance": 1.0282124977330004e+26,
+        "block_height": 88833095,
+        "epoch_id": "GsLwtFZS1NzAb2N45XPN1nQte73sVcwgeLJ2fCXNRjF6",
+        "next_epoch_id": "7kzmYo1DxC3ooXgKgGxVHePfZfrLVnmQtqKkr1Gmq7C9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4130315612230714e+22
+    },
+    {
+        "timestamp": "2023-04-04T09:21:43.032Z",
+        "balance": 1.028071194576878e+26,
+        "block_height": 88789895,
+        "epoch_id": "F5nzWKS1Zi9erwKHqwF4YcAACssAaidr5VDKF1e1ix1D",
+        "next_epoch_id": "GsLwtFZS1NzAb2N45XPN1nQte73sVcwgeLJ2fCXNRjF6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.411959231111872e+22
+    },
+    {
+        "timestamp": "2023-04-03T19:53:48.249Z",
+        "balance": 1.0279299986537669e+26,
+        "block_height": 88746695,
+        "epoch_id": "hrWNCdAGVES4ZiszhvCmAUQru7xqW7n6eVakvTHjK8n",
+        "next_epoch_id": "F5nzWKS1Zi9erwKHqwF4YcAACssAaidr5VDKF1e1ix1D",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5743377565838203e+22
+    },
+    {
+        "timestamp": "2023-04-03T06:26:27.179Z",
+        "balance": 1.0277725648781085e+26,
+        "block_height": 88703495,
+        "epoch_id": "A9oq8gXmGTbsTqJvVKy2iUVtR3aXv4LW38zyA4QBnQbB",
+        "next_epoch_id": "hrWNCdAGVES4ZiszhvCmAUQru7xqW7n6eVakvTHjK8n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.525461922227079e+22
+    },
+    {
+        "timestamp": "2023-04-02T15:21:17.206Z",
+        "balance": 1.0276200186858858e+26,
+        "block_height": 88660295,
+        "epoch_id": "5aCPTK2rZnPxkicv92qDTNDaAkf71xtSrwgR1SKztcFS",
+        "next_epoch_id": "A9oq8gXmGTbsTqJvVKy2iUVtR3aXv4LW38zyA4QBnQbB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4461885498532993e+22
+    },
+    {
+        "timestamp": "2023-04-02T00:35:45.148Z",
+        "balance": 1.0274753998309004e+26,
+        "block_height": 88617095,
+        "epoch_id": "G6Smh3AcKowZmnGTMaBM2hCKJ6AfWSuNbZR24WJXL6s8",
+        "next_epoch_id": "5aCPTK2rZnPxkicv92qDTNDaAkf71xtSrwgR1SKztcFS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.425196661627169e+22
+    },
+    {
+        "timestamp": "2023-04-01T10:47:31.926Z",
+        "balance": 1.0273328801647377e+26,
+        "block_height": 88573895,
+        "epoch_id": "5vj9porsGXFUZicuyND4yDPg2dJFfcsj2LZC2wSQTrrA",
+        "next_epoch_id": "G6Smh3AcKowZmnGTMaBM2hCKJ6AfWSuNbZR24WJXL6s8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5473400216613298e+22
+    },
+    {
+        "timestamp": "2023-03-31T21:18:36.119Z",
+        "balance": 1.0271781461625716e+26,
+        "block_height": 88530695,
+        "epoch_id": "7uhw6fkjrKo5h1QHxCtPorD44nPrs4uQVoe3oGcs5xL5",
+        "next_epoch_id": "5vj9porsGXFUZicuyND4yDPg2dJFfcsj2LZC2wSQTrrA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5996598669825045e+22
+    },
+    {
+        "timestamp": "2023-03-31T06:28:10.040Z",
+        "balance": 1.0270181801758733e+26,
+        "block_height": 88487495,
+        "epoch_id": "8A2SNoXDs24nPk6gdPoLEuKxHpEU98WEJ3uazu4atrkd",
+        "next_epoch_id": "7uhw6fkjrKo5h1QHxCtPorD44nPrs4uQVoe3oGcs5xL5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.582418612945653e+22
+    },
+    {
+        "timestamp": "2023-03-30T14:53:23.540Z",
+        "balance": 1.0268599383145788e+26,
+        "block_height": 88444295,
+        "epoch_id": "8TjKurM2Z9gVW78sQfVSjURt2w9V4v5W1UB2ZjnqJG3e",
+        "next_epoch_id": "8A2SNoXDs24nPk6gdPoLEuKxHpEU98WEJ3uazu4atrkd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4567032332574282e+22
+    },
+    {
+        "timestamp": "2023-03-29T23:41:21.457Z",
+        "balance": 1.026714267991253e+26,
+        "block_height": 88401095,
+        "epoch_id": "AMLsAZYwaFVF7DZaKKfEbsV95oHhpeGGJFt9m2ia93p5",
+        "next_epoch_id": "8TjKurM2Z9gVW78sQfVSjURt2w9V4v5W1UB2ZjnqJG3e",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.621550184104064e+22
+    },
+    {
+        "timestamp": "2023-03-29T10:04:03.425Z",
+        "balance": 1.0265521129728426e+26,
+        "block_height": 88357895,
+        "epoch_id": "3mS5Tcz8Sgmbn3AWZc8UAF1tEQNtZ5gHSqFXZuUw24Cz",
+        "next_epoch_id": "AMLsAZYwaFVF7DZaKKfEbsV95oHhpeGGJFt9m2ia93p5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.621357318350247e+22
+    },
+    {
+        "timestamp": "2023-03-28T18:46:17.812Z",
+        "balance": 1.0263899772410076e+26,
+        "block_height": 88314695,
+        "epoch_id": "9tkHhz9mKp4BXep5LxTHsQZ33CKWXcbMZKX4i8vnNNN9",
+        "next_epoch_id": "3mS5Tcz8Sgmbn3AWZc8UAF1tEQNtZ5gHSqFXZuUw24Cz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6303760899030227e+22
+    },
+    {
+        "timestamp": "2023-03-28T03:08:59.057Z",
+        "balance": 1.0262269396320173e+26,
+        "block_height": 88271494,
+        "epoch_id": "6brNw8dJYmyjBUEPhtuKC2BserECXbim22kQPQYATKPJ",
+        "next_epoch_id": "9tkHhz9mKp4BXep5LxTHsQZ33CKWXcbMZKX4i8vnNNN9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.424681177822647e+22
+    },
+    {
+        "timestamp": "2023-03-27T11:46:26.901Z",
+        "balance": 1.026084471514235e+26,
+        "block_height": 88228294,
+        "epoch_id": "Hzp3yHtUDH2nhqxGSRrLTw7v73gsrqr3UfLr5EWqHwK6",
+        "next_epoch_id": "6brNw8dJYmyjBUEPhtuKC2BserECXbim22kQPQYATKPJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5755656483214088e+22
+    },
+    {
+        "timestamp": "2023-03-26T22:19:34.167Z",
+        "balance": 1.0259269149494029e+26,
+        "block_height": 88185094,
+        "epoch_id": "FyKtMH8iTqJYogHXNnVc8dvNZcWGYfqZY7TZaFddmSvJ",
+        "next_epoch_id": "Hzp3yHtUDH2nhqxGSRrLTw7v73gsrqr3UfLr5EWqHwK6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5626721019080644e+22
+    },
+    {
+        "timestamp": "2023-03-26T07:07:50.496Z",
+        "balance": 1.0257706477392121e+26,
+        "block_height": 88141894,
+        "epoch_id": "A589G4wzSPB4GEmAeGHK9B85waoqJUjgYA3iTwn7yAd",
+        "next_epoch_id": "FyKtMH8iTqJYogHXNnVc8dvNZcWGYfqZY7TZaFddmSvJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4486932409628894e+22
+    },
+    {
+        "timestamp": "2023-03-25T16:02:48.551Z",
+        "balance": 1.0256257784151158e+26,
+        "block_height": 88098694,
+        "epoch_id": "7q2aAhGMdubJDX9h1gwry31qy7nJAHcS1wRykFmkrocc",
+        "next_epoch_id": "A589G4wzSPB4GEmAeGHK9B85waoqJUjgYA3iTwn7yAd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4608822274359028e+22
+    },
+    {
+        "timestamp": "2023-03-25T02:22:54.936Z",
+        "balance": 1.0254796901923722e+26,
+        "block_height": 88055494,
+        "epoch_id": "DiLNmTaC62fV9qEeHL556FoQPCwsypZ2J6eLA5f7rfxH",
+        "next_epoch_id": "7q2aAhGMdubJDX9h1gwry31qy7nJAHcS1wRykFmkrocc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.539334262890285e+22
+    },
+    {
+        "timestamp": "2023-03-24T12:35:28.784Z",
+        "balance": 1.0253257567660832e+26,
+        "block_height": 88012294,
+        "epoch_id": "84g56LR2dQKpYTkCxwAwSaEtsToao8gJqK4683zcoxPE",
+        "next_epoch_id": "DiLNmTaC62fV9qEeHL556FoQPCwsypZ2J6eLA5f7rfxH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5342462887069506e+22
+    },
+    {
+        "timestamp": "2023-03-23T21:45:13.871Z",
+        "balance": 1.0251723321372125e+26,
+        "block_height": 87969094,
+        "epoch_id": "JAjP5R8o36iu9sdQ5TzMnShjPuLvTha5BAXhfcpJDoes",
+        "next_epoch_id": "84g56LR2dQKpYTkCxwAwSaEtsToao8gJqK4683zcoxPE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4643814196110151e+22
+    },
+    {
+        "timestamp": "2023-03-23T06:59:08.203Z",
+        "balance": 1.0250258939952514e+26,
+        "block_height": 87925894,
+        "epoch_id": "4TpPLTcgJJhQNjdpGDoXDVQEt6hW8JBU7M7mLReB3dxw",
+        "next_epoch_id": "JAjP5R8o36iu9sdQ5TzMnShjPuLvTha5BAXhfcpJDoes",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4212937075583269e+22
+    },
+    {
+        "timestamp": "2023-03-22T16:47:55.697Z",
+        "balance": 1.0248837646244956e+26,
+        "block_height": 87882694,
+        "epoch_id": "2wFhbumSrTFuvo9npeC7vpYzaafLDxp16m5VFz9PAkmL",
+        "next_epoch_id": "4TpPLTcgJJhQNjdpGDoXDVQEt6hW8JBU7M7mLReB3dxw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3715347694143295e+22
+    },
+    {
+        "timestamp": "2023-03-22T02:46:51.678Z",
+        "balance": 1.0247466111475541e+26,
+        "block_height": 87839494,
+        "epoch_id": "AKrskX1uxEoJcPpEcXmHV5QwhWoVpPVbZMHXFoHmTgd8",
+        "next_epoch_id": "2wFhbumSrTFuvo9npeC7vpYzaafLDxp16m5VFz9PAkmL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4090724030421131e+22
+    },
+    {
+        "timestamp": "2023-03-21T12:53:26.483Z",
+        "balance": 1.0246057039072499e+26,
+        "block_height": 87796294,
+        "epoch_id": "FRxtuukvrAT4Kmu8446m8hMwxwLx4xBQRT7AYyzE2i2E",
+        "next_epoch_id": "AKrskX1uxEoJcPpEcXmHV5QwhWoVpPVbZMHXFoHmTgd8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.408440415638347e+22
+    },
+    {
+        "timestamp": "2023-03-20T23:08:17.618Z",
+        "balance": 1.024464859865686e+26,
+        "block_height": 87753094,
+        "epoch_id": "A3mFezQ5Z21XphYYqKM5iTMB7Sne46EBiVWPG4Pd84UC",
+        "next_epoch_id": "FRxtuukvrAT4Kmu8446m8hMwxwLx4xBQRT7AYyzE2i2E",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.391723306317521e+22
+    },
+    {
+        "timestamp": "2023-03-20T09:14:56.297Z",
+        "balance": 1.0243256875350543e+26,
+        "block_height": 87709894,
+        "epoch_id": "46LWfLSZ86Cxz9VsDe3bWih38tbdTpeGjyDtjDdygd37",
+        "next_epoch_id": "A3mFezQ5Z21XphYYqKM5iTMB7Sne46EBiVWPG4Pd84UC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.2731614970848934e+22
+    },
+    {
+        "timestamp": "2023-03-19T19:35:32.434Z",
+        "balance": 1.0241983713853458e+26,
+        "block_height": 87666694,
+        "epoch_id": "GiKsPqESTBniwKBeDe4mKdvpT1Em5JKPG4xRM6DdcCTG",
+        "next_epoch_id": "46LWfLSZ86Cxz9VsDe3bWih38tbdTpeGjyDtjDdygd37",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.404039835541497e+22
+    },
+    {
+        "timestamp": "2023-03-19T05:47:53.927Z",
+        "balance": 1.0240579674017917e+26,
+        "block_height": 87623494,
+        "epoch_id": "AZnLKRGgZan9pvgHEHi8v7ja5a3XEPaX4NeYeTWvv3pb",
+        "next_epoch_id": "GiKsPqESTBniwKBeDe4mKdvpT1Em5JKPG4xRM6DdcCTG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4163054440455283e+22
+    },
+    {
+        "timestamp": "2023-03-18T16:02:58.000Z",
+        "balance": 1.0239163368573871e+26,
+        "block_height": 87580294,
+        "epoch_id": "EXToUgP2vU7XPttN1Z5S5HpnS3N5icue81nNDoNv5McW",
+        "next_epoch_id": "AZnLKRGgZan9pvgHEHi8v7ja5a3XEPaX4NeYeTWvv3pb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4301864950484395e+22
+    },
+    {
+        "timestamp": "2023-03-18T02:11:09.985Z",
+        "balance": 1.0237733182078823e+26,
+        "block_height": 87537094,
+        "epoch_id": "keaBuitDqQx52jAiPbULQLG3Nn9quio75j7WyLe48Vy",
+        "next_epoch_id": "EXToUgP2vU7XPttN1Z5S5HpnS3N5icue81nNDoNv5McW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4624879718866023e+22
+    },
+    {
+        "timestamp": "2023-03-17T12:15:27.788Z",
+        "balance": 1.0236270694106936e+26,
+        "block_height": 87493894,
+        "epoch_id": "4fMBYmknKBPALsvCbKrx9vjGu2Z32g5zj2eZfT7Wbr8K",
+        "next_epoch_id": "keaBuitDqQx52jAiPbULQLG3Nn9quio75j7WyLe48Vy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5236656745620949e+22
+    },
+    {
+        "timestamp": "2023-03-16T21:57:19.527Z",
+        "balance": 1.0234747028432374e+26,
+        "block_height": 87450694,
+        "epoch_id": "4g1jQdVxgApubFhpLBCJoeq17kqsh9TxQnaatA38cJ2Q",
+        "next_epoch_id": "4fMBYmknKBPALsvCbKrx9vjGu2Z32g5zj2eZfT7Wbr8K",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5016956609911815e+22
+    },
+    {
+        "timestamp": "2023-03-16T07:03:45.586Z",
+        "balance": 1.0233245332771383e+26,
+        "block_height": 87407494,
+        "epoch_id": "A8APWChacZAcdr3x4YQGGspwSPpS19EhwG32M6DmiUhS",
+        "next_epoch_id": "4g1jQdVxgApubFhpLBCJoeq17kqsh9TxQnaatA38cJ2Q",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.472929958176063e+22
+    },
+    {
+        "timestamp": "2023-03-15T17:04:22.054Z",
+        "balance": 1.0231772402813207e+26,
+        "block_height": 87364294,
+        "epoch_id": "6abGchQG1zFXGTEvfk6yT8f2pDKZnhAgeqtHWSQne9i6",
+        "next_epoch_id": "A8APWChacZAcdr3x4YQGGspwSPpS19EhwG32M6DmiUhS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4088693718806725e+22
+    },
+    {
+        "timestamp": "2023-03-15T03:13:38.033Z",
+        "balance": 1.0230363533441326e+26,
+        "block_height": 87321094,
+        "epoch_id": "3Bs7rAESjF31GimQm2EbTmnQn6GHKLVPeUAB12912EYP",
+        "next_epoch_id": "6abGchQG1zFXGTEvfk6yT8f2pDKZnhAgeqtHWSQne9i6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4139980142434673e+22
+    },
+    {
+        "timestamp": "2023-03-14T13:13:08.299Z",
+        "balance": 1.0228949535427083e+26,
+        "block_height": 87277894,
+        "epoch_id": "4b9oNg77Fm3qMTWfQBHZ5CXDEjySjVcqdx5ki2htURER",
+        "next_epoch_id": "3Bs7rAESjF31GimQm2EbTmnQn6GHKLVPeUAB12912EYP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4275140715588365e+22
+    },
+    {
+        "timestamp": "2023-03-13T23:18:05.283Z",
+        "balance": 1.0227522021355524e+26,
+        "block_height": 87234694,
+        "epoch_id": "4wBVxCTpisTziDy4dVuGTuwBsKCafrbp9YGRXp8hs2Nc",
+        "next_epoch_id": "4b9oNg77Fm3qMTWfQBHZ5CXDEjySjVcqdx5ki2htURER",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4331958354986666e+22
+    },
+    {
+        "timestamp": "2023-03-13T09:15:44.756Z",
+        "balance": 1.0226088825520025e+26,
+        "block_height": 87191494,
+        "epoch_id": "HsSH9ibnJfjmmSczC6MdeNmy8VNx1DU9o7pugnrnasmW",
+        "next_epoch_id": "4wBVxCTpisTziDy4dVuGTuwBsKCafrbp9YGRXp8hs2Nc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4154685061384645e+22
+    },
+    {
+        "timestamp": "2023-03-12T19:19:06.728Z",
+        "balance": 1.0224673357013887e+26,
+        "block_height": 87148294,
+        "epoch_id": "FRayVdAYZMZ9Y3RxFGevExv4vLBNYQDCNM8vQj7ZVbAB",
+        "next_epoch_id": "HsSH9ibnJfjmmSczC6MdeNmy8VNx1DU9o7pugnrnasmW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.43306223193381e+22
+    },
+    {
+        "timestamp": "2023-03-12T05:23:39.272Z",
+        "balance": 1.0223240294781953e+26,
+        "block_height": 87105094,
+        "epoch_id": "9q9ntgDjNv1bp9o66D7h47xBhxfEwMqUTL6y3HyfBMvc",
+        "next_epoch_id": "FRayVdAYZMZ9Y3RxFGevExv4vLBNYQDCNM8vQj7ZVbAB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4124083903872956e+22
+    },
+    {
+        "timestamp": "2023-03-11T15:15:14.367Z",
+        "balance": 1.0221827886391566e+26,
+        "block_height": 87061894,
+        "epoch_id": "4WmgGD74H7xkzLUT5XJTGVtY6TAeN2abmMZhSGLMP6i1",
+        "next_epoch_id": "9q9ntgDjNv1bp9o66D7h47xBhxfEwMqUTL6y3HyfBMvc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4188416010201139e+22
+    },
+    {
+        "timestamp": "2023-03-11T01:18:50.360Z",
+        "balance": 1.0220409044790546e+26,
+        "block_height": 87018694,
+        "epoch_id": "GFdg5VhnTtYuvFcqCmVfm2Vxci7RD9vELV7ETyVVFxTo",
+        "next_epoch_id": "4WmgGD74H7xkzLUT5XJTGVtY6TAeN2abmMZhSGLMP6i1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4129940642687917e+22
+    },
+    {
+        "timestamp": "2023-03-10T11:19:28.890Z",
+        "balance": 1.0218996050726277e+26,
+        "block_height": 86975494,
+        "epoch_id": "EJWcgEiGNEFrhNasNNFsSWPF4bkfHiroxak42a37Gkkb",
+        "next_epoch_id": "GFdg5VhnTtYuvFcqCmVfm2Vxci7RD9vELV7ETyVVFxTo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4298964606520205e+22
+    },
+    {
+        "timestamp": "2023-03-09T21:19:42.050Z",
+        "balance": 1.0217566154265625e+26,
+        "block_height": 86932087,
+        "epoch_id": "7V9wihGQoBHNWx5F2rer4935vfTFFeuvE99rQzUg3nbN",
+        "next_epoch_id": "EJWcgEiGNEFrhNasNNFsSWPF4bkfHiroxak42a37Gkkb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.443043441102543e+22
+    },
+    {
+        "timestamp": "2023-03-09T07:20:34.148Z",
+        "balance": 1.0216123110824522e+26,
+        "block_height": 86889094,
+        "epoch_id": "Ccz5gen9em6b23ieYGASoBWNj4HqCa44NtJm9fLwPUoX",
+        "next_epoch_id": "7V9wihGQoBHNWx5F2rer4935vfTFFeuvE99rQzUg3nbN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4386886395726064e+22
+    },
+    {
+        "timestamp": "2023-03-08T17:06:28.533Z",
+        "balance": 1.021468442218495e+26,
+        "block_height": 86845894,
+        "epoch_id": "1222q1LQnKZFEYCR3EmtG9TMy36eS6J6EA6puX3z92he",
+        "next_epoch_id": "Ccz5gen9em6b23ieYGASoBWNj4HqCa44NtJm9fLwPUoX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4508170588548982e+22
+    },
+    {
+        "timestamp": "2023-03-08T02:55:15.624Z",
+        "balance": 1.0213233605126095e+26,
+        "block_height": 86802694,
+        "epoch_id": "P945V85vCE2Jpojn13TcFdMEP3Zi7eNUUFXNcSTV7mB",
+        "next_epoch_id": "1222q1LQnKZFEYCR3EmtG9TMy36eS6J6EA6puX3z92he",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4115508749362933e+22
+    },
+    {
+        "timestamp": "2023-03-07T12:36:50.133Z",
+        "balance": 1.0211822054251158e+26,
+        "block_height": 86759494,
+        "epoch_id": "BCC27fXZwLaqs3MmuhvVfiSHtHjSw2y4zQfP6RTCT2QS",
+        "next_epoch_id": "P945V85vCE2Jpojn13TcFdMEP3Zi7eNUUFXNcSTV7mB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4413587580700848e+22
+    },
+    {
+        "timestamp": "2023-03-06T22:40:14.830Z",
+        "balance": 1.0210380695493088e+26,
+        "block_height": 86716294,
+        "epoch_id": "5h3PDeeRRQjgyNvzbKepLcBJT3jWJdhu662LzfJGC8ub",
+        "next_epoch_id": "BCC27fXZwLaqs3MmuhvVfiSHtHjSw2y4zQfP6RTCT2QS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.420613779832682e+22
+    },
+    {
+        "timestamp": "2023-03-06T08:26:19.650Z",
+        "balance": 1.0208960081713256e+26,
+        "block_height": 86673094,
+        "epoch_id": "FhmQexFCMWUBxNCWKgEKwvPbSWA4ccGMqJ7S5uTAdYYp",
+        "next_epoch_id": "5h3PDeeRRQjgyNvzbKepLcBJT3jWJdhu662LzfJGC8ub",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4208448507104484e+22
+    },
+    {
+        "timestamp": "2023-03-05T18:23:46.667Z",
+        "balance": 1.0207539236862545e+26,
+        "block_height": 86629894,
+        "epoch_id": "8YiL4eP5SxkA8LujDmdJTaigCQqFDbsa8vNVhds27BSi",
+        "next_epoch_id": "FhmQexFCMWUBxNCWKgEKwvPbSWA4ccGMqJ7S5uTAdYYp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.414975720823785e+22
+    },
+    {
+        "timestamp": "2023-03-05T04:20:40.176Z",
+        "balance": 1.0206124261141721e+26,
+        "block_height": 86586694,
+        "epoch_id": "3J7kS3B22YSPX8gufCojQGKvjaoxkRnw7FbKhmAJi3Tj",
+        "next_epoch_id": "8YiL4eP5SxkA8LujDmdJTaigCQqFDbsa8vNVhds27BSi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3902568700330105e+22
+    },
+    {
+        "timestamp": "2023-03-04T14:20:48.924Z",
+        "balance": 1.0204734004271688e+26,
+        "block_height": 86543494,
+        "epoch_id": "5ZUTWb3dZYyVYdgutFVFzCBtMVDHHe1MXqaM2WoqsvSz",
+        "next_epoch_id": "3J7kS3B22YSPX8gufCojQGKvjaoxkRnw7FbKhmAJi3Tj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4182045553990035e+22
+    },
+    {
+        "timestamp": "2023-03-04T00:34:52.410Z",
+        "balance": 1.020331579971629e+26,
+        "block_height": 86500294,
+        "epoch_id": "DArJwAhpD34NRHmptRHCN6W1LWx4uAKk8Q7HXHMz6aAu",
+        "next_epoch_id": "5ZUTWb3dZYyVYdgutFVFzCBtMVDHHe1MXqaM2WoqsvSz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3835640931667635e+22
+    },
+    {
+        "timestamp": "2023-03-03T10:30:46.194Z",
+        "balance": 1.0201932235623123e+26,
+        "block_height": 86457094,
+        "epoch_id": "E3R6WKjUvpcBmW8TR3SGzyJZWjNrroBK2vu1pXiSAdyY",
+        "next_epoch_id": "DArJwAhpD34NRHmptRHCN6W1LWx4uAKk8Q7HXHMz6aAu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4026437726242668e+22
+    },
+    {
+        "timestamp": "2023-03-02T20:47:15.019Z",
+        "balance": 1.0200529591850498e+26,
+        "block_height": 86413894,
+        "epoch_id": "Hpe5yccJyhiPuQd3XNvXpbX4dgdxoPWs7ZQXmcSEkdG3",
+        "next_epoch_id": "E3R6WKjUvpcBmW8TR3SGzyJZWjNrroBK2vu1pXiSAdyY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.379648198297893e+22
+    },
+    {
+        "timestamp": "2023-03-02T06:51:36.498Z",
+        "balance": 1.01991499436522e+26,
+        "block_height": 86370694,
+        "epoch_id": "CoXTGzZEyxi6uXoqNJTU15QrHFHuWnmFuTRLDHuXT6n7",
+        "next_epoch_id": "Hpe5yccJyhiPuQd3XNvXpbX4dgdxoPWs7ZQXmcSEkdG3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4082455976535313e+22
+    },
+    {
+        "timestamp": "2023-03-01T17:12:05.222Z",
+        "balance": 1.0197741698054547e+26,
+        "block_height": 86327494,
+        "epoch_id": "orDiiR2W9RLYm1bL11sQSktnWhfv1EzajnahUqQ6PYh",
+        "next_epoch_id": "CoXTGzZEyxi6uXoqNJTU15QrHFHuWnmFuTRLDHuXT6n7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4385826065487202e+22
+    },
+    {
+        "timestamp": "2023-03-01T03:16:40.813Z",
+        "balance": 1.0196303115447998e+26,
+        "block_height": 86284294,
+        "epoch_id": "AZM7q2MuSAh69auVyY4mVPMB1a3E7NLm2kPzQPJTtgKB",
+        "next_epoch_id": "orDiiR2W9RLYm1bL11sQSktnWhfv1EzajnahUqQ6PYh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3796311493891339e+22
+    },
+    {
+        "timestamp": "2023-02-28T13:03:13.657Z",
+        "balance": 1.0194923484298609e+26,
+        "block_height": 86241094,
+        "epoch_id": "2BLcRKHM9mJ3HZNq7689SF711LKeTjQ9nD98myEcFAKy",
+        "next_epoch_id": "AZM7q2MuSAh69auVyY4mVPMB1a3E7NLm2kPzQPJTtgKB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4038951848259749e+22
+    },
+    {
+        "timestamp": "2023-02-27T23:23:30.699Z",
+        "balance": 1.0193519589113783e+26,
+        "block_height": 86197894,
+        "epoch_id": "5sN4GYJ9BraJBhnUBpprVYTPhyFfC9NggLvKxdQiVQXE",
+        "next_epoch_id": "2BLcRKHM9mJ3HZNq7689SF711LKeTjQ9nD98myEcFAKy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3801642098559705e+22
+    },
+    {
+        "timestamp": "2023-02-27T09:28:37.300Z",
+        "balance": 1.0192139424903927e+26,
+        "block_height": 86154694,
+        "epoch_id": "32ynLJW4nvdyo4FB3WkpzLJjmkb3pq96uXPKPH2dV2Tg",
+        "next_epoch_id": "5sN4GYJ9BraJBhnUBpprVYTPhyFfC9NggLvKxdQiVQXE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3872027113293257e+22
+    },
+    {
+        "timestamp": "2023-02-26T19:45:41.065Z",
+        "balance": 1.0190752222192598e+26,
+        "block_height": 86111494,
+        "epoch_id": "AL2TpamedBPzFvjGucJWxbFr2kjpgR26ncrqYuc7y4X9",
+        "next_epoch_id": "32ynLJW4nvdyo4FB3WkpzLJjmkb3pq96uXPKPH2dV2Tg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3882080647515667e+22
+    },
+    {
+        "timestamp": "2023-02-26T05:58:19.303Z",
+        "balance": 1.0189364014127846e+26,
+        "block_height": 86068294,
+        "epoch_id": "9zt8k5mtPPtrBCtWLeQ8tUUeDMQaQhV756bJ8VBCwHy2",
+        "next_epoch_id": "AL2TpamedBPzFvjGucJWxbFr2kjpgR26ncrqYuc7y4X9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3916911803108984e+22
+    },
+    {
+        "timestamp": "2023-02-25T16:10:05.823Z",
+        "balance": 1.0187972322947535e+26,
+        "block_height": 86025094,
+        "epoch_id": "EzTC7gftAqnY1BY65xvyy8Gsi9ACNtRJeEuG5FMGEuyQ",
+        "next_epoch_id": "9zt8k5mtPPtrBCtWLeQ8tUUeDMQaQhV756bJ8VBCwHy2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4133174521013312e+22
+    },
+    {
+        "timestamp": "2023-02-25T02:23:30.560Z",
+        "balance": 1.0186559005495434e+26,
+        "block_height": 85981894,
+        "epoch_id": "BKn53HqMSadLwCsr2bsJdsBHV6SukBEouhEFTP59ZpF5",
+        "next_epoch_id": "EzTC7gftAqnY1BY65xvyy8Gsi9ACNtRJeEuG5FMGEuyQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3752164912295831e+22
+    },
+    {
+        "timestamp": "2023-02-24T12:24:44.472Z",
+        "balance": 1.0185183789004204e+26,
+        "block_height": 85938694,
+        "epoch_id": "6amQwAjzdngXhUaSHZsnuVt9UJiMRKJrXN6xgVgf7DRU",
+        "next_epoch_id": "BKn53HqMSadLwCsr2bsJdsBHV6SukBEouhEFTP59ZpF5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4671880503918477e+22
+    },
+    {
+        "timestamp": "2023-02-23T17:42:52.051Z",
+        "balance": 1.0183716600953813e+26,
+        "block_height": 85879794,
+        "epoch_id": "CA56oY4Bfge118JVwBrA8N6NBaYePpmHtF7jaNuvXjfK",
+        "next_epoch_id": "6amQwAjzdngXhUaSHZsnuVt9UJiMRKJrXN6xgVgf7DRU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4015989750367051e+22
+    },
+    {
+        "timestamp": "2023-02-23T08:09:17.269Z",
+        "balance": 1.0182315001978776e+26,
+        "block_height": 85852294,
+        "epoch_id": "8b2KQ2fv96F84TzapZpf5BEDdGDE5JTK42LDqDRG8JHZ",
+        "next_epoch_id": "CA56oY4Bfge118JVwBrA8N6NBaYePpmHtF7jaNuvXjfK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4292928610390377e+22
+    },
+    {
+        "timestamp": "2023-02-22T18:13:10.788Z",
+        "balance": 1.0180885709117737e+26,
+        "block_height": 85809094,
+        "epoch_id": "H99thh9tGD8kBwJC5fac83TYGs6W2TTq1Xv3Jqw2VWYv",
+        "next_epoch_id": "8b2KQ2fv96F84TzapZpf5BEDdGDE5JTK42LDqDRG8JHZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4006036357619294e+22
+    },
+    {
+        "timestamp": "2023-02-22T04:01:03.289Z",
+        "balance": 1.0179485105481975e+26,
+        "block_height": 85765894,
+        "epoch_id": "8i1ux2cofaExDynsU7Qjs1dAkg9EL6FcW6duZMZm2uev",
+        "next_epoch_id": "H99thh9tGD8kBwJC5fac83TYGs6W2TTq1Xv3Jqw2VWYv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4040436089073487e+22
+    },
+    {
+        "timestamp": "2023-02-21T14:05:32.682Z",
+        "balance": 1.0178081061873068e+26,
+        "block_height": 85722694,
+        "epoch_id": "BjLJGkHAF4r4mvFBc82esAB5Xo7EAFseTAUZHuwkfLEK",
+        "next_epoch_id": "8i1ux2cofaExDynsU7Qjs1dAkg9EL6FcW6duZMZm2uev",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4208982508737812e+22
+    },
+    {
+        "timestamp": "2023-02-21T00:14:37.054Z",
+        "balance": 1.0176660163622194e+26,
+        "block_height": 85679494,
+        "epoch_id": "HTrKnWapTNuZwoAeeepeV3deyQcJNg1CeKg4PPR8n9Ah",
+        "next_epoch_id": "BjLJGkHAF4r4mvFBc82esAB5Xo7EAFseTAUZHuwkfLEK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5400788116184056e+22
+    },
+    {
+        "timestamp": "2023-02-20T10:13:29.252Z",
+        "balance": 1.0175120084810575e+26,
+        "block_height": 85636294,
+        "epoch_id": "DG65XbJeNCtwNFFe6bvi98AFH6cCmj4dmH6VyTebnjnx",
+        "next_epoch_id": "HTrKnWapTNuZwoAeeepeV3deyQcJNg1CeKg4PPR8n9Ah",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.543035950787009e+22
+    },
+    {
+        "timestamp": "2023-02-19T18:54:15.505Z",
+        "balance": 1.0173577048859788e+26,
+        "block_height": 85593094,
+        "epoch_id": "9MsQxYJpiDzPxUvxS2QLuNvx6s194BAMhFUXQcnTQcT9",
+        "next_epoch_id": "DG65XbJeNCtwNFFe6bvi98AFH6cCmj4dmH6VyTebnjnx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4114824430883632e+22
+    },
+    {
+        "timestamp": "2023-02-18T14:25:03.793Z",
+        "balance": 1.01721655664167e+26,
+        "block_height": 85508512,
+        "epoch_id": "9Zeok26JjVmsiRbwK3KsHuX528wmvWCzktXS28vLxPu2",
+        "next_epoch_id": "9MsQxYJpiDzPxUvxS2QLuNvx6s194BAMhFUXQcnTQcT9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4756725055090904e+22
+    },
+    {
+        "timestamp": "2023-02-18T13:50:15.148Z",
+        "balance": 1.0170689893911191e+26,
+        "block_height": 85506694,
+        "epoch_id": "G22yCvEzwZnKSrz4Pda1xzViV6ckCmePb2FLWRaapLZm",
+        "next_epoch_id": "9Zeok26JjVmsiRbwK3KsHuX528wmvWCzktXS28vLxPu2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.481064083716752e+22
+    },
+    {
+        "timestamp": "2023-02-18T00:06:24.141Z",
+        "balance": 1.0169208829827474e+26,
+        "block_height": 85463494,
+        "epoch_id": "5faSk416TCFPURrvs7qLTAQfc81gW6mA6T9n9PQMqUbp",
+        "next_epoch_id": "G22yCvEzwZnKSrz4Pda1xzViV6ckCmePb2FLWRaapLZm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4554002006117297e+22
+    },
+    {
+        "timestamp": "2023-02-17T10:20:04.007Z",
+        "balance": 1.0167753429626862e+26,
+        "block_height": 85420294,
+        "epoch_id": "3jvt2LuA1LZGQwKtbcThcjT4twe4juCfqwSEiuktBrqH",
+        "next_epoch_id": "5faSk416TCFPURrvs7qLTAQfc81gW6mA6T9n9PQMqUbp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.505709653383821e+22
+    },
+    {
+        "timestamp": "2023-02-16T20:46:49.754Z",
+        "balance": 1.0166247719973479e+26,
+        "block_height": 85377094,
+        "epoch_id": "4GoC7oSPLfaXo3Gz9z2Rkb86nN1fM8qVd578gTAmf1fn",
+        "next_epoch_id": "3jvt2LuA1LZGQwKtbcThcjT4twe4juCfqwSEiuktBrqH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7247399511079172e+22
+    },
+    {
+        "timestamp": "2023-02-16T06:57:32.072Z",
+        "balance": 1.016452298002237e+26,
+        "block_height": 85333894,
+        "epoch_id": "8L6L2PQPjVKcHH5XNWBgcey24Dss573vcsWt23BEum1X",
+        "next_epoch_id": "4GoC7oSPLfaXo3Gz9z2Rkb86nN1fM8qVd578gTAmf1fn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6676840123984542e+22
+    },
+    {
+        "timestamp": "2023-02-15T16:30:12.718Z",
+        "balance": 1.0162855296009972e+26,
+        "block_height": 85290694,
+        "epoch_id": "3eamESNKbwvU6BFeVkEXpMMjVzitHsJKtvryTAwBjWGL",
+        "next_epoch_id": "8L6L2PQPjVKcHH5XNWBgcey24Dss573vcsWt23BEum1X",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7022852054990348e+22
+    },
+    {
+        "timestamp": "2023-02-15T00:48:16.025Z",
+        "balance": 1.0161153010804473e+26,
+        "block_height": 85247493,
+        "epoch_id": "CCmy3f1zchPLX7pCrPg2aXZ3ZRv5pE7tmNG2b7JtcQZm",
+        "next_epoch_id": "3eamESNKbwvU6BFeVkEXpMMjVzitHsJKtvryTAwBjWGL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4362288928510735e+22
+    },
+    {
+        "timestamp": "2023-02-13T20:03:02.731Z",
+        "balance": 1.0159716781911622e+26,
+        "block_height": 85163507,
+        "epoch_id": "EBsUK5nXpfegCAJjtC5BnxrKorb4NrzyrbtX6B8kgYqX",
+        "next_epoch_id": "CCmy3f1zchPLX7pCrPg2aXZ3ZRv5pE7tmNG2b7JtcQZm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4674283194385766e+22
+    },
+    {
+        "timestamp": "2023-02-13T19:17:05.555Z",
+        "balance": 1.0158249353592184e+26,
+        "block_height": 85161090,
+        "epoch_id": "HmTF7XTpXzJfxhrbfd6Lna9LQcZGHX8xp5QFczMRJLRq",
+        "next_epoch_id": "EBsUK5nXpfegCAJjtC5BnxrKorb4NrzyrbtX6B8kgYqX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4507586957984433e+22
+    },
+    {
+        "timestamp": "2023-02-13T05:29:10.472Z",
+        "balance": 1.0156798594896385e+26,
+        "block_height": 85117890,
+        "epoch_id": "ALCp8TAk1ppmT3UYqB1cvD5AfdmG9juiAdzUvPBARC9Y",
+        "next_epoch_id": "HmTF7XTpXzJfxhrbfd6Lna9LQcZGHX8xp5QFczMRJLRq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4543646263238432e+22
+    },
+    {
+        "timestamp": "2023-02-12T15:51:05.049Z",
+        "balance": 1.0155344230270061e+26,
+        "block_height": 85074690,
+        "epoch_id": "AU4v755Rv4eDah4zdTqz1CDpQEFYsKw5V5bzZAneG5ho",
+        "next_epoch_id": "ALCp8TAk1ppmT3UYqB1cvD5AfdmG9juiAdzUvPBARC9Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4773400059029697e+22
+    },
+    {
+        "timestamp": "2023-02-12T02:11:08.252Z",
+        "balance": 1.0153866890264158e+26,
+        "block_height": 85031490,
+        "epoch_id": "DATR7GFLJxJaVNWZKSg2uGFWjwDD7mP4sJeZD655L5fq",
+        "next_epoch_id": "AU4v755Rv4eDah4zdTqz1CDpQEFYsKw5V5bzZAneG5ho",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4683058268576762e+22
+    },
+    {
+        "timestamp": "2023-02-11T12:18:08.696Z",
+        "balance": 1.01523985844373e+26,
+        "block_height": 84988290,
+        "epoch_id": "FwMXVrajyWHvmoCysfbxUvzcG8VfHE6iMQXPvFmWc2tz",
+        "next_epoch_id": "DATR7GFLJxJaVNWZKSg2uGFWjwDD7mP4sJeZD655L5fq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4967984004755293e+22
+    },
+    {
+        "timestamp": "2023-02-10T22:30:20.254Z",
+        "balance": 1.0150901786036825e+26,
+        "block_height": 84945090,
+        "epoch_id": "GzmULYwqPZV7h9VEW77Bd8GZhRb9QqGZ7KEYLuQiU2a",
+        "next_epoch_id": "FwMXVrajyWHvmoCysfbxUvzcG8VfHE6iMQXPvFmWc2tz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4761403198323714e+22
+    },
+    {
+        "timestamp": "2023-02-10T08:26:11.910Z",
+        "balance": 1.0149425645716993e+26,
+        "block_height": 84901890,
+        "epoch_id": "AC6dduMkZY7mpvH4UAFj82BD16RZ4uinqQ2x4rwBZwM3",
+        "next_epoch_id": "GzmULYwqPZV7h9VEW77Bd8GZhRb9QqGZ7KEYLuQiU2a",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5211920383320795e+22
+    },
+    {
+        "timestamp": "2023-02-09T18:33:35.037Z",
+        "balance": 1.014790445367866e+26,
+        "block_height": 84858690,
+        "epoch_id": "FtixY36hCUfVLnjkkanCNdnJVw4JVCh8W1F42GTJBsM5",
+        "next_epoch_id": "AC6dduMkZY7mpvH4UAFj82BD16RZ4uinqQ2x4rwBZwM3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.520467115444992e+22
+    },
+    {
+        "timestamp": "2023-02-09T04:29:10.695Z",
+        "balance": 1.0146383986563216e+26,
+        "block_height": 84815490,
+        "epoch_id": "Aa6ZFsXi2HWA5RywwmQoUJTypdrjFvCK12WCQgXYzdf8",
+        "next_epoch_id": "FtixY36hCUfVLnjkkanCNdnJVw4JVCh8W1F42GTJBsM5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.513218370692523e+22
+    },
+    {
+        "timestamp": "2023-02-08T14:27:25.408Z",
+        "balance": 1.0144870768192523e+26,
+        "block_height": 84772290,
+        "epoch_id": "3JLdVaNf7sy5Z5hWCiLmorqo2AgTtYU6CKo1ndtrnnrk",
+        "next_epoch_id": "Aa6ZFsXi2HWA5RywwmQoUJTypdrjFvCK12WCQgXYzdf8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.627977924285141e+22
+    },
+    {
+        "timestamp": "2023-02-08T00:18:37.728Z",
+        "balance": 1.0143242790268238e+26,
+        "block_height": 84729090,
+        "epoch_id": "9dJz2Qk4KohFm2BrowJTdCUboCyQHKFjyJvH5febVd4s",
+        "next_epoch_id": "3JLdVaNf7sy5Z5hWCiLmorqo2AgTtYU6CKo1ndtrnnrk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6000241274538456e+22
+    },
+    {
+        "timestamp": "2023-02-06T19:13:43.325Z",
+        "balance": 1.0141642766140784e+26,
+        "block_height": 84645951,
+        "epoch_id": "6MMj24BxWLzanXaQsxfiiztRcn71UwnfszEwnR14bLvz",
+        "next_epoch_id": "9dJz2Qk4KohFm2BrowJTdCUboCyQHKFjyJvH5febVd4s",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5974119450415332e+22
+    },
+    {
+        "timestamp": "2023-02-06T18:01:45.143Z",
+        "balance": 1.0140045354195743e+26,
+        "block_height": 84642690,
+        "epoch_id": "EyjhRHB9dzHNnCf1K5y3NC2fqDQznBdQ365wRcmQb34a",
+        "next_epoch_id": "6MMj24BxWLzanXaQsxfiiztRcn71UwnfszEwnR14bLvz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6147368512012081e+22
+    },
+    {
+        "timestamp": "2023-02-05T15:10:54.443Z",
+        "balance": 1.0138430617344541e+26,
+        "block_height": 84565258,
+        "epoch_id": "BzzVtW8Tj5hx1Bf3ZCiUQnn28dZLYmyN2TZjmVaTruMa",
+        "next_epoch_id": "EyjhRHB9dzHNnCf1K5y3NC2fqDQznBdQ365wRcmQb34a",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.609761381268985e+22
+    },
+    {
+        "timestamp": "2023-02-05T08:55:29.052Z",
+        "balance": 1.0136820855963272e+26,
+        "block_height": 84547534,
+        "epoch_id": "8yKoncL7xAQ9TPyyuza1UB79RMHRferhLVUwqz6PLZe6",
+        "next_epoch_id": "BzzVtW8Tj5hx1Bf3ZCiUQnn28dZLYmyN2TZjmVaTruMa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6668043547349017e+22
+    },
+    {
+        "timestamp": "2023-02-04T20:59:33.654Z",
+        "balance": 1.0135154051608538e+26,
+        "block_height": 84513090,
+        "epoch_id": "6iA3S5GwbRQWS8LVu81zCUzyNDx4epNbgVp3BdtAM7uo",
+        "next_epoch_id": "8yKoncL7xAQ9TPyyuza1UB79RMHRferhLVUwqz6PLZe6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.643052157384877e+22
+    },
+    {
+        "timestamp": "2023-02-04T05:52:03.627Z",
+        "balance": 1.0133510999451153e+26,
+        "block_height": 84469890,
+        "epoch_id": "ATkese1o5FoAb1isZeham6CRwNnYmDmqgHpvKnrgQkgk",
+        "next_epoch_id": "6iA3S5GwbRQWS8LVu81zCUzyNDx4epNbgVp3BdtAM7uo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6500881913892127e+22
+    },
+    {
+        "timestamp": "2023-02-03T14:38:52.840Z",
+        "balance": 1.0131860911259763e+26,
+        "block_height": 84426690,
+        "epoch_id": "HAcXaPBrsExxbbnr9hJSVGTDU7wJCjn5yQeFXFb83EW1",
+        "next_epoch_id": "ATkese1o5FoAb1isZeham6CRwNnYmDmqgHpvKnrgQkgk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5902261492865414e+22
+    },
+    {
+        "timestamp": "2023-02-02T23:13:47.489Z",
+        "balance": 1.0130270685110477e+26,
+        "block_height": 84383490,
+        "epoch_id": "64aCaYqXXEfBzDecmV3oeVpbqS2HHVZJu8fqFipf93UK",
+        "next_epoch_id": "HAcXaPBrsExxbbnr9hJSVGTDU7wJCjn5yQeFXFb83EW1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.493865341556467e+22
+    },
+    {
+        "timestamp": "2023-02-02T08:21:12.640Z",
+        "balance": 1.012877681976892e+26,
+        "block_height": 84340290,
+        "epoch_id": "5krUWKW7Ffpk3wktQJzhryBjwifa4w3iHnnhK8X9zDAP",
+        "next_epoch_id": "64aCaYqXXEfBzDecmV3oeVpbqS2HHVZJu8fqFipf93UK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5053500192072971e+22
+    },
+    {
+        "timestamp": "2023-02-01T18:23:28.948Z",
+        "balance": 1.0127271469749713e+26,
+        "block_height": 84297090,
+        "epoch_id": "4DrXbKokJhMtnWiRp9GNTpBG3Hi6t7FiGAob1nAVsJKR",
+        "next_epoch_id": "5krUWKW7Ffpk3wktQJzhryBjwifa4w3iHnnhK8X9zDAP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.477329484746641e+22
+    },
+    {
+        "timestamp": "2023-02-01T04:20:58.645Z",
+        "balance": 1.0125794140264967e+26,
+        "block_height": 84253890,
+        "epoch_id": "EA3fNhMfPCn4RRpTebhPAKPCBZVPqXaKFAiuH9TzT4xU",
+        "next_epoch_id": "4DrXbKokJhMtnWiRp9GNTpBG3Hi6t7FiGAob1nAVsJKR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5006000968747192e+22
+    },
+    {
+        "timestamp": "2023-01-31T14:33:45.983Z",
+        "balance": 1.0124293540168092e+26,
+        "block_height": 84210690,
+        "epoch_id": "2iGmsFLeoRBRx5ZBhvyuKiZ6akW3ZAvKCAwtR3XTzDGL",
+        "next_epoch_id": "EA3fNhMfPCn4RRpTebhPAKPCBZVPqXaKFAiuH9TzT4xU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5114826039237775e+22
+    },
+    {
+        "timestamp": "2023-01-31T00:33:58.038Z",
+        "balance": 1.0122782057564168e+26,
+        "block_height": 84167490,
+        "epoch_id": "HkFxBVweGyA4b9EKCDnex696RoK17BSxjA9ZHKnAwWfV",
+        "next_epoch_id": "2iGmsFLeoRBRx5ZBhvyuKiZ6akW3ZAvKCAwtR3XTzDGL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5187032253540875e+22
+    },
+    {
+        "timestamp": "2023-01-30T10:34:03.120Z",
+        "balance": 1.0121263354338814e+26,
+        "block_height": 84124290,
+        "epoch_id": "GV4HHKS9s2j8qfqxdNee6Qgcx3nTqYRf6pEzXGDMv95R",
+        "next_epoch_id": "HkFxBVweGyA4b9EKCDnex696RoK17BSxjA9ZHKnAwWfV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5798549826011553e+22
+    },
+    {
+        "timestamp": "2023-01-29T20:21:39.728Z",
+        "balance": 1.0119683499356213e+26,
+        "block_height": 84081090,
+        "epoch_id": "E5nuSeyQcwjpE2HcTK6ayqhTMPtzaTcQ8Vi5gMjGEV98",
+        "next_epoch_id": "GV4HHKS9s2j8qfqxdNee6Qgcx3nTqYRf6pEzXGDMv95R",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5048815425811613e+22
+    },
+    {
+        "timestamp": "2023-01-29T05:34:16.280Z",
+        "balance": 1.0118178617813632e+26,
+        "block_height": 84037890,
+        "epoch_id": "6QDV9kbC24rCaMpiXSvduUk3NejMjikrhLVXwW5kheoT",
+        "next_epoch_id": "E5nuSeyQcwjpE2HcTK6ayqhTMPtzaTcQ8Vi5gMjGEV98",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5241199956202682e+22
+    },
+    {
+        "timestamp": "2023-01-28T15:30:36.871Z",
+        "balance": 1.0116654497818011e+26,
+        "block_height": 83994690,
+        "epoch_id": "6snRpT2j27qBNWWdUw2vQ7wifB8pgK8TbwXn8dyQh4u4",
+        "next_epoch_id": "6QDV9kbC24rCaMpiXSvduUk3NejMjikrhLVXwW5kheoT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4940582040358009e+22
+    },
+    {
+        "timestamp": "2023-01-28T01:17:55.368Z",
+        "balance": 1.0115160439613976e+26,
+        "block_height": 83951490,
+        "epoch_id": "2SSsvwweEuiPzQBq68BAHYLrWWxyR7BoCdvF7vQ5cTAL",
+        "next_epoch_id": "6snRpT2j27qBNWWdUw2vQ7wifB8pgK8TbwXn8dyQh4u4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4722217058815533e+22
+    },
+    {
+        "timestamp": "2023-01-27T11:20:40.084Z",
+        "balance": 1.0113688217908094e+26,
+        "block_height": 83908290,
+        "epoch_id": "2TopHcrvMJQGsmjaS3F8eZ9PXiMkB2fx4PrXg4cihzg9",
+        "next_epoch_id": "2SSsvwweEuiPzQBq68BAHYLrWWxyR7BoCdvF7vQ5cTAL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4835972399471526e+22
+    },
+    {
+        "timestamp": "2023-01-26T21:35:00.460Z",
+        "balance": 1.0112204620668147e+26,
+        "block_height": 83865090,
+        "epoch_id": "3XayxhF1jbMBE6pV6Xj7PneUDBzfYHNFA53nZ35yBB6W",
+        "next_epoch_id": "2TopHcrvMJQGsmjaS3F8eZ9PXiMkB2fx4PrXg4cihzg9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4579394643955764e+22
+    },
+    {
+        "timestamp": "2023-01-26T07:43:25.655Z",
+        "balance": 1.0110746681203751e+26,
+        "block_height": 83821890,
+        "epoch_id": "6HDXs6RHqmXyzdJyfWE9vU6DbPJK54Aii71hv2CskNtn",
+        "next_epoch_id": "3XayxhF1jbMBE6pV6Xj7PneUDBzfYHNFA53nZ35yBB6W",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.471713474732324e+22
+    },
+    {
+        "timestamp": "2023-01-25T18:06:17.597Z",
+        "balance": 1.0109274967729019e+26,
+        "block_height": 83778690,
+        "epoch_id": "4zNh7ejrwGRS3TQC4GbfBhGbxp7Rb1JYy2RwucpkmsEi",
+        "next_epoch_id": "6HDXs6RHqmXyzdJyfWE9vU6DbPJK54Aii71hv2CskNtn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.472361224990766e+22
+    },
+    {
+        "timestamp": "2023-01-25T04:20:13.431Z",
+        "balance": 1.0107802606504028e+26,
+        "block_height": 83735490,
+        "epoch_id": "DYzHE6ASGsz7pmH77NDFTz1nMRdLW4asFEPYTRbiC9qz",
+        "next_epoch_id": "4zNh7ejrwGRS3TQC4GbfBhGbxp7Rb1JYy2RwucpkmsEi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4717365835461621e+22
+    },
+    {
+        "timestamp": "2023-01-24T14:33:04.573Z",
+        "balance": 1.0106330869920482e+26,
+        "block_height": 83692290,
+        "epoch_id": "49hvRqL4vbeU9re1SbBwdNb6FLr6gJyWq1KsbZifHTvY",
+        "next_epoch_id": "DYzHE6ASGsz7pmH77NDFTz1nMRdLW4asFEPYTRbiC9qz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4685584720330572e+22
+    },
+    {
+        "timestamp": "2023-01-24T00:47:12.660Z",
+        "balance": 1.0104862311448449e+26,
+        "block_height": 83649090,
+        "epoch_id": "ETA5cxQcmaZ62azG3vdA8MxXbdNbFLvS6JxpjjDL4GjA",
+        "next_epoch_id": "49hvRqL4vbeU9re1SbBwdNb6FLr6gJyWq1KsbZifHTvY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4558103961379765e+22
+    },
+    {
+        "timestamp": "2023-01-23T11:05:01.587Z",
+        "balance": 1.0103406501052311e+26,
+        "block_height": 83605890,
+        "epoch_id": "49NL19GcC8ZMLSW7L8f9RqQWj85RZ5sJawdqxLpFVSyG",
+        "next_epoch_id": "ETA5cxQcmaZ62azG3vdA8MxXbdNbFLvS6JxpjjDL4GjA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4823784527860353e+22
+    },
+    {
+        "timestamp": "2023-01-22T21:29:26.157Z",
+        "balance": 1.0101924122599525e+26,
+        "block_height": 83562690,
+        "epoch_id": "A6N4BD5ct4AqQLLtwxHtPYBo5h8iTtuPNuhztr5Seepf",
+        "next_epoch_id": "49NL19GcC8ZMLSW7L8f9RqQWj85RZ5sJawdqxLpFVSyG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4522680090146298e+22
+    },
+    {
+        "timestamp": "2023-01-22T07:38:35.356Z",
+        "balance": 1.010047185459051e+26,
+        "block_height": 83519490,
+        "epoch_id": "Du2Z6Q1WnfM3RgAH76dA1JTbxP2a4J9vETYDvLF773Mb",
+        "next_epoch_id": "A6N4BD5ct4AqQLLtwxHtPYBo5h8iTtuPNuhztr5Seepf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4579888970038421e+22
+    },
+    {
+        "timestamp": "2023-01-21T18:04:55.333Z",
+        "balance": 1.0099013865693506e+26,
+        "block_height": 83476290,
+        "epoch_id": "2gXBRkuuH29cv5xEzpTi3XGqwmhPfVX4xyrg5Hkv5boc",
+        "next_epoch_id": "Du2Z6Q1WnfM3RgAH76dA1JTbxP2a4J9vETYDvLF773Mb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4697059436261743e+22
+    },
+    {
+        "timestamp": "2023-01-21T04:23:12.338Z",
+        "balance": 1.009754415974988e+26,
+        "block_height": 83433090,
+        "epoch_id": "9dWzzZjBJTXKouGoSe4xD26jCu3PwcEAUwdRd6ZM9nZB",
+        "next_epoch_id": "2gXBRkuuH29cv5xEzpTi3XGqwmhPfVX4xyrg5Hkv5boc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4643381005262e+22
+    },
+    {
+        "timestamp": "2023-01-20T14:35:12.023Z",
+        "balance": 1.0096079821649354e+26,
+        "block_height": 83389890,
+        "epoch_id": "6fCuaE4TSCKNhXU7LizUyFGyKgYSY7JvJw8gTmqqqyVV",
+        "next_epoch_id": "9dWzzZjBJTXKouGoSe4xD26jCu3PwcEAUwdRd6ZM9nZB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4698071196124204e+22
+    },
+    {
+        "timestamp": "2023-01-20T00:52:35.470Z",
+        "balance": 1.0094610014529742e+26,
+        "block_height": 83346690,
+        "epoch_id": "BphYvNKPwJXNndGHNqFYngcmSPNcHno282grubRzNcaR",
+        "next_epoch_id": "6fCuaE4TSCKNhXU7LizUyFGyKgYSY7JvJw8gTmqqqyVV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4540833156622734e+22
+    },
+    {
+        "timestamp": "2023-01-19T11:09:31.398Z",
+        "balance": 1.009315593121408e+26,
+        "block_height": 83303490,
+        "epoch_id": "5v6cbqJsT2YrBipv3tsNqQ5jGaE1mJqcrFwEm7dryLfv",
+        "next_epoch_id": "BphYvNKPwJXNndGHNqFYngcmSPNcHno282grubRzNcaR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4795814637515158e+22
+    },
+    {
+        "timestamp": "2023-01-18T21:35:52.129Z",
+        "balance": 1.0091676349750328e+26,
+        "block_height": 83260290,
+        "epoch_id": "H63UFvaNgqshkLDUQdWzu9cDsSMBPkzjgB3h2jTVGGjv",
+        "next_epoch_id": "5v6cbqJsT2YrBipv3tsNqQ5jGaE1mJqcrFwEm7dryLfv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.463332855849095e+22
+    },
+    {
+        "timestamp": "2023-01-18T07:47:32.288Z",
+        "balance": 1.0090213016894479e+26,
+        "block_height": 83217090,
+        "epoch_id": "ANnLWmwm2io65Er2oQgiGNJzm7yf1dU4aEnnaZ8odJHN",
+        "next_epoch_id": "H63UFvaNgqshkLDUQdWzu9cDsSMBPkzjgB3h2jTVGGjv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4616453690018564e+22
+    },
+    {
+        "timestamp": "2023-01-17T18:05:27.753Z",
+        "balance": 1.0088751371525477e+26,
+        "block_height": 83173890,
+        "epoch_id": "5MF9uU79ELVhvXDrnJWkgQ1w63L2t5roA2wRHcpSuhPt",
+        "next_epoch_id": "ANnLWmwm2io65Er2oQgiGNJzm7yf1dU4aEnnaZ8odJHN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.457630098222509e+22
+    },
+    {
+        "timestamp": "2023-01-17T04:23:09.822Z",
+        "balance": 1.0087293741427254e+26,
+        "block_height": 83130690,
+        "epoch_id": "CZcMA2oyeH9rTcj7xGHNLqHTaLSE1d8dgsJXw3mwe717",
+        "next_epoch_id": "5MF9uU79ELVhvXDrnJWkgQ1w63L2t5roA2wRHcpSuhPt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4653178551908786e+22
+    },
+    {
+        "timestamp": "2023-01-16T14:43:12.135Z",
+        "balance": 1.0085828423572064e+26,
+        "block_height": 83087490,
+        "epoch_id": "4FVkXLyAnYjg2bXyUsonKPb3DB6Z7BRZBcbPCQrtCsWf",
+        "next_epoch_id": "CZcMA2oyeH9rTcj7xGHNLqHTaLSE1d8dgsJXw3mwe717",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.478651325153772e+22
+    },
+    {
+        "timestamp": "2023-01-16T00:57:26.168Z",
+        "balance": 1.008434977224691e+26,
+        "block_height": 83044290,
+        "epoch_id": "8gBisGqLp1TXtbv3d1F9LatSBhzrftCABZFRNP1u4CKb",
+        "next_epoch_id": "4FVkXLyAnYjg2bXyUsonKPb3DB6Z7BRZBcbPCQrtCsWf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4556833632683515e+22
+    },
+    {
+        "timestamp": "2023-01-15T11:05:37.644Z",
+        "balance": 1.0082894088883641e+26,
+        "block_height": 83001090,
+        "epoch_id": "AsepMay6n9Bugb9LfZXpovxdNwa2R1Lz3TWgz3qNWMFe",
+        "next_epoch_id": "8gBisGqLp1TXtbv3d1F9LatSBhzrftCABZFRNP1u4CKb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4804460979046528e+22
+    },
+    {
+        "timestamp": "2023-01-14T21:27:18.035Z",
+        "balance": 1.0081413642785737e+26,
+        "block_height": 82957890,
+        "epoch_id": "Dybtv1b4Pmjyc5R4uzR2Pbn8vWWWQaH4LzWQKxBG62h7",
+        "next_epoch_id": "AsepMay6n9Bugb9LfZXpovxdNwa2R1Lz3TWgz3qNWMFe",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4865672742997957e+22
+    },
+    {
+        "timestamp": "2023-01-14T07:37:30.908Z",
+        "balance": 1.0079927075511437e+26,
+        "block_height": 82914690,
+        "epoch_id": "9Ef3Zbo15HDY3Y9rxwBctT6MysiN99aGDyZAWhXfrXoB",
+        "next_epoch_id": "Dybtv1b4Pmjyc5R4uzR2Pbn8vWWWQaH4LzWQKxBG62h7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5003672359129955e+22
+    },
+    {
+        "timestamp": "2023-01-13T17:44:48.892Z",
+        "balance": 1.0078426708275524e+26,
+        "block_height": 82871490,
+        "epoch_id": "CGWMcvgfgtSpy2oLe9dJhjwGH1ExfaMbUpTPUwmTHnYB",
+        "next_epoch_id": "9Ef3Zbo15HDY3Y9rxwBctT6MysiN99aGDyZAWhXfrXoB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.505838813000992e+22
+    },
+    {
+        "timestamp": "2023-01-13T03:43:56.749Z",
+        "balance": 1.0076920869462523e+26,
+        "block_height": 82828290,
+        "epoch_id": "38DiRdkNzLpBP6pqKprAWWXEySA9EqRR7E9z6unUeaif",
+        "next_epoch_id": "CGWMcvgfgtSpy2oLe9dJhjwGH1ExfaMbUpTPUwmTHnYB",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4730169409893309e+22
+    },
+    {
+        "timestamp": "2023-01-12T13:39:57.759Z",
+        "balance": 1.0075447852521534e+26,
+        "block_height": 82785090,
+        "epoch_id": "PQPeyAxTUV9maHdsfVE2VHbKrhc4nLGDyjqGSnG2WVY",
+        "next_epoch_id": "38DiRdkNzLpBP6pqKprAWWXEySA9EqRR7E9z6unUeaif",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4796106247291837e+22
+    },
+    {
+        "timestamp": "2023-01-11T23:54:31.582Z",
+        "balance": 1.0073968241896804e+26,
+        "block_height": 82741890,
+        "epoch_id": "3NKJVSKM8t7LeksU65MNexvHCHYumfjmQfc1zmji3KjZ",
+        "next_epoch_id": "PQPeyAxTUV9maHdsfVE2VHbKrhc4nLGDyjqGSnG2WVY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4793442141355154e+22
+    },
+    {
+        "timestamp": "2023-01-11T10:05:03.337Z",
+        "balance": 1.0072488897682669e+26,
+        "block_height": 82698690,
+        "epoch_id": "A8VczT4XpoLtewqKXdm9HDwvEr88adwcU6GDZHdJ2ZUu",
+        "next_epoch_id": "3NKJVSKM8t7LeksU65MNexvHCHYumfjmQfc1zmji3KjZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5348826866521467e+22
+    },
+    {
+        "timestamp": "2023-01-10T20:15:49.786Z",
+        "balance": 1.0070954014996017e+26,
+        "block_height": 82655490,
+        "epoch_id": "BsfTz2H8i8zEzPXZV8fdYahq78US9UXoqASVX14rdm8",
+        "next_epoch_id": "A8VczT4XpoLtewqKXdm9HDwvEr88adwcU6GDZHdJ2ZUu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4578565931304491e+22
+    },
+    {
+        "timestamp": "2023-01-10T05:56:03.385Z",
+        "balance": 1.0069496158402886e+26,
+        "block_height": 82612290,
+        "epoch_id": "EokTjg7RtQNFSkycGnJcKrYrcrfVyDEFTocHCZShmQes",
+        "next_epoch_id": "BsfTz2H8i8zEzPXZV8fdYahq78US9UXoqASVX14rdm8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.473664616891581e+22
+    },
+    {
+        "timestamp": "2023-01-09T16:19:21.267Z",
+        "balance": 1.0068022493785995e+26,
+        "block_height": 82569090,
+        "epoch_id": "9wBYLh2kqnN9gkSkTFsYiJLV92KBJcaaFf2FShx8CMXW",
+        "next_epoch_id": "EokTjg7RtQNFSkycGnJcKrYrcrfVyDEFTocHCZShmQes",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.46105538809795e+22
+    },
+    {
+        "timestamp": "2023-01-09T02:33:22.313Z",
+        "balance": 1.0066561438397897e+26,
+        "block_height": 82525890,
+        "epoch_id": "EhX11u6kr9uKRKwKxfqpseB93uQcrEoXHSMkcdP6DgDX",
+        "next_epoch_id": "9wBYLh2kqnN9gkSkTFsYiJLV92KBJcaaFf2FShx8CMXW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.455834537539262e+22
+    },
+    {
+        "timestamp": "2023-01-08T12:54:10.971Z",
+        "balance": 1.0065105603860358e+26,
+        "block_height": 82482690,
+        "epoch_id": "9mzAZUszv8LKH9EKP5AayfLAPBEs42TwX3NEz4PmnCXj",
+        "next_epoch_id": "EhX11u6kr9uKRKwKxfqpseB93uQcrEoXHSMkcdP6DgDX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.451843051249418e+22
+    },
+    {
+        "timestamp": "2023-01-07T23:18:35.890Z",
+        "balance": 1.0063653760809108e+26,
+        "block_height": 82439490,
+        "epoch_id": "3iTE1d4gwEuvxMhU7eJpivXnjdhZ95bL3rc3dkcbkmpJ",
+        "next_epoch_id": "9mzAZUszv8LKH9EKP5AayfLAPBEs42TwX3NEz4PmnCXj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4547218193010857e+22
+    },
+    {
+        "timestamp": "2023-01-07T09:42:46.145Z",
+        "balance": 1.0062199038989807e+26,
+        "block_height": 82396290,
+        "epoch_id": "4xBmf4C1C5C7MPa1RbhRreRART8CFxttyLQCkBMfB6Qs",
+        "next_epoch_id": "3iTE1d4gwEuvxMhU7eJpivXnjdhZ95bL3rc3dkcbkmpJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4720535788215337e+22
+    },
+    {
+        "timestamp": "2023-01-06T20:08:15.905Z",
+        "balance": 1.0060726985410986e+26,
+        "block_height": 82353090,
+        "epoch_id": "7XQCPVVC3D5vkBsfE2ANmcLSCPCqKKXF35KjcCQzaR4W",
+        "next_epoch_id": "4xBmf4C1C5C7MPa1RbhRreRART8CFxttyLQCkBMfB6Qs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4543836831246593e+22
+    },
+    {
+        "timestamp": "2023-01-06T06:16:26.723Z",
+        "balance": 1.0059272601727861e+26,
+        "block_height": 82309890,
+        "epoch_id": "9UHtAyLQXqj5W9iLPfTDLziqFjCRbSQMtRUMkmPvxpML",
+        "next_epoch_id": "7XQCPVVC3D5vkBsfE2ANmcLSCPCqKKXF35KjcCQzaR4W",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4854119642693863e+22
+    },
+    {
+        "timestamp": "2023-01-05T16:34:24.519Z",
+        "balance": 1.0057787189763591e+26,
+        "block_height": 82266690,
+        "epoch_id": "23BkqpZteZiUx2sATZpfBdMnuU2x9NYZRXqGd9FkggdJ",
+        "next_epoch_id": "9UHtAyLQXqj5W9iLPfTDLziqFjCRbSQMtRUMkmPvxpML",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5056941348131411e+22
+    },
+    {
+        "timestamp": "2023-01-05T02:36:40.221Z",
+        "balance": 1.0056281495628778e+26,
+        "block_height": 82223490,
+        "epoch_id": "2bJ9x7jhkYwvcW5PkzSH8LCihHS1sWFwCLqQB9k7iCdK",
+        "next_epoch_id": "23BkqpZteZiUx2sATZpfBdMnuU2x9NYZRXqGd9FkggdJ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4568600873734796e+22
+    },
+    {
+        "timestamp": "2023-01-04T12:31:39.622Z",
+        "balance": 1.0054824635541405e+26,
+        "block_height": 82180290,
+        "epoch_id": "A5ctpE6pUhZGgwN9bhavLUbSKmUryrbUDK6czxkzx1mu",
+        "next_epoch_id": "2bJ9x7jhkYwvcW5PkzSH8LCihHS1sWFwCLqQB9k7iCdK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.474138996855776e+22
+    },
+    {
+        "timestamp": "2023-01-03T22:52:54.128Z",
+        "balance": 1.0053350496544549e+26,
+        "block_height": 82137090,
+        "epoch_id": "7w5etRG8DMfbSEMiodfWD4iLkAVsAGhMFQeSZWhwSj93",
+        "next_epoch_id": "A5ctpE6pUhZGgwN9bhavLUbSKmUryrbUDK6czxkzx1mu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.441728737999909e+22
+    },
+    {
+        "timestamp": "2023-01-03T09:04:40.893Z",
+        "balance": 1.005190876780655e+26,
+        "block_height": 82093890,
+        "epoch_id": "5ZZEukQDd4NupD5M9SwDSKkWMXHhQCfafHW1hFEvDJTV",
+        "next_epoch_id": "7w5etRG8DMfbSEMiodfWD4iLkAVsAGhMFQeSZWhwSj93",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.459417911717621e+22
+    },
+    {
+        "timestamp": "2023-01-02T19:35:08.019Z",
+        "balance": 1.0050449349894832e+26,
+        "block_height": 82050690,
+        "epoch_id": "6BfgrTeXie1rvSc6QJAEeLSouQkVKngr69oaVFSMRDX4",
+        "next_epoch_id": "5ZZEukQDd4NupD5M9SwDSKkWMXHhQCfafHW1hFEvDJTV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4438051721342351e+22
+    },
+    {
+        "timestamp": "2023-01-02T05:55:13.587Z",
+        "balance": 1.0049005544722697e+26,
+        "block_height": 82007490,
+        "epoch_id": "sKoa4xrt4MBFpS8bB3YFMRrqMPM9ZuxQxYUoibyoMsG",
+        "next_epoch_id": "6BfgrTeXie1rvSc6QJAEeLSouQkVKngr69oaVFSMRDX4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4547535853172935e+22
+    },
+    {
+        "timestamp": "2023-01-01T16:23:57.203Z",
+        "balance": 1.004755079113738e+26,
+        "block_height": 81964290,
+        "epoch_id": "CpGSQHyicoxEDHAmdjq1TNix11MwPptPUCfhpPJq7kKV",
+        "next_epoch_id": "sKoa4xrt4MBFpS8bB3YFMRrqMPM9ZuxQxYUoibyoMsG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4513129196822712e+22
+    },
+    {
+        "timestamp": "2023-01-01T02:47:10.682Z",
+        "balance": 1.0046099478217698e+26,
+        "block_height": 81921090,
+        "epoch_id": "FuBgEh2wSvqWdSmEEZwrVRQ1ZHhQ7axZ5dnU4AL8ZZD7",
+        "next_epoch_id": "CpGSQHyicoxEDHAmdjq1TNix11MwPptPUCfhpPJq7kKV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4561234652188161e+22
+    },
+    {
+        "timestamp": "2022-12-31T13:12:30.879Z",
+        "balance": 1.0044643354752479e+26,
+        "block_height": 81877890,
+        "epoch_id": "3JEVZQ44qstnCtwpqS6twCSgTWvr684kZq6sH4LuukME",
+        "next_epoch_id": "FuBgEh2wSvqWdSmEEZwrVRQ1ZHhQ7axZ5dnU4AL8ZZD7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4597875215398055e+22
+    },
+    {
+        "timestamp": "2022-12-30T23:34:35.611Z",
+        "balance": 1.0043183567230939e+26,
+        "block_height": 81834690,
+        "epoch_id": "GpkN62wRbLgFqhbUCVkTFE7ZCm4pc8yMrWhFFQ1C2r4",
+        "next_epoch_id": "3JEVZQ44qstnCtwpqS6twCSgTWvr684kZq6sH4LuukME",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4595921144469676e+22
+    },
+    {
+        "timestamp": "2022-12-30T09:54:13.895Z",
+        "balance": 1.0041723975116492e+26,
+        "block_height": 81791490,
+        "epoch_id": "BjZuGjHfwssYZ6T3TpEfqw173noGGFGYgmAk9ftyVY8K",
+        "next_epoch_id": "GpkN62wRbLgFqhbUCVkTFE7ZCm4pc8yMrWhFFQ1C2r4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4952813606183312e+22
+    },
+    {
+        "timestamp": "2022-12-29T20:14:23.889Z",
+        "balance": 1.0040228693755874e+26,
+        "block_height": 81748290,
+        "epoch_id": "ANnaL256wYDenoK697YNS8LSMf1r6uHYnLCDEMFDXxo7",
+        "next_epoch_id": "BjZuGjHfwssYZ6T3TpEfqw173noGGFGYgmAk9ftyVY8K",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4848878501747596e+22
+    },
+    {
+        "timestamp": "2022-12-29T06:28:50.251Z",
+        "balance": 1.0038743805905699e+26,
+        "block_height": 81705090,
+        "epoch_id": "3xjZ1KzxZtV3tpmMZYmm5UFugo7H6osJHWKsK9kZdHjb",
+        "next_epoch_id": "ANnaL256wYDenoK697YNS8LSMf1r6uHYnLCDEMFDXxo7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4910615646456817e+22
+    },
+    {
+        "timestamp": "2022-12-28T16:48:56.037Z",
+        "balance": 1.0037252744341053e+26,
+        "block_height": 81661890,
+        "epoch_id": "Eu94iL8W7vv4GwAhn918D2dcZm5ThJ99DKeEUJh92Kod",
+        "next_epoch_id": "3xjZ1KzxZtV3tpmMZYmm5UFugo7H6osJHWKsK9kZdHjb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4997912099539753e+22
+    },
+    {
+        "timestamp": "2022-12-28T03:02:50.466Z",
+        "balance": 1.00357529531311e+26,
+        "block_height": 81618690,
+        "epoch_id": "J7YxxZvEtva6E5JYQvG4WrALkmYTi5eX3quZbrDdzsoE",
+        "next_epoch_id": "Eu94iL8W7vv4GwAhn918D2dcZm5ThJ99DKeEUJh92Kod",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5051177684178332e+22
+    },
+    {
+        "timestamp": "2022-12-27T13:12:04.385Z",
+        "balance": 1.0034247835362682e+26,
+        "block_height": 81575490,
+        "epoch_id": "8PfsDhiLEnkh43ANyqD7VezrHPmMTD1xHFLQki7nXDcE",
+        "next_epoch_id": "J7YxxZvEtva6E5JYQvG4WrALkmYTi5eX3quZbrDdzsoE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5354635802281704e+22
+    },
+    {
+        "timestamp": "2022-12-26T23:25:14.858Z",
+        "balance": 1.0032712371782453e+26,
+        "block_height": 81532290,
+        "epoch_id": "ZeHVtAjkZAwNkUXbVQqgqQ2vZPBokmGGfKq8JQu2QnM",
+        "next_epoch_id": "8PfsDhiLEnkh43ANyqD7VezrHPmMTD1xHFLQki7nXDcE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6483910431401727e+22
+    },
+    {
+        "timestamp": "2022-12-26T09:21:16.246Z",
+        "balance": 1.0031063980739313e+26,
+        "block_height": 81489090,
+        "epoch_id": "8EmDp6mY1VedxyZrWcDsmF9wUT5kPFCQ4HKyS6UBN6sv",
+        "next_epoch_id": "ZeHVtAjkZAwNkUXbVQqgqQ2vZPBokmGGfKq8JQu2QnM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.654604898672655e+22
+    },
+    {
+        "timestamp": "2022-12-25T18:07:12.747Z",
+        "balance": 1.002940937584064e+26,
+        "block_height": 81445890,
+        "epoch_id": "6eCPqCvsfMba5XmBvZd7tQUBKz1bTSVqgy5WmMDSTFjz",
+        "next_epoch_id": "8EmDp6mY1VedxyZrWcDsmF9wUT5kPFCQ4HKyS6UBN6sv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5008626078150354e+22
+    },
+    {
+        "timestamp": "2022-12-25T02:51:07.756Z",
+        "balance": 1.0027908513232826e+26,
+        "block_height": 81402690,
+        "epoch_id": "GYFYs2ztVwdVa2KZc3gebgJU9nT58PoYDnDGePqFHxHP",
+        "next_epoch_id": "6eCPqCvsfMba5XmBvZd7tQUBKz1bTSVqgy5WmMDSTFjz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4889399634584498e+22
+    },
+    {
+        "timestamp": "2022-12-24T13:07:38.799Z",
+        "balance": 1.0026419573269367e+26,
+        "block_height": 81359490,
+        "epoch_id": "2acUXupKVA2tU2yg6XcYHr6NGmekXNXHwAENp3xyBaz1",
+        "next_epoch_id": "GYFYs2ztVwdVa2KZc3gebgJU9nT58PoYDnDGePqFHxHP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.658327717318849e+22
+    },
+    {
+        "timestamp": "2022-12-23T23:29:23.662Z",
+        "balance": 1.0024761245552048e+26,
+        "block_height": 81316290,
+        "epoch_id": "HpEWC4Rp4dEpazp8kdHMj9c11cMGq4VN4xgTuuuXgcRh",
+        "next_epoch_id": "2acUXupKVA2tU2yg6XcYHr6NGmekXNXHwAENp3xyBaz1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6631901795782545e+22
+    },
+    {
+        "timestamp": "2022-12-23T08:09:03.456Z",
+        "balance": 1.002309805537247e+26,
+        "block_height": 81273090,
+        "epoch_id": "BBmTFxVx7WkAsqEV3Bf87UYknhUYLz52UDUfuaREvheL",
+        "next_epoch_id": "HpEWC4Rp4dEpazp8kdHMj9c11cMGq4VN4xgTuuuXgcRh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5149317143887807e+22
+    },
+    {
+        "timestamp": "2022-12-22T16:48:09.020Z",
+        "balance": 1.0021583123658081e+26,
+        "block_height": 81229890,
+        "epoch_id": "JCuh9B3bHKJ1ZgWnD1EgSpWnt49eYRHSJ9kXnxwygDbE",
+        "next_epoch_id": "BBmTFxVx7WkAsqEV3Bf87UYknhUYLz52UDUfuaREvheL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5237094348551564e+22
+    },
+    {
+        "timestamp": "2022-12-22T02:55:39.370Z",
+        "balance": 1.0020059414223226e+26,
+        "block_height": 81186690,
+        "epoch_id": "AnsK2maD2Txx9o6gAwitKaCaSGMgXoZD2CUJuYS5efhz",
+        "next_epoch_id": "JCuh9B3bHKJ1ZgWnD1EgSpWnt49eYRHSJ9kXnxwygDbE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6735012668592267e+22
+    },
+    {
+        "timestamp": "2022-12-21T13:02:09.262Z",
+        "balance": 1.0018385912956367e+26,
+        "block_height": 81143490,
+        "epoch_id": "3FGEiSSp4n79D41uAQAJHnv5cBExCizVZDx9shRVXZwi",
+        "next_epoch_id": "AnsK2maD2Txx9o6gAwitKaCaSGMgXoZD2CUJuYS5efhz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6818777962395233e+22
+    },
+    {
+        "timestamp": "2022-12-20T21:29:08.365Z",
+        "balance": 1.0016704035160127e+26,
+        "block_height": 81100290,
+        "epoch_id": "BfEKU9U6L6KEfLx5wPCDGGfp7Bd2JNKJ9rrv4b5nEAAv",
+        "next_epoch_id": "3FGEiSSp4n79D41uAQAJHnv5cBExCizVZDx9shRVXZwi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.466324424404974e+22
+    },
+    {
+        "timestamp": "2022-12-20T05:47:46.793Z",
+        "balance": 1.0015237710735722e+26,
+        "block_height": 81057090,
+        "epoch_id": "7CfkLjnwDK3YH53tMMHDYo7XLG7SSn1My3YKKzZs3Kqg",
+        "next_epoch_id": "BfEKU9U6L6KEfLx5wPCDGGfp7Bd2JNKJ9rrv4b5nEAAv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4930585329652436e+22
+    },
+    {
+        "timestamp": "2022-12-19T16:06:14.387Z",
+        "balance": 1.0013744652202757e+26,
+        "block_height": 81013890,
+        "epoch_id": "5mYGnpTcEkfTknpXCXpgXsuRKkoMUam4uX7WiqJk6jWD",
+        "next_epoch_id": "7CfkLjnwDK3YH53tMMHDYo7XLG7SSn1My3YKKzZs3Kqg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.4746266227550917e+22
+    },
+    {
+        "timestamp": "2022-12-19T02:09:55.997Z",
+        "balance": 1.0012270025580002e+26,
+        "block_height": 80970690,
+        "epoch_id": "B9yXmTG5EUa4KZJBRYnRAB9PcQFJdQXpHxeuCjCNdbt3",
+        "next_epoch_id": "5mYGnpTcEkfTknpXCXpgXsuRKkoMUam4uX7WiqJk6jWD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5092666393088833e+22
+    },
+    {
+        "timestamp": "2022-12-18T12:23:32.500Z",
+        "balance": 1.0010760758940693e+26,
+        "block_height": 80927490,
+        "epoch_id": "7FYk1nNWgo5goL2YRGPbVtqxQme327u7vQLYDehXqVDS",
+        "next_epoch_id": "B9yXmTG5EUa4KZJBRYnRAB9PcQFJdQXpHxeuCjCNdbt3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5214563394869201e+22
+    },
+    {
+        "timestamp": "2022-12-17T22:37:11.727Z",
+        "balance": 1.0009239302601206e+26,
+        "block_height": 80884290,
+        "epoch_id": "Hr531UsVafgntxwtuDvXwAcayPXHbTfERot7o31oqzLE",
+        "next_epoch_id": "7FYk1nNWgo5goL2YRGPbVtqxQme327u7vQLYDehXqVDS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5034350973696768e+22
+    },
+    {
+        "timestamp": "2022-12-17T08:42:01.836Z",
+        "balance": 1.0007735867503837e+26,
+        "block_height": 80841090,
+        "epoch_id": "6peP4456KiwpwvzPuiTjJbX4S2B3De12RDAxcexFbie7",
+        "next_epoch_id": "Hr531UsVafgntxwtuDvXwAcayPXHbTfERot7o31oqzLE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5410244961835667e+22
+    },
+    {
+        "timestamp": "2022-12-16T18:55:03.174Z",
+        "balance": 1.0006194843007653e+26,
+        "block_height": 80797890,
+        "epoch_id": "EsoebE3uKqtsh3B86jEU4kx1WF5v5Y9JynKzfkqqMmRW",
+        "next_epoch_id": "6peP4456KiwpwvzPuiTjJbX4S2B3De12RDAxcexFbie7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.542267461967874e+22
+    },
+    {
+        "timestamp": "2022-12-16T04:46:06.618Z",
+        "balance": 1.0004652575545685e+26,
+        "block_height": 80754690,
+        "epoch_id": "5tGwsoNRG2274d1BCThwa1tQU7iL81WutndzzsQeYun4",
+        "next_epoch_id": "EsoebE3uKqtsh3B86jEU4kx1WF5v5Y9JynKzfkqqMmRW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.550426804675461e+22
+    },
+    {
+        "timestamp": "2022-12-15T14:46:59.944Z",
+        "balance": 1.000310214874101e+26,
+        "block_height": 80711490,
+        "epoch_id": "Em9iLhZxtz2ywwdZrvF1cXthKM8dVJ9C5hWNXahiAMUb",
+        "next_epoch_id": "5tGwsoNRG2274d1BCThwa1tQU7iL81WutndzzsQeYun4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5704797962985953e+22
+    },
+    {
+        "timestamp": "2022-12-15T00:43:38.984Z",
+        "balance": 1.0001531668944711e+26,
+        "block_height": 80668290,
+        "epoch_id": "EFwXgcHdUPvY8E3oMPuREd4DyrLxKS5hua6k8twXtT6A",
+        "next_epoch_id": "Em9iLhZxtz2ywwdZrvF1cXthKM8dVJ9C5hWNXahiAMUb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5316689447105474e+22
+    },
+    {
+        "timestamp": "2022-12-14T10:29:50.854Z",
+        "balance": 1e+26,
+        "block_height": 80625090,
+        "epoch_id": "Hd4jjSEujjUz9qFmyh5hVJfg52ZT1KnNt4F11gCbdHgX",
+        "next_epoch_id": "EFwXgcHdUPvY8E3oMPuREd4DyrLxKS5hua6k8twXtT6A",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-13T20:57:21.080Z",
+        "balance": 1e+26,
+        "hash": "4syZCwYR9MdRvfPPV1FCt6XPtdSQX2PGyfA58tcbBy4w",
+        "block_height": 80582947,
+        "epoch_id": "Hd4jjSEujjUz9qFmyh5hVJfg52ZT1KnNt4F11gCbdHgX",
+        "next_epoch_id": "EFwXgcHdUPvY8E3oMPuREd4DyrLxKS5hua6k8twXtT6A",
+        "deposit": 1e+26,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-13T20:56:44.801Z",
+        "balance": 0,
+        "hash": "GJof1hwvnEtw3TpV5K9XZwpQfxrYgM2af38EHmdUnZSW",
+        "block_height": 80582914,
+        "epoch_id": "Hd4jjSEujjUz9qFmyh5hVJfg52ZT1KnNt4F11gCbdHgX",
+        "next_epoch_id": "EFwXgcHdUPvY8E3oMPuREd4DyrLxKS5hua6k8twXtT6A",
+        "deposit": 0,
+        "withdrawal": 1.1178057595053792e+26,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-13T20:37:25.778Z",
+        "balance": 1.1178057595053792e+26,
+        "block_height": 80581890,
+        "epoch_id": "5w7rNnceQmEsfFP5HFPWDGaVTNhhmtzpj6GxH2f86jza",
+        "next_epoch_id": "Hd4jjSEujjUz9qFmyh5hVJfg52ZT1KnNt4F11gCbdHgX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-13T06:28:48.374Z",
+        "balance": 1.1178057595053792e+26,
+        "block_height": 80538690,
+        "epoch_id": "6knziGBz73Zn7x3cB5t17hBT98U9NH4YxnBupDRLAzMX",
+        "next_epoch_id": "5w7rNnceQmEsfFP5HFPWDGaVTNhhmtzpj6GxH2f86jza",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-12T16:27:28.304Z",
+        "balance": 1.1178057595053792e+26,
+        "block_height": 80495490,
+        "epoch_id": "6TcpJ8DsrFcw3F9RZpCdgWdxbZe8GDe9rCKVg2SAKEBV",
+        "next_epoch_id": "6knziGBz73Zn7x3cB5t17hBT98U9NH4YxnBupDRLAzMX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-12T02:25:27.394Z",
+        "balance": 1.1178057595053792e+26,
+        "block_height": 80452290,
+        "epoch_id": "79x6gYdk2LqBFxagdDKQszQoZcV4m3HRsKvFX78nhcD6",
+        "next_epoch_id": "6TcpJ8DsrFcw3F9RZpCdgWdxbZe8GDe9rCKVg2SAKEBV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-11T12:33:17.716Z",
+        "balance": 1.1178057595053792e+26,
+        "block_height": 80409090,
+        "epoch_id": "7MHG589WTnqLMrvrECwC6aDafnNHGHQmnqWAKJopohBW",
+        "next_epoch_id": "79x6gYdk2LqBFxagdDKQszQoZcV4m3HRsKvFX78nhcD6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-10T22:43:53.458Z",
+        "balance": 1.1178057595053792e+26,
+        "block_height": 80365890,
+        "epoch_id": "7SwPxBQv2aNyQs7s4LzQ9zi53u6eKFcjAiSsKxMFQxaw",
+        "next_epoch_id": "7MHG589WTnqLMrvrECwC6aDafnNHGHQmnqWAKJopohBW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-10T08:44:43.721Z",
+        "balance": 1.1178057595053792e+26,
+        "block_height": 80322690,
+        "epoch_id": "SWf5Rp1gHenypjDbKvbcAqi4XoEPKLbWb9juw32UYAc",
+        "next_epoch_id": "7SwPxBQv2aNyQs7s4LzQ9zi53u6eKFcjAiSsKxMFQxaw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 0
+    },
+    {
+        "timestamp": "2022-12-10T05:07:01.661Z",
+        "balance": 1.1178057595053792e+26,
+        "hash": "8EDs6Rn1LPmG5hFopCErGTTYA5YTGxEbNeBNb37Jkrfg",
+        "block_height": 80311315,
+        "epoch_id": "SWf5Rp1gHenypjDbKvbcAqi4XoEPKLbWb9juw32UYAc",
+        "next_epoch_id": "7SwPxBQv2aNyQs7s4LzQ9zi53u6eKFcjAiSsKxMFQxaw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6798884767189856e+22
+    },
+    {
+        "timestamp": "2022-12-09T18:46:44.659Z",
+        "balance": 1.1176377706577073e+26,
+        "block_height": 80279490,
+        "epoch_id": "GwboET2merPWv2g8qSWcRNFDMKygqdxUAg2T4WrUJ5w",
+        "next_epoch_id": "SWf5Rp1gHenypjDbKvbcAqi4XoEPKLbWb9juw32UYAc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6676936892964976e+22
+    },
+    {
+        "timestamp": "2022-12-09T04:39:00.569Z",
+        "balance": 1.1174710012887777e+26,
+        "block_height": 80236290,
+        "epoch_id": "HkR5faW2Wv5A8zXSzFfTxHTyTE6VXhCzzdQJE5J9MvvH",
+        "next_epoch_id": "GwboET2merPWv2g8qSWcRNFDMKygqdxUAg2T4WrUJ5w",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6672074637592427e+22
+    },
+    {
+        "timestamp": "2022-12-08T14:37:24.289Z",
+        "balance": 1.1173042805424017e+26,
+        "block_height": 80193090,
+        "epoch_id": "4SjtaUTt2PcnmCgWhX3fpqZfEorWbhjNjsLc3ZdpnkKX",
+        "next_epoch_id": "HkR5faW2Wv5A8zXSzFfTxHTyTE6VXhCzzdQJE5J9MvvH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7117148948420918e+22
+    },
+    {
+        "timestamp": "2022-12-08T00:36:09.722Z",
+        "balance": 1.1171331090529175e+26,
+        "block_height": 80149890,
+        "epoch_id": "Fz618UfUGrWLL8P5Vmgzdj6XvY5ysJq3AgGfHwvrEhnU",
+        "next_epoch_id": "4SjtaUTt2PcnmCgWhX3fpqZfEorWbhjNjsLc3ZdpnkKX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6881844603304534e+22
+    },
+    {
+        "timestamp": "2022-12-07T10:12:16.232Z",
+        "balance": 1.1169642906068845e+26,
+        "block_height": 80106690,
+        "epoch_id": "2hqcAX5Qyo2tuYG3wKpw2vq8C1Q4nxyUoc6bevFaLXNv",
+        "next_epoch_id": "Fz618UfUGrWLL8P5Vmgzdj6XvY5ysJq3AgGfHwvrEhnU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.693014029754621e+22
+    },
+    {
+        "timestamp": "2022-12-06T20:00:13.402Z",
+        "balance": 1.116794989203909e+26,
+        "block_height": 80063490,
+        "epoch_id": "FVtntZ55U96L9PvfZuZwJeVAthvhwDyVRmVEcP4VuAnf",
+        "next_epoch_id": "2hqcAX5Qyo2tuYG3wKpw2vq8C1Q4nxyUoc6bevFaLXNv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7212393818889803e+22
+    },
+    {
+        "timestamp": "2022-12-06T05:46:18.231Z",
+        "balance": 1.1166228652657201e+26,
+        "block_height": 80020290,
+        "epoch_id": "31cS6Nq14ssA6q5w1sUwbLNvshkZZ8nsX313VKestSci",
+        "next_epoch_id": "FVtntZ55U96L9PvfZuZwJeVAthvhwDyVRmVEcP4VuAnf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6704959522072592e+22
+    },
+    {
+        "timestamp": "2022-12-05T15:18:13.025Z",
+        "balance": 1.1164558156704994e+26,
+        "block_height": 79977090,
+        "epoch_id": "GaWdkkFLtTJopsLKVd2UxFZB5sVoHKMEti1RYrggdUYK",
+        "next_epoch_id": "31cS6Nq14ssA6q5w1sUwbLNvshkZZ8nsX313VKestSci",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6635574654760984e+22
+    },
+    {
+        "timestamp": "2022-12-05T01:16:10.309Z",
+        "balance": 1.1162894599239518e+26,
+        "block_height": 79933890,
+        "epoch_id": "9oh6KD5bwEWnwMRNTPzbqhY8xe2i8Pbuqksc2i2BJ4Gz",
+        "next_epoch_id": "GaWdkkFLtTJopsLKVd2UxFZB5sVoHKMEti1RYrggdUYK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6439164249642732e+22
+    },
+    {
+        "timestamp": "2022-12-04T11:20:57.886Z",
+        "balance": 1.1161250682814554e+26,
+        "block_height": 79890690,
+        "epoch_id": "B56dc2uwZMWMS1kEgPm8WjcsKBGFZtM7QuwdkFyaiHAd",
+        "next_epoch_id": "9oh6KD5bwEWnwMRNTPzbqhY8xe2i8Pbuqksc2i2BJ4Gz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7031659915656011e+22
+    },
+    {
+        "timestamp": "2022-12-03T21:35:39.833Z",
+        "balance": 1.1159547516822988e+26,
+        "block_height": 79847490,
+        "epoch_id": "HjWiXZ3dKcy4f7yRHLVfzbwmjZEATaBVeETfEyyo1fnj",
+        "next_epoch_id": "B56dc2uwZMWMS1kEgPm8WjcsKBGFZtM7QuwdkFyaiHAd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7031272916030077e+22
+    },
+    {
+        "timestamp": "2022-12-03T07:23:10.023Z",
+        "balance": 1.1157844389531385e+26,
+        "block_height": 79804290,
+        "epoch_id": "8i1HExUuPRnnou8ewidHUAhujtJdBDFr63akV2VCNoXG",
+        "next_epoch_id": "HjWiXZ3dKcy4f7yRHLVfzbwmjZEATaBVeETfEyyo1fnj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6873426715223987e+22
+    },
+    {
+        "timestamp": "2022-12-02T17:08:39.822Z",
+        "balance": 1.1156157046859863e+26,
+        "block_height": 79761090,
+        "epoch_id": "CCgXKEK3gTKqxaCjz3Rgg4K54HyapiLhWHPZwPFntAmu",
+        "next_epoch_id": "8i1HExUuPRnnou8ewidHUAhujtJdBDFr63akV2VCNoXG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6917307906495307e+22
+    },
+    {
+        "timestamp": "2022-12-02T03:02:13.908Z",
+        "balance": 1.1154465316069213e+26,
+        "block_height": 79717890,
+        "epoch_id": "7wkmV1uCGuu3zLCvAyFwKxZEMGZFJsoKxCApBds4s25Z",
+        "next_epoch_id": "CCgXKEK3gTKqxaCjz3Rgg4K54HyapiLhWHPZwPFntAmu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6737318652424869e+22
+    },
+    {
+        "timestamp": "2022-12-01T12:53:05.126Z",
+        "balance": 1.115279158420397e+26,
+        "block_height": 79674690,
+        "epoch_id": "6qd1SjFaCwpE3PDi1KBraSbz5NdRqm8rxqMbuVVNuRdb",
+        "next_epoch_id": "7wkmV1uCGuu3zLCvAyFwKxZEMGZFJsoKxCApBds4s25Z",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7046947650655754e+22
+    },
+    {
+        "timestamp": "2022-11-30T22:55:05.568Z",
+        "balance": 1.1151086889438905e+26,
+        "block_height": 79631490,
+        "epoch_id": "EGeznQfni7WwLZG7jEzPA4L5y7y3H26cq3yBSRRMcqRQ",
+        "next_epoch_id": "6qd1SjFaCwpE3PDi1KBraSbz5NdRqm8rxqMbuVVNuRdb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7080599496327959e+22
+    },
+    {
+        "timestamp": "2022-11-30T08:41:26.208Z",
+        "balance": 1.1149378829489272e+26,
+        "block_height": 79588290,
+        "epoch_id": "7GKPczhy1DQrnqqnufvoktxTqRzLzhS5iKc7WWveKkVE",
+        "next_epoch_id": "EGeznQfni7WwLZG7jEzPA4L5y7y3H26cq3yBSRRMcqRQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7483054386755964e+22
+    },
+    {
+        "timestamp": "2022-11-29T18:37:39.674Z",
+        "balance": 1.1147630524050597e+26,
+        "block_height": 79545090,
+        "epoch_id": "EDGgq9g2PkRGASc7jxke1SVnHgFHSUCDGALFKDzTRqw",
+        "next_epoch_id": "7GKPczhy1DQrnqqnufvoktxTqRzLzhS5iKc7WWveKkVE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7251930185922679e+22
+    },
+    {
+        "timestamp": "2022-11-29T03:43:28.271Z",
+        "balance": 1.1145905331032004e+26,
+        "block_height": 79501890,
+        "epoch_id": "8UETBoquAfFFnnBetAUUpBHNEHmGpCe1JeSmn3qSxhbk",
+        "next_epoch_id": "EDGgq9g2PkRGASc7jxke1SVnHgFHSUCDGALFKDzTRqw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6840738665624664e+22
+    },
+    {
+        "timestamp": "2022-11-28T13:31:27.023Z",
+        "balance": 1.1144221257165442e+26,
+        "block_height": 79458690,
+        "epoch_id": "9MuDnqTu3kRKzHJhpnUqqAgEHRfcBp6rX9CAkTHtvGWi",
+        "next_epoch_id": "8UETBoquAfFFnnBetAUUpBHNEHmGpCe1JeSmn3qSxhbk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7086638318769605e+22
+    },
+    {
+        "timestamp": "2022-11-27T23:39:48.375Z",
+        "balance": 1.1142512593333565e+26,
+        "block_height": 79415490,
+        "epoch_id": "wBLYiJt7pcP5dpXxUNeAixhufVmGLRHqPP2ScKajNBS",
+        "next_epoch_id": "9MuDnqTu3kRKzHJhpnUqqAgEHRfcBp6rX9CAkTHtvGWi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7081545802795794e+22
+    },
+    {
+        "timestamp": "2022-11-27T09:35:25.033Z",
+        "balance": 1.1140804438753285e+26,
+        "block_height": 79372290,
+        "epoch_id": "4jaFS1baqaYMeGb7yCNqAYnTuJ3jP4V3bjxZPUz4boUd",
+        "next_epoch_id": "wBLYiJt7pcP5dpXxUNeAixhufVmGLRHqPP2ScKajNBS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7099195055950413e+22
+    },
+    {
+        "timestamp": "2022-11-26T19:32:12.014Z",
+        "balance": 1.113909451924769e+26,
+        "block_height": 79329090,
+        "epoch_id": "G4M9tG9eaXzPT1fT1cXutoahLVeSAJS6LBipysQBHMT7",
+        "next_epoch_id": "4jaFS1baqaYMeGb7yCNqAYnTuJ3jP4V3bjxZPUz4boUd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.687290540501286e+22
+    },
+    {
+        "timestamp": "2022-11-26T05:28:07.370Z",
+        "balance": 1.1137407228707189e+26,
+        "block_height": 79285890,
+        "epoch_id": "6PuRQpPhD1GTBZddG3DA3mr7X6RGAi9BRhaXhRaHuKC1",
+        "next_epoch_id": "G4M9tG9eaXzPT1fT1cXutoahLVeSAJS6LBipysQBHMT7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7120979903358817e+22
+    },
+    {
+        "timestamp": "2022-11-25T15:36:02.187Z",
+        "balance": 1.1135695130716853e+26,
+        "block_height": 79242690,
+        "epoch_id": "DGKqNVPWRVQR39TNYHQbahfTpXbA4FaUrj6XHxwAoNo1",
+        "next_epoch_id": "6PuRQpPhD1GTBZddG3DA3mr7X6RGAi9BRhaXhRaHuKC1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.717101299783979e+22
+    },
+    {
+        "timestamp": "2022-11-25T01:31:17.668Z",
+        "balance": 1.1133978029417069e+26,
+        "block_height": 79199490,
+        "epoch_id": "HbtLhZPC24X3ogcDqSr1pdBefcmL1LMbeWYzwtZfbWtA",
+        "next_epoch_id": "DGKqNVPWRVQR39TNYHQbahfTpXbA4FaUrj6XHxwAoNo1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7103221113488585e+22
+    },
+    {
+        "timestamp": "2022-11-24T11:23:18.524Z",
+        "balance": 1.113226770730572e+26,
+        "block_height": 79156290,
+        "epoch_id": "3WMyrfKGFYtsXhjZDusGPDRTEHs2FoaLnmXPy7JwNwvY",
+        "next_epoch_id": "HbtLhZPC24X3ogcDqSr1pdBefcmL1LMbeWYzwtZfbWtA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.724121486080547e+22
+    },
+    {
+        "timestamp": "2022-11-23T21:20:27.740Z",
+        "balance": 1.113054358581964e+26,
+        "block_height": 79113090,
+        "epoch_id": "Dr5S3KKobDpf6BHzCioscSKeHk1GED3v38SGZfWrTdkL",
+        "next_epoch_id": "3WMyrfKGFYtsXhjZDusGPDRTEHs2FoaLnmXPy7JwNwvY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7147008573317782e+22
+    },
+    {
+        "timestamp": "2022-11-23T07:10:19.061Z",
+        "balance": 1.1128828884962308e+26,
+        "block_height": 79069890,
+        "epoch_id": "CQb7FPt2t4WuYHB1R542DLSE9UCBzNq2Ho86624eTbS3",
+        "next_epoch_id": "Dr5S3KKobDpf6BHzCioscSKeHk1GED3v38SGZfWrTdkL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7096222720156724e+22
+    },
+    {
+        "timestamp": "2022-11-22T17:04:34.075Z",
+        "balance": 1.1127119262690292e+26,
+        "block_height": 79026690,
+        "epoch_id": "EwWpVTAc7HzunmhEYEFsM7aYjf7AxpFGETuRBtQMeu8D",
+        "next_epoch_id": "CQb7FPt2t4WuYHB1R542DLSE9UCBzNq2Ho86624eTbS3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7125539241663006e+22
+    },
+    {
+        "timestamp": "2022-11-22T03:02:03.760Z",
+        "balance": 1.1125406708766126e+26,
+        "block_height": 78983490,
+        "epoch_id": "3A13S7kcLj5YJQ9RQn3GbXwTUXB2xjwxVHparzanDMDo",
+        "next_epoch_id": "EwWpVTAc7HzunmhEYEFsM7aYjf7AxpFGETuRBtQMeu8D",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6884029968357926e+22
+    },
+    {
+        "timestamp": "2022-11-21T12:58:15.449Z",
+        "balance": 1.112371830576929e+26,
+        "block_height": 78940290,
+        "epoch_id": "5pw4aoPoEaDWtLTBEB1zAbnvFFV9JUTTksTZwR3B7Qv",
+        "next_epoch_id": "3A13S7kcLj5YJQ9RQn3GbXwTUXB2xjwxVHparzanDMDo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7132370054785544e+22
+    },
+    {
+        "timestamp": "2022-11-20T23:04:05.853Z",
+        "balance": 1.1122005068763812e+26,
+        "block_height": 78897090,
+        "epoch_id": "55sP2grdJPCR5LZkcRNnJCRAAjDz4cxFVtUWsn8d8zAx",
+        "next_epoch_id": "5pw4aoPoEaDWtLTBEB1zAbnvFFV9JUTTksTZwR3B7Qv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6992596266742507e+22
+    },
+    {
+        "timestamp": "2022-11-20T08:57:33.764Z",
+        "balance": 1.1120305809137137e+26,
+        "block_height": 78853890,
+        "epoch_id": "BJto3ABhPH1yTRxpq5KsrCyZZxL6VRz1HRdMsu5Dt47d",
+        "next_epoch_id": "55sP2grdJPCR5LZkcRNnJCRAAjDz4cxFVtUWsn8d8zAx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7156826515578846e+22
+    },
+    {
+        "timestamp": "2022-11-19T18:57:53.149Z",
+        "balance": 1.111859012648558e+26,
+        "block_height": 78810690,
+        "epoch_id": "CxfEHGntH75hy63p7XYgkJHw6cn5r64VqXVuExmyUYUK",
+        "next_epoch_id": "BJto3ABhPH1yTRxpq5KsrCyZZxL6VRz1HRdMsu5Dt47d",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7156036553788965e+22
+    },
+    {
+        "timestamp": "2022-11-19T04:57:16.037Z",
+        "balance": 1.11168745228302e+26,
+        "block_height": 78767490,
+        "epoch_id": "GcJezuuoxhUWtr2Z88pCpzyQGP9LrbxV3JcQi2eoBWSU",
+        "next_epoch_id": "CxfEHGntH75hy63p7XYgkJHw6cn5r64VqXVuExmyUYUK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7306221752555084e+22
+    },
+    {
+        "timestamp": "2022-11-18T14:50:37.653Z",
+        "balance": 1.1115143900654945e+26,
+        "block_height": 78724290,
+        "epoch_id": "GcKhGdLNVAxrTtntGp5scdH2qcW4w2jUg46m21mW62W6",
+        "next_epoch_id": "GcJezuuoxhUWtr2Z88pCpzyQGP9LrbxV3JcQi2eoBWSU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7320335891555127e+22
+    },
+    {
+        "timestamp": "2022-11-18T00:36:15.886Z",
+        "balance": 1.111341186706579e+26,
+        "block_height": 78681090,
+        "epoch_id": "BAetWsFE6A6atvewcULHeTBMaAM7s7MkXPstwJiBVnKZ",
+        "next_epoch_id": "GcKhGdLNVAxrTtntGp5scdH2qcW4w2jUg46m21mW62W6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6849472109608192e+22
+    },
+    {
+        "timestamp": "2022-11-17T10:20:11.756Z",
+        "balance": 1.1111726919854829e+26,
+        "block_height": 78637890,
+        "epoch_id": "GRXm3S9QHXX4eqH4T4sSK8jb1T3tA2y2rMne9VjrsUVK",
+        "next_epoch_id": "BAetWsFE6A6atvewcULHeTBMaAM7s7MkXPstwJiBVnKZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.716103282906332e+22
+    },
+    {
+        "timestamp": "2022-11-16T20:28:44.928Z",
+        "balance": 1.1110010816571922e+26,
+        "block_height": 78594690,
+        "epoch_id": "B6DZx6EAYnmtVU73yYdJ192hfVEZT8hnVG2WNybqTyxg",
+        "next_epoch_id": "GRXm3S9QHXX4eqH4T4sSK8jb1T3tA2y2rMne9VjrsUVK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7268539750331e+22
+    },
+    {
+        "timestamp": "2022-11-16T06:20:33.760Z",
+        "balance": 1.110828396259689e+26,
+        "block_height": 78551490,
+        "epoch_id": "Ap9bHvQgUAsvtFsFDLCBmhb6wJYCWgCxTynt6aZc5saC",
+        "next_epoch_id": "B6DZx6EAYnmtVU73yYdJ192hfVEZT8hnVG2WNybqTyxg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6579432676373326e+22
+    },
+    {
+        "timestamp": "2022-11-15T16:07:02.593Z",
+        "balance": 1.1106626019329252e+26,
+        "block_height": 78508290,
+        "epoch_id": "AJK4pFzb28umJ3nMXNeVBSkjzu2xw3VsEweV8XVKYJ9C",
+        "next_epoch_id": "Ap9bHvQgUAsvtFsFDLCBmhb6wJYCWgCxTynt6aZc5saC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6561533741514067e+22
+    },
+    {
+        "timestamp": "2022-11-15T02:04:12.335Z",
+        "balance": 1.11049698659551e+26,
+        "block_height": 78465090,
+        "epoch_id": "FTdVFCpwyUNRGSCpwF9CG9iCayG4GZcC2nTKUjX2z7yC",
+        "next_epoch_id": "AJK4pFzb28umJ3nMXNeVBSkjzu2xw3VsEweV8XVKYJ9C",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6447392592707608e+22
+    },
+    {
+        "timestamp": "2022-11-14T12:03:24.451Z",
+        "balance": 1.110332512669583e+26,
+        "block_height": 78421890,
+        "epoch_id": "CVMX9TNR4o5hCpwtab6bqxgbn6xgAgRzDyKsrNztNXxv",
+        "next_epoch_id": "FTdVFCpwyUNRGSCpwF9CG9iCayG4GZcC2nTKUjX2z7yC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6960875132444654e+22
+    },
+    {
+        "timestamp": "2022-11-13T22:11:54.288Z",
+        "balance": 1.1101629039182585e+26,
+        "block_height": 78378690,
+        "epoch_id": "EJrknLiuh4AVFtVstE8941Ff7iVjNnC3e9B5UwS5Ms6H",
+        "next_epoch_id": "CVMX9TNR4o5hCpwtab6bqxgbn6xgAgRzDyKsrNztNXxv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6672226201542284e+22
+    },
+    {
+        "timestamp": "2022-11-13T07:53:24.924Z",
+        "balance": 1.1099961816562431e+26,
+        "block_height": 78335490,
+        "epoch_id": "8T8vRamM38PR6GcG3gtjNXKDC4i2CbXRf6xEKssc8rje",
+        "next_epoch_id": "EJrknLiuh4AVFtVstE8941Ff7iVjNnC3e9B5UwS5Ms6H",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7565147500342915e+22
+    },
+    {
+        "timestamp": "2022-11-12T17:46:10.520Z",
+        "balance": 1.1098205301812397e+26,
+        "block_height": 78292290,
+        "epoch_id": "GyCp1xRdBKQBXVnXwBRL4eBfhRq1YcMyyrTmgbSbfHYY",
+        "next_epoch_id": "8T8vRamM38PR6GcG3gtjNXKDC4i2CbXRf6xEKssc8rje",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.774237306455749e+22
+    },
+    {
+        "timestamp": "2022-11-12T03:32:09.582Z",
+        "balance": 1.1096431064505941e+26,
+        "block_height": 78249090,
+        "epoch_id": "Qt4V1TE6ypuFR22U1dHCAMcADSaYRUkWWFe4hHATmkd",
+        "next_epoch_id": "GyCp1xRdBKQBXVnXwBRL4eBfhRq1YcMyyrTmgbSbfHYY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7667973378347148e+22
+    },
+    {
+        "timestamp": "2022-11-11T13:08:29.639Z",
+        "balance": 1.1094664267168106e+26,
+        "block_height": 78205890,
+        "epoch_id": "6WNH91jbFC8Vozm42NSvQ2FRmzrWHZQYmqqW3bbdDso7",
+        "next_epoch_id": "Qt4V1TE6ypuFR22U1dHCAMcADSaYRUkWWFe4hHATmkd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7923165025097606e+22
+    },
+    {
+        "timestamp": "2022-11-10T22:47:57.113Z",
+        "balance": 1.1092871950665597e+26,
+        "block_height": 78162690,
+        "epoch_id": "368LMywDxdYdmkvTVGLH65CjrgrrkVHZAB3UvtrcT4TP",
+        "next_epoch_id": "6WNH91jbFC8Vozm42NSvQ2FRmzrWHZQYmqqW3bbdDso7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7881568726775304e+22
+    },
+    {
+        "timestamp": "2022-11-10T08:13:10.117Z",
+        "balance": 1.1091083793792919e+26,
+        "block_height": 78119490,
+        "epoch_id": "6w9h3GPwfaGfuTS3vm5ch8T9LHMiDPAeH7qtvrU4FpMD",
+        "next_epoch_id": "368LMywDxdYdmkvTVGLH65CjrgrrkVHZAB3UvtrcT4TP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7713799624036104e+22
+    },
+    {
+        "timestamp": "2022-11-09T17:37:43.054Z",
+        "balance": 1.1089312413830515e+26,
+        "block_height": 78076290,
+        "epoch_id": "J1MYA1rxm1egY1uQjceXr5haSniBBYcXDoCUbJDQjU6x",
+        "next_epoch_id": "6w9h3GPwfaGfuTS3vm5ch8T9LHMiDPAeH7qtvrU4FpMD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7672816526612788e+22
+    },
+    {
+        "timestamp": "2022-11-09T03:10:30.663Z",
+        "balance": 1.1087545132177854e+26,
+        "block_height": 78033090,
+        "epoch_id": "FsVq19BMKmS5sEu5Ng4U3o5iSEZTzRZyFCKLkN3SMAeq",
+        "next_epoch_id": "J1MYA1rxm1egY1uQjceXr5haSniBBYcXDoCUbJDQjU6x",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8344277420757001e+22
+    },
+    {
+        "timestamp": "2022-11-08T12:41:24.466Z",
+        "balance": 1.1085710704435778e+26,
+        "block_height": 77989890,
+        "epoch_id": "2dPvKTbJKP8fQkb8sMuS1QU2kfsfpzUETxRKu71EMWKq",
+        "next_epoch_id": "FsVq19BMKmS5sEu5Ng4U3o5iSEZTzRZyFCKLkN3SMAeq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6106668523783352e+22
+    },
+    {
+        "timestamp": "2022-11-07T21:39:29.344Z",
+        "balance": 1.10841000375834e+26,
+        "block_height": 77946690,
+        "epoch_id": "GazWfmY6KsNXFXeGfkZJz7dkWyvKwEawLVKYp1gotoWp",
+        "next_epoch_id": "2dPvKTbJKP8fQkb8sMuS1QU2kfsfpzUETxRKu71EMWKq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6145456452186048e+22
+    },
+    {
+        "timestamp": "2022-11-07T07:13:50.920Z",
+        "balance": 1.1082485491938182e+26,
+        "block_height": 77903490,
+        "epoch_id": "ApJTxnJiRxayDrLuwwKeDs11afVm7fFG9zBZquxwKCTP",
+        "next_epoch_id": "GazWfmY6KsNXFXeGfkZJz7dkWyvKwEawLVKYp1gotoWp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8420741403850509e+22
+    },
+    {
+        "timestamp": "2022-11-06T16:55:04.340Z",
+        "balance": 1.1080643417797796e+26,
+        "block_height": 77860290,
+        "epoch_id": "7c5agiptJDGcsM2fGPUjGRu2v73EHLokqLxs21jmg82N",
+        "next_epoch_id": "ApJTxnJiRxayDrLuwwKeDs11afVm7fFG9zBZquxwKCTP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7864011392844307e+22
+    },
+    {
+        "timestamp": "2022-11-06T01:54:12.644Z",
+        "balance": 1.1078857016658512e+26,
+        "block_height": 77817090,
+        "epoch_id": "13VY4rncQVpjFhdnUdCxuJWuNPp17PM7hkSG79tjpkWW",
+        "next_epoch_id": "7c5agiptJDGcsM2fGPUjGRu2v73EHLokqLxs21jmg82N",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7391734963872744e+22
+    },
+    {
+        "timestamp": "2022-11-05T10:59:04.402Z",
+        "balance": 1.1077117843162125e+26,
+        "block_height": 77773890,
+        "epoch_id": "GAHJBiYMoqDhLr5RvehxUUr2DU2SVTvjmXo8PAFq69BN",
+        "next_epoch_id": "13VY4rncQVpjFhdnUdCxuJWuNPp17PM7hkSG79tjpkWW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.747384197118068e+22
+    },
+    {
+        "timestamp": "2022-11-04T20:28:25.564Z",
+        "balance": 1.1075370458965007e+26,
+        "block_height": 77730690,
+        "epoch_id": "8QUTia4eXNtxhQC3MkxHjgH569yv4nx5ZBk98usPmjNR",
+        "next_epoch_id": "GAHJBiYMoqDhLr5RvehxUUr2DU2SVTvjmXo8PAFq69BN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7259189989192015e+22
+    },
+    {
+        "timestamp": "2022-11-04T05:48:36.640Z",
+        "balance": 1.1073644539966088e+26,
+        "block_height": 77687490,
+        "epoch_id": "JE742LACes7sR32uiCQa5K9HmGuo8RAGeL3nnVotH6Vs",
+        "next_epoch_id": "8QUTia4eXNtxhQC3MkxHjgH569yv4nx5ZBk98usPmjNR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7248922799227305e+22
+    },
+    {
+        "timestamp": "2022-11-03T15:18:19.662Z",
+        "balance": 1.1071919647686165e+26,
+        "block_height": 77644290,
+        "epoch_id": "FQoHiTfWAiMixLG29rLfoHwEHFgdy34hZSBigroFM8ne",
+        "next_epoch_id": "JE742LACes7sR32uiCQa5K9HmGuo8RAGeL3nnVotH6Vs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.755992287361462e+22
+    },
+    {
+        "timestamp": "2022-11-03T00:47:34.300Z",
+        "balance": 1.1070163655398803e+26,
+        "block_height": 77601090,
+        "epoch_id": "GE9Tv76V32QdKujh3yHyvEk4f7Ek5TGxoJDQDYvyCkMt",
+        "next_epoch_id": "FQoHiTfWAiMixLG29rLfoHwEHFgdy34hZSBigroFM8ne",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7101896167926614e+22
+    },
+    {
+        "timestamp": "2022-11-02T09:59:31.057Z",
+        "balance": 1.106845346578201e+26,
+        "block_height": 77557890,
+        "epoch_id": "88hDzhn1P8zE1ur8fbA3AxmPjnZQqfJjh33jyUQZgXy4",
+        "next_epoch_id": "GE9Tv76V32QdKujh3yHyvEk4f7Ek5TGxoJDQDYvyCkMt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7413431893403678e+22
+    },
+    {
+        "timestamp": "2022-11-01T19:36:10.796Z",
+        "balance": 1.106671212259267e+26,
+        "block_height": 77514690,
+        "epoch_id": "5EYHzarTPBH9finnP3Mc7AXXAXkfGbpSeaHQ8wn5LSn8",
+        "next_epoch_id": "88hDzhn1P8zE1ur8fbA3AxmPjnZQqfJjh33jyUQZgXy4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7350471936235014e+22
+    },
+    {
+        "timestamp": "2022-11-01T04:56:49.423Z",
+        "balance": 1.1064977075399047e+26,
+        "block_height": 77471490,
+        "epoch_id": "EECqcrCuZXaePJJjdg2Z7M8NoeWMijWVUuinPwsF5NCq",
+        "next_epoch_id": "5EYHzarTPBH9finnP3Mc7AXXAXkfGbpSeaHQ8wn5LSn8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6922866629967824e+22
+    },
+    {
+        "timestamp": "2022-10-31T14:20:21.708Z",
+        "balance": 1.106328478873605e+26,
+        "block_height": 77428290,
+        "epoch_id": "AksNL3zPCKVC6EntAtLeTVsSkTiCdauPMQEShr4WbjFF",
+        "next_epoch_id": "EECqcrCuZXaePJJjdg2Z7M8NoeWMijWVUuinPwsF5NCq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8007098689315156e+22
+    },
+    {
+        "timestamp": "2022-10-31T00:05:44.998Z",
+        "balance": 1.1061484078867118e+26,
+        "block_height": 77385090,
+        "epoch_id": "H3yVu46bXQXbuumh9aFLwrNbCqvShu4PBy4BnSrHH9Hz",
+        "next_epoch_id": "AksNL3zPCKVC6EntAtLeTVsSkTiCdauPMQEShr4WbjFF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7557137443235601e+22
+    },
+    {
+        "timestamp": "2022-10-30T09:29:29.995Z",
+        "balance": 1.1059728365122795e+26,
+        "block_height": 77341890,
+        "epoch_id": "4arbvweYVBQwCP7HNHEnm8A8YT4eVX2WqbVNLLDjXT56",
+        "next_epoch_id": "H3yVu46bXQXbuumh9aFLwrNbCqvShu4PBy4BnSrHH9Hz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8740674883134012e+22
+    },
+    {
+        "timestamp": "2022-10-29T18:42:41.859Z",
+        "balance": 1.1057854297634482e+26,
+        "block_height": 77298690,
+        "epoch_id": "Akb8q7dRbctNuyhv1hdh8W3JJ9K9j8DYYCdcPV5obrXA",
+        "next_epoch_id": "4arbvweYVBQwCP7HNHEnm8A8YT4eVX2WqbVNLLDjXT56",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8172265992057185e+22
+    },
+    {
+        "timestamp": "2022-10-29T02:53:40.553Z",
+        "balance": 1.1056037071035276e+26,
+        "block_height": 77255490,
+        "epoch_id": "2d6KBxrfL7G31pVJJUaqqbzpQdQEsEdPbrw8sZShQEVr",
+        "next_epoch_id": "Akb8q7dRbctNuyhv1hdh8W3JJ9K9j8DYYCdcPV5obrXA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7078366419496487e+22
+    },
+    {
+        "timestamp": "2022-10-28T11:37:14.156Z",
+        "balance": 1.1054329234393326e+26,
+        "block_height": 77212290,
+        "epoch_id": "WdwsMTZGTZSE4uKAm8zVrPvHtvhkwcwfAXo8ij2tHKg",
+        "next_epoch_id": "2d6KBxrfL7G31pVJJUaqqbzpQdQEsEdPbrw8sZShQEVr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.727652000548488e+22
+    },
+    {
+        "timestamp": "2022-10-27T21:18:08.665Z",
+        "balance": 1.1052601582392778e+26,
+        "block_height": 77169090,
+        "epoch_id": "CryQFW9z8Njz6bP5DUTGxPyUq9WUbMZmoKsSkVuruZK4",
+        "next_epoch_id": "WdwsMTZGTZSE4uKAm8zVrPvHtvhkwcwfAXo8ij2tHKg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7482290076726977e+22
+    },
+    {
+        "timestamp": "2022-10-27T06:49:59.237Z",
+        "balance": 1.1050853353385105e+26,
+        "block_height": 77125890,
+        "epoch_id": "8Zb3TBeW7E86RLYys4vADXSBYTAjXZSnQj6RerwiJtSo",
+        "next_epoch_id": "CryQFW9z8Njz6bP5DUTGxPyUq9WUbMZmoKsSkVuruZK4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7298369451555058e+22
+    },
+    {
+        "timestamp": "2022-10-26T16:13:05.987Z",
+        "balance": 1.104912351643995e+26,
+        "block_height": 77082690,
+        "epoch_id": "G5PR4MuBgV67GB5ZBY62d7XbjA3XXikHSMJC9NxNAHDs",
+        "next_epoch_id": "8Zb3TBeW7E86RLYys4vADXSBYTAjXZSnQj6RerwiJtSo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7176139944573549e+22
+    },
+    {
+        "timestamp": "2022-10-26T01:42:48.208Z",
+        "balance": 1.1047405902445492e+26,
+        "block_height": 77039490,
+        "epoch_id": "BHSpQhW1ZqUPEEtCB9afhRHzZdEkPFBuW3uHQXtSs6Ft",
+        "next_epoch_id": "G5PR4MuBgV67GB5ZBY62d7XbjA3XXikHSMJC9NxNAHDs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.697140472919157e+22
+    },
+    {
+        "timestamp": "2022-10-25T11:18:51.862Z",
+        "balance": 1.1045708761972573e+26,
+        "block_height": 76996290,
+        "epoch_id": "FMoNp34TVh6Cwsh4erdAwCQvzv1n6BQLVuCVWYZc3xaK",
+        "next_epoch_id": "BHSpQhW1ZqUPEEtCB9afhRHzZdEkPFBuW3uHQXtSs6Ft",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.75343621737574e+22
+    },
+    {
+        "timestamp": "2022-10-24T21:06:08.076Z",
+        "balance": 1.1043955325755197e+26,
+        "block_height": 76953090,
+        "epoch_id": "7PXokJyzmYFpH3B2uzRGgFvVk5x2V8hAoa4dWJ5MX1Yv",
+        "next_epoch_id": "FMoNp34TVh6Cwsh4erdAwCQvzv1n6BQLVuCVWYZc3xaK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7192230578131086e+22
+    },
+    {
+        "timestamp": "2022-10-24T06:24:17.677Z",
+        "balance": 1.1042236102697384e+26,
+        "block_height": 76909890,
+        "epoch_id": "AioyMgHpyN9pUnwuNtAC7XvteMPGKSGqVjckSyeGbBYm",
+        "next_epoch_id": "7PXokJyzmYFpH3B2uzRGgFvVk5x2V8hAoa4dWJ5MX1Yv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6969714014267527e+22
+    },
+    {
+        "timestamp": "2022-10-23T15:58:07.142Z",
+        "balance": 1.1040539131295957e+26,
+        "block_height": 76866690,
+        "epoch_id": "71MDQJLRpy9erbzyQjFi8M7YpByGhr2V9fhRmmaSMXgF",
+        "next_epoch_id": "AioyMgHpyN9pUnwuNtAC7XvteMPGKSGqVjckSyeGbBYm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.720873961547977e+22
+    },
+    {
+        "timestamp": "2022-10-23T01:43:44.275Z",
+        "balance": 1.103881825733441e+26,
+        "block_height": 76823490,
+        "epoch_id": "Hn3Fh2vceqkknD6TpbZffw9XsN7ojhmr3cKMzpDssGzG",
+        "next_epoch_id": "71MDQJLRpy9erbzyQjFi8M7YpByGhr2V9fhRmmaSMXgF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7324835673471967e+22
+    },
+    {
+        "timestamp": "2022-10-22T11:17:02.142Z",
+        "balance": 1.1037085773767062e+26,
+        "block_height": 76780290,
+        "epoch_id": "HUG9yYDvMTmRQtnvxjgirjzmPAroNXzy2BmqGy28mdP8",
+        "next_epoch_id": "Hn3Fh2vceqkknD6TpbZffw9XsN7ojhmr3cKMzpDssGzG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7469384296590635e+22
+    },
+    {
+        "timestamp": "2022-10-21T20:43:08.891Z",
+        "balance": 1.1035338835337403e+26,
+        "block_height": 76737090,
+        "epoch_id": "C5MzZTppbz714DJx4xj2XuAv2ne9ud6dodJmSLTwu4g8",
+        "next_epoch_id": "HUG9yYDvMTmRQtnvxjgirjzmPAroNXzy2BmqGy28mdP8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.692243535936519e+22
+    },
+    {
+        "timestamp": "2022-10-21T06:00:41.725Z",
+        "balance": 1.1033646591801467e+26,
+        "block_height": 76693890,
+        "epoch_id": "HQ9jQubWvRVkP3zcgDBjm4cPA6YZB2wx3eUDyN4uiNDX",
+        "next_epoch_id": "C5MzZTppbz714DJx4xj2XuAv2ne9ud6dodJmSLTwu4g8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.716882027684745e+22
+    },
+    {
+        "timestamp": "2022-10-20T15:48:18.357Z",
+        "balance": 1.1031929709773782e+26,
+        "block_height": 76650690,
+        "epoch_id": "6FhyCcmWaqjYRrzdk6ZYqGsizjxs3dQishDpAiPYAniv",
+        "next_epoch_id": "HQ9jQubWvRVkP3zcgDBjm4cPA6YZB2wx3eUDyN4uiNDX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7681273695261633e+22
+    },
+    {
+        "timestamp": "2022-10-20T01:23:20.162Z",
+        "balance": 1.1030161582404256e+26,
+        "block_height": 76607490,
+        "epoch_id": "2CDyXUCvuGY84kRWRkAwM4GNS9Jsra2cYDgekWUA51e8",
+        "next_epoch_id": "6FhyCcmWaqjYRrzdk6ZYqGsizjxs3dQishDpAiPYAniv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7598120126349192e+22
+    },
+    {
+        "timestamp": "2022-10-19T10:29:54.193Z",
+        "balance": 1.102840177039162e+26,
+        "block_height": 76564290,
+        "epoch_id": "C9KBDwhBJT7rN8XvK3HQWtQH1SsJjm6YXH53aPQGFj3X",
+        "next_epoch_id": "2CDyXUCvuGY84kRWRkAwM4GNS9Jsra2cYDgekWUA51e8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7045681978511507e+22
+    },
+    {
+        "timestamp": "2022-10-18T19:52:50.094Z",
+        "balance": 1.102669720219377e+26,
+        "block_height": 76521090,
+        "epoch_id": "5bP8PCfp7NyhqUE15Mf6Kk8wFMVAAB2ZmpwBPdFz6C2Y",
+        "next_epoch_id": "C9KBDwhBJT7rN8XvK3HQWtQH1SsJjm6YXH53aPQGFj3X",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7716696332980493e+22
+    },
+    {
+        "timestamp": "2022-10-18T05:32:45.117Z",
+        "balance": 1.1024925532560472e+26,
+        "block_height": 76477890,
+        "epoch_id": "9u38skJBTabq2HB3LoCYJ7xY8q3b864itUpYM3DJ5mkx",
+        "next_epoch_id": "5bP8PCfp7NyhqUE15Mf6Kk8wFMVAAB2ZmpwBPdFz6C2Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6941377417432755e+22
+    },
+    {
+        "timestamp": "2022-10-17T14:38:41.486Z",
+        "balance": 1.1023231394818728e+26,
+        "block_height": 76434690,
+        "epoch_id": "Go1vT3zeP2bw4rDAfbeiX1gzspVTyWGjjrXr8zRyRtAW",
+        "next_epoch_id": "9u38skJBTabq2HB3LoCYJ7xY8q3b864itUpYM3DJ5mkx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6802452354784704e+22
+    },
+    {
+        "timestamp": "2022-10-17T00:22:12.989Z",
+        "balance": 1.102155114958325e+26,
+        "block_height": 76391490,
+        "epoch_id": "4v3iy14wzzqkJkmtTSickMUABPsbEvTxVHENqzMufX13",
+        "next_epoch_id": "Go1vT3zeP2bw4rDAfbeiX1gzspVTyWGjjrXr8zRyRtAW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6352200956090614e+22
+    },
+    {
+        "timestamp": "2022-10-16T10:14:42.029Z",
+        "balance": 1.101991592948764e+26,
+        "block_height": 76348290,
+        "epoch_id": "3NcXihewVQ6KtEZK6yqBK75rdnAomWSKpECRLrHaDK9t",
+        "next_epoch_id": "4v3iy14wzzqkJkmtTSickMUABPsbEvTxVHENqzMufX13",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.667503748040888e+22
+    },
+    {
+        "timestamp": "2022-10-15T20:30:25.249Z",
+        "balance": 1.10182484257396e+26,
+        "block_height": 76305090,
+        "epoch_id": "EWgGRMkgYVvQj7sBuFU57sR579BiSWMkFavigmnFifxa",
+        "next_epoch_id": "3NcXihewVQ6KtEZK6yqBK75rdnAomWSKpECRLrHaDK9t",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6830931251290515e+22
+    },
+    {
+        "timestamp": "2022-10-15T06:29:53.655Z",
+        "balance": 1.101656533261447e+26,
+        "block_height": 76261890,
+        "epoch_id": "9wSwU6g6AR9KpDmEmfw1LV7UCn7sZ1R7Bz3FkLwXUcug",
+        "next_epoch_id": "EWgGRMkgYVvQj7sBuFU57sR579BiSWMkFavigmnFifxa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7414588777393572e+22
+    },
+    {
+        "timestamp": "2022-10-14T16:20:57.374Z",
+        "balance": 1.1014823873736731e+26,
+        "block_height": 76218690,
+        "epoch_id": "9F7abjVSHhMYBZSySURdrXFhXdYgokuQKGEzwRrML4Zp",
+        "next_epoch_id": "9wSwU6g6AR9KpDmEmfw1LV7UCn7sZ1R7Bz3FkLwXUcug",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7491293562364016e+22
+    },
+    {
+        "timestamp": "2022-10-14T01:42:49.683Z",
+        "balance": 1.1013074744380495e+26,
+        "block_height": 76175490,
+        "epoch_id": "7STQ9NZ61UCw6ec4DYoWRAuhUKFjLsq6nAaZT4f3bWpy",
+        "next_epoch_id": "9F7abjVSHhMYBZSySURdrXFhXdYgokuQKGEzwRrML4Zp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.719744260528076e+22
+    },
+    {
+        "timestamp": "2022-10-13T11:01:07.750Z",
+        "balance": 1.1011355000119967e+26,
+        "block_height": 76132290,
+        "epoch_id": "DWaHe9dqWegKQ7BCfsv2JekKcHoTxPbogG5bFMpUy5v4",
+        "next_epoch_id": "7STQ9NZ61UCw6ec4DYoWRAuhUKFjLsq6nAaZT4f3bWpy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7433533434294308e+22
+    },
+    {
+        "timestamp": "2022-10-12T20:33:17.720Z",
+        "balance": 1.1009611646776538e+26,
+        "block_height": 76089090,
+        "epoch_id": "EMRbJDos8SBtLdNGjhyLaXntdJBuhrJGZ2X87B57fqr7",
+        "next_epoch_id": "DWaHe9dqWegKQ7BCfsv2JekKcHoTxPbogG5bFMpUy5v4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7690011233345427e+22
+    },
+    {
+        "timestamp": "2022-10-12T05:53:39.133Z",
+        "balance": 1.1007842645653203e+26,
+        "block_height": 76045890,
+        "epoch_id": "B179NnZqaiaTmqXA1S9WDPHfiZg2XJzGciQorJf9nLoE",
+        "next_epoch_id": "EMRbJDos8SBtLdNGjhyLaXntdJBuhrJGZ2X87B57fqr7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7317414273466868e+22
+    },
+    {
+        "timestamp": "2022-10-11T15:02:19.771Z",
+        "balance": 1.1006110904225856e+26,
+        "block_height": 76002690,
+        "epoch_id": "7CbfSgxDvmShTkWKg7vXPRKbNfWkTTpAQm32pJystEkw",
+        "next_epoch_id": "B179NnZqaiaTmqXA1S9WDPHfiZg2XJzGciQorJf9nLoE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7643947324971132e+22
+    },
+    {
+        "timestamp": "2022-10-11T00:31:29.909Z",
+        "balance": 1.100434650949336e+26,
+        "block_height": 75959490,
+        "epoch_id": "4jpC46DVUMpgiv6vrhxjCC2Xz2NKAQsRPULK8ovNbn91",
+        "next_epoch_id": "7CbfSgxDvmShTkWKg7vXPRKbNfWkTTpAQm32pJystEkw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7691064541707898e+22
+    },
+    {
+        "timestamp": "2022-10-10T09:44:46.185Z",
+        "balance": 1.1002577403039188e+26,
+        "block_height": 75916290,
+        "epoch_id": "3cSQ83fCKohcpCCioSWGF2XvrUfDyEdUTD8bLffCKPeM",
+        "next_epoch_id": "4jpC46DVUMpgiv6vrhxjCC2Xz2NKAQsRPULK8ovNbn91",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7658651433873093e+22
+    },
+    {
+        "timestamp": "2022-10-09T19:01:45.117Z",
+        "balance": 1.1000811537895801e+26,
+        "block_height": 75873090,
+        "epoch_id": "Cy4qMoKKLdor1AvoS3XQ4LbHr1NwJfMVcwd18MS6J8uK",
+        "next_epoch_id": "3cSQ83fCKohcpCCioSWGF2XvrUfDyEdUTD8bLffCKPeM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7599340496363813e+22
+    },
+    {
+        "timestamp": "2022-10-09T04:19:41.055Z",
+        "balance": 1.0999051603846165e+26,
+        "block_height": 75829890,
+        "epoch_id": "GW23y7aKtFfQ5btmMKpSjo7LjtSdqm8tWjm1mox9gW2q",
+        "next_epoch_id": "Cy4qMoKKLdor1AvoS3XQ4LbHr1NwJfMVcwd18MS6J8uK",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8554887666137324e+22
+    },
+    {
+        "timestamp": "2022-10-08T13:33:17.509Z",
+        "balance": 1.0997196115079551e+26,
+        "block_height": 75786690,
+        "epoch_id": "3BkkUZ8hwcxajkKuSg8Q8sc3oKtDBexdXmy6LozEeFuR",
+        "next_epoch_id": "GW23y7aKtFfQ5btmMKpSjo7LjtSdqm8tWjm1mox9gW2q",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8161077095324705e+22
+    },
+    {
+        "timestamp": "2022-10-07T22:09:47.396Z",
+        "balance": 1.0995380007370019e+26,
+        "block_height": 75743490,
+        "epoch_id": "DNvvwk6ibduZGRG2vSMtvkfjRWGDiNPTU3omSoujTeuo",
+        "next_epoch_id": "3BkkUZ8hwcxajkKuSg8Q8sc3oKtDBexdXmy6LozEeFuR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8204227480627662e+22
+    },
+    {
+        "timestamp": "2022-10-07T07:17:19.652Z",
+        "balance": 1.0993559584621956e+26,
+        "block_height": 75700290,
+        "epoch_id": "EXfPTSH3cQwj9S8G696kvQZThfntj59UeNjdN8T3Aphv",
+        "next_epoch_id": "DNvvwk6ibduZGRG2vSMtvkfjRWGDiNPTU3omSoujTeuo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7797900180048438e+22
+    },
+    {
+        "timestamp": "2022-10-06T16:23:43.078Z",
+        "balance": 1.0991779794603951e+26,
+        "block_height": 75657090,
+        "epoch_id": "BuURRENtm5mxYjDtWRu4jMie5AkepsC7moCFP15cC3oj",
+        "next_epoch_id": "EXfPTSH3cQwj9S8G696kvQZThfntj59UeNjdN8T3Aphv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8763288494544318e+22
+    },
+    {
+        "timestamp": "2022-10-06T01:46:24.030Z",
+        "balance": 1.0989903465754496e+26,
+        "block_height": 75613890,
+        "epoch_id": "FVxfLsToReCY37UthRiJhKHTVuRKM6tXU4B73rNvZJkk",
+        "next_epoch_id": "BuURRENtm5mxYjDtWRu4jMie5AkepsC7moCFP15cC3oj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.910146351453461e+22
+    },
+    {
+        "timestamp": "2022-10-05T10:11:14.696Z",
+        "balance": 1.0987993319403043e+26,
+        "block_height": 75570690,
+        "epoch_id": "CoiqrdkDKH5ec7ck8JyTSEW6c3b9ZvSc9pzfEzhim8iZ",
+        "next_epoch_id": "FVxfLsToReCY37UthRiJhKHTVuRKM6tXU4B73rNvZJkk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7957058859672627e+22
+    },
+    {
+        "timestamp": "2022-10-04T18:18:10.250Z",
+        "balance": 1.0986197613517076e+26,
+        "block_height": 75527490,
+        "epoch_id": "7odNryWrVkFNudQSCzGfhP7ehzkSsto41ctsDeDYagLv",
+        "next_epoch_id": "CoiqrdkDKH5ec7ck8JyTSEW6c3b9ZvSc9pzfEzhim8iZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6561486942055761e+22
+    },
+    {
+        "timestamp": "2022-10-04T03:33:01.284Z",
+        "balance": 1.098454146482287e+26,
+        "block_height": 75484290,
+        "epoch_id": "EzYNagyKMJwYJEVkmyZ41kKmTS9vwhRLAYfCJMi7R4R8",
+        "next_epoch_id": "7odNryWrVkFNudQSCzGfhP7ehzkSsto41ctsDeDYagLv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6432528480983788e+22
+    },
+    {
+        "timestamp": "2022-10-03T13:27:31.373Z",
+        "balance": 1.0982898211974772e+26,
+        "block_height": 75441090,
+        "epoch_id": "7Myp7DVnDiCBtqY2TXv3e5AXFHS3JYLUPs6MEuMzgdrW",
+        "next_epoch_id": "EzYNagyKMJwYJEVkmyZ41kKmTS9vwhRLAYfCJMi7R4R8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.811827547876939e+22
+    },
+    {
+        "timestamp": "2022-10-02T23:28:03.706Z",
+        "balance": 1.0981086384426895e+26,
+        "block_height": 75397890,
+        "epoch_id": "J7Qndq5xF2xAbc9mjnmUHe88u2TKMu2EYHZX2eEDv9G5",
+        "next_epoch_id": "7Myp7DVnDiCBtqY2TXv3e5AXFHS3JYLUPs6MEuMzgdrW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.806986299854296e+22
+    },
+    {
+        "timestamp": "2022-10-02T07:48:16.487Z",
+        "balance": 1.097927939812704e+26,
+        "block_height": 75354690,
+        "epoch_id": "Efnk5sL4jmTBNkcQpnXE5ouNTZAX5aCCTUnbdeiC71qt",
+        "next_epoch_id": "J7Qndq5xF2xAbc9mjnmUHe88u2TKMu2EYHZX2eEDv9G5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.645744158020892e+22
+    },
+    {
+        "timestamp": "2022-10-01T16:11:56.700Z",
+        "balance": 1.097763365396902e+26,
+        "block_height": 75311490,
+        "epoch_id": "GfEygWABG2FsnBmiU4JLzXCT6daddjhDDgonxvezaFR",
+        "next_epoch_id": "Efnk5sL4jmTBNkcQpnXE5ouNTZAX5aCCTUnbdeiC71qt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 3772424394899456
+    },
+    {
+        "timestamp": "2022-09-30T20:20:48.228Z",
+        "balance": 1.0977633653591777e+26,
+        "block_height": 75250511,
+        "epoch_id": "FhsQS1zgTLpZjYitRKevStmzJfUgweUTjQA1rUeNW6QR",
+        "next_epoch_id": "GfEygWABG2FsnBmiU4JLzXCT6daddjhDDgonxvezaFR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8481012194738591e+22
+    },
+    {
+        "timestamp": "2022-09-30T11:48:24.908Z",
+        "balance": 1.0975785552372303e+26,
+        "block_height": 75225090,
+        "epoch_id": "7XciHBpUitLPSu8QBrsWp6sghvVhwXj7nzjm5FxNZbjn",
+        "next_epoch_id": "FhsQS1zgTLpZjYitRKevStmzJfUgweUTjQA1rUeNW6QR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 7371589809078272
+    },
+    {
+        "timestamp": "2022-09-29T19:54:19.467Z",
+        "balance": 1.0975785551635144e+26,
+        "block_height": 75181890,
+        "epoch_id": "235gTuzMxiALmnyykDmZmhoK1JKgoNkUyegQMjirTVwM",
+        "next_epoch_id": "7XciHBpUitLPSu8QBrsWp6sghvVhwXj7nzjm5FxNZbjn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6492507057157638e+22
+    },
+    {
+        "timestamp": "2022-09-29T03:52:46.912Z",
+        "balance": 1.0974136300929429e+26,
+        "block_height": 75138690,
+        "epoch_id": "ChRU9G2vTKXYaqffEQwG2MhSa5cuSebijeRtNKfmSFsp",
+        "next_epoch_id": "235gTuzMxiALmnyykDmZmhoK1JKgoNkUyegQMjirTVwM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6504272315652015e+22
+    },
+    {
+        "timestamp": "2022-09-28T13:45:56.172Z",
+        "balance": 1.0972485873697863e+26,
+        "block_height": 75095490,
+        "epoch_id": "3vmxpGC412KRenHkmzqauzC8uZ5diAm23jx8wofZmHhP",
+        "next_epoch_id": "ChRU9G2vTKXYaqffEQwG2MhSa5cuSebijeRtNKfmSFsp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6850942118257521e+22
+    },
+    {
+        "timestamp": "2022-09-27T23:38:41.560Z",
+        "balance": 1.0970800779486038e+26,
+        "block_height": 75052290,
+        "epoch_id": "AWnggNBTNbDbxfqVhgR7YQ2dxP7yHBJbGD9mQBFtU4rS",
+        "next_epoch_id": "3vmxpGC412KRenHkmzqauzC8uZ5diAm23jx8wofZmHhP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6834681692719944e+22
+    },
+    {
+        "timestamp": "2022-09-27T09:13:38.407Z",
+        "balance": 1.0969117311316766e+26,
+        "block_height": 75009090,
+        "epoch_id": "7ZdfGDYaShdKZdpUWrZUDZdQmKCMsLkAhk7fn7rJELsT",
+        "next_epoch_id": "AWnggNBTNbDbxfqVhgR7YQ2dxP7yHBJbGD9mQBFtU4rS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6996546211842376e+22
+    },
+    {
+        "timestamp": "2022-09-26T18:49:42.489Z",
+        "balance": 1.0967417656695581e+26,
+        "block_height": 74965890,
+        "epoch_id": "Af5d177oKfmSXhJ33h3W4PkcdsxdXDydzqDVBMfhaRgu",
+        "next_epoch_id": "7ZdfGDYaShdKZdpUWrZUDZdQmKCMsLkAhk7fn7rJELsT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7031834866939746e+22
+    },
+    {
+        "timestamp": "2022-09-26T04:17:27.811Z",
+        "balance": 1.0965714473208887e+26,
+        "block_height": 74922690,
+        "epoch_id": "2bRFLbHiHX9EiVJUe93PZuByB4ZugnwrPLb4nLvEfCjr",
+        "next_epoch_id": "Af5d177oKfmSXhJ33h3W4PkcdsxdXDydzqDVBMfhaRgu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6903321655094305e+22
+    },
+    {
+        "timestamp": "2022-09-25T13:43:36.746Z",
+        "balance": 1.0964024141043378e+26,
+        "block_height": 74879490,
+        "epoch_id": "B4kuxMvFcaHMqa9B5ncKmVqaP1jPwxRtvKzA4pJDC6AD",
+        "next_epoch_id": "2bRFLbHiHX9EiVJUe93PZuByB4ZugnwrPLb4nLvEfCjr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7316506746585166e+22
+    },
+    {
+        "timestamp": "2022-09-24T08:51:31.866Z",
+        "balance": 1.096229249036872e+26,
+        "block_height": 74794251,
+        "epoch_id": "4whpaAhugWnxWeu8dta5zAprWwkU9Kt7HVADdJ7oJgfs",
+        "next_epoch_id": "B4kuxMvFcaHMqa9B5ncKmVqaP1jPwxRtvKzA4pJDC6AD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7589274718409413e+22
+    },
+    {
+        "timestamp": "2022-09-24T08:28:13.845Z",
+        "balance": 1.0960533562896879e+26,
+        "block_height": 74793090,
+        "epoch_id": "5iLoCHbdkvHCKgRRfYJPZRGNTcMh16bEAXRKSEPry8tC",
+        "next_epoch_id": "4whpaAhugWnxWeu8dta5zAprWwkU9Kt7HVADdJ7oJgfs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7569553353283497e+22
+    },
+    {
+        "timestamp": "2022-09-23T17:38:11.176Z",
+        "balance": 1.095877660756155e+26,
+        "block_height": 74749890,
+        "epoch_id": "7ng3CqH6g41gj75JKxGTr1ghwMWW6rjMDvhXbY62wPRc",
+        "next_epoch_id": "5iLoCHbdkvHCKgRRfYJPZRGNTcMh16bEAXRKSEPry8tC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8118140272855315e+22
+    },
+    {
+        "timestamp": "2022-09-22T15:10:01.810Z",
+        "balance": 1.0956964793534265e+26,
+        "block_height": 74673827,
+        "epoch_id": "DecqMtWx5DaPoQhwTHLZ53Sqc5sMTWU2A3euuxfukHRS",
+        "next_epoch_id": "7ng3CqH6g41gj75JKxGTr1ghwMWW6rjMDvhXbY62wPRc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8904795230663554e+22
+    },
+    {
+        "timestamp": "2022-09-22T11:28:11.765Z",
+        "balance": 1.0955074314011198e+26,
+        "block_height": 74663490,
+        "epoch_id": "HR2uWbZvmo6ByDvG8bqEVotdK76XW27dUXCna2eoNvZc",
+        "next_epoch_id": "DecqMtWx5DaPoQhwTHLZ53Sqc5sMTWU2A3euuxfukHRS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.901739859146075e+22
+    },
+    {
+        "timestamp": "2022-09-21T20:13:15.421Z",
+        "balance": 1.0953172574152052e+26,
+        "block_height": 74620290,
+        "epoch_id": "7UhxH5wrpYQV4Hpftx2gk5GCt9habeFKg6999ucQwSEz",
+        "next_epoch_id": "HR2uWbZvmo6ByDvG8bqEVotdK76XW27dUXCna2eoNvZc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8808037540445205e+22
+    },
+    {
+        "timestamp": "2022-09-21T04:48:37.324Z",
+        "balance": 1.0951291770398008e+26,
+        "block_height": 74577090,
+        "epoch_id": "YBQkuAtqDW7wxMBjaPFQvVg15eXqkH8u9zx3WPA7Exw",
+        "next_epoch_id": "7UhxH5wrpYQV4Hpftx2gk5GCt9habeFKg6999ucQwSEz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8745547714038893e+22
+    },
+    {
+        "timestamp": "2022-09-20T13:34:18.550Z",
+        "balance": 1.0949417215626604e+26,
+        "block_height": 74533890,
+        "epoch_id": "D8ooGFX5qJ2Ysmwi9VmSWQusxG1onDp72RS8ggMUA7i7",
+        "next_epoch_id": "YBQkuAtqDW7wxMBjaPFQvVg15eXqkH8u9zx3WPA7Exw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.921586800733668e+22
+    },
+    {
+        "timestamp": "2022-09-19T22:23:20.564Z",
+        "balance": 1.094749562882587e+26,
+        "block_height": 74490690,
+        "epoch_id": "41JDsD4AxqLNSY7mWkcaVa37Bo2dGDw3vc6ALU5qh3wy",
+        "next_epoch_id": "D8ooGFX5qJ2Ysmwi9VmSWQusxG1onDp72RS8ggMUA7i7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.936591687116208e+22
+    },
+    {
+        "timestamp": "2022-09-19T06:48:35.093Z",
+        "balance": 1.0945559037138754e+26,
+        "block_height": 74447490,
+        "epoch_id": "CHvUfW653PAf9n6H4ZxHYJv5rxCqKWwfEhA6RBG9eHxm",
+        "next_epoch_id": "41JDsD4AxqLNSY7mWkcaVa37Bo2dGDw3vc6ALU5qh3wy",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.92810982064791e+22
+    },
+    {
+        "timestamp": "2022-09-18T14:30:34.858Z",
+        "balance": 1.0943630927318106e+26,
+        "block_height": 74402040,
+        "epoch_id": "EPB3GJdnToAJWXcJiEQZsYjqUEsWKoVMBRtSY5pdtwfY",
+        "next_epoch_id": "CHvUfW653PAf9n6H4ZxHYJv5rxCqKWwfEhA6RBG9eHxm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8837479358637275e+22
+    },
+    {
+        "timestamp": "2022-09-17T23:54:21.678Z",
+        "balance": 1.0941747179382242e+26,
+        "block_height": 74361090,
+        "epoch_id": "AkV8RFSsnpPPoNx4hL6Y5Pmo2rp6gEmE6rSRrNqgjLqd",
+        "next_epoch_id": "EPB3GJdnToAJWXcJiEQZsYjqUEsWKoVMBRtSY5pdtwfY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.070395220631811e+22
+    },
+    {
+        "timestamp": "2022-09-17T08:05:43.712Z",
+        "balance": 1.093967678416161e+26,
+        "block_height": 74317890,
+        "epoch_id": "3Nwhup7ntUtpLWx5owLhu6hEYNFSQuqmhiuFErAv6cqw",
+        "next_epoch_id": "AkV8RFSsnpPPoNx4hL6Y5Pmo2rp6gEmE6rSRrNqgjLqd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.936336727142433e+22
+    },
+    {
+        "timestamp": "2022-09-16T16:26:49.640Z",
+        "balance": 1.0937740447434468e+26,
+        "block_height": 74274690,
+        "epoch_id": "At98gwswXFicEfPtcYvikdvS4nvU17YP7TD4uRDtYGUE",
+        "next_epoch_id": "3Nwhup7ntUtpLWx5owLhu6hEYNFSQuqmhiuFErAv6cqw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.971411488386234e+22
+    },
+    {
+        "timestamp": "2022-09-16T00:49:48.666Z",
+        "balance": 1.0935769035946082e+26,
+        "block_height": 74231490,
+        "epoch_id": "CmWmJ8eNQhXsUvdcC87Xt6mt6qMQNCYc29a81o5FL5Hr",
+        "next_epoch_id": "At98gwswXFicEfPtcYvikdvS4nvU17YP7TD4uRDtYGUE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5843105574108965e+22
+    },
+    {
+        "timestamp": "2022-09-14T16:43:01.848Z",
+        "balance": 1.0934184725388671e+26,
+        "block_height": 74145847,
+        "epoch_id": "6nom9bfnE8wt3ewpMtypix6K5qP11dkEAg8epVjRF4L8",
+        "next_epoch_id": "CmWmJ8eNQhXsUvdcC87Xt6mt6qMQNCYc29a81o5FL5Hr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.948678151223499e+22
+    },
+    {
+        "timestamp": "2022-09-14T16:25:42.848Z",
+        "balance": 1.0932236047237447e+26,
+        "block_height": 74145089,
+        "epoch_id": "39zW9KWiM9YTmTG3eripKE2FCbJ4BTHr2UnsjfK17u6f",
+        "next_epoch_id": "6nom9bfnE8wt3ewpMtypix6K5qP11dkEAg8epVjRF4L8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.900611855535045e+22
+    },
+    {
+        "timestamp": "2022-09-14T00:14:01.956Z",
+        "balance": 1.0930335435381912e+26,
+        "block_height": 74101889,
+        "epoch_id": "ACYJQGtKKYMKUToGRTknBVwE2PQLjGeTZT91AFQLrQcH",
+        "next_epoch_id": "39zW9KWiM9YTmTG3eripKE2FCbJ4BTHr2UnsjfK17u6f",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8478160141170474e+22
+    },
+    {
+        "timestamp": "2022-09-13T08:14:28.599Z",
+        "balance": 1.0928487619367795e+26,
+        "block_height": 74058689,
+        "epoch_id": "2JryJrzJbZFi8D1VsA8Z4mfxRWov4cTtez7audmWvdz6",
+        "next_epoch_id": "ACYJQGtKKYMKUToGRTknBVwE2PQLjGeTZT91AFQLrQcH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.796367524433671e+22
+    },
+    {
+        "timestamp": "2022-09-12T16:41:36.758Z",
+        "balance": 1.0926691251843362e+26,
+        "block_height": 74015489,
+        "epoch_id": "5MKD25xWVqmidHzjCsSM54QU22LjF9HtmVL1txePcTWV",
+        "next_epoch_id": "2JryJrzJbZFi8D1VsA8Z4mfxRWov4cTtez7audmWvdz6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7996623175930303e+22
+    },
+    {
+        "timestamp": "2022-09-12T01:37:16.247Z",
+        "balance": 1.0924891589525769e+26,
+        "block_height": 73972289,
+        "epoch_id": "HeibALv5rqdYeKqw8gGiksqDsMeY7Emy4nwEMtHywTEf",
+        "next_epoch_id": "5MKD25xWVqmidHzjCsSM54QU22LjF9HtmVL1txePcTWV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.783699750183196e+22
+    },
+    {
+        "timestamp": "2022-09-11T10:31:24.831Z",
+        "balance": 1.0923107889775585e+26,
+        "block_height": 73929089,
+        "epoch_id": "BcAsvtfZffENDz4mxDHqmZDUbizWHd54NctgssshB2Vw",
+        "next_epoch_id": "HeibALv5rqdYeKqw8gGiksqDsMeY7Emy4nwEMtHywTEf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.846380708303536e+22
+    },
+    {
+        "timestamp": "2022-09-10T19:38:39.530Z",
+        "balance": 1.0921261509067282e+26,
+        "block_height": 73885889,
+        "epoch_id": "6ynx19JzAffZKhRSQeJMjiV9A6oXdcWV5BpHGg4L3QSU",
+        "next_epoch_id": "BcAsvtfZffENDz4mxDHqmZDUbizWHd54NctgssshB2Vw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.941320019400667e+22
+    },
+    {
+        "timestamp": "2022-09-10T04:07:06.339Z",
+        "balance": 1.0919320189047881e+26,
+        "block_height": 73842689,
+        "epoch_id": "CMXt21a8MBYwMeDRRHfztnZ9F6ZqmQJaDFLhpQhDQgkQ",
+        "next_epoch_id": "6ynx19JzAffZKhRSQeJMjiV9A6oXdcWV5BpHGg4L3QSU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8625541840303743e+22
+    },
+    {
+        "timestamp": "2022-09-09T11:52:43.221Z",
+        "balance": 1.0917457634863851e+26,
+        "block_height": 73799489,
+        "epoch_id": "HGPW2UFDv2DRUkzZ2FeCH2ZkCLg4SXUovzRjXtYLqhYF",
+        "next_epoch_id": "CMXt21a8MBYwMeDRRHfztnZ9F6ZqmQJaDFLhpQhDQgkQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8465652220484873e+22
+    },
+    {
+        "timestamp": "2022-09-08T20:16:36.023Z",
+        "balance": 1.0915611069641802e+26,
+        "block_height": 73756289,
+        "epoch_id": "9Rda19988zsFtL9qJEywyqVBhyTAnEbV1RFeA7XhvTvc",
+        "next_epoch_id": "HGPW2UFDv2DRUkzZ2FeCH2ZkCLg4SXUovzRjXtYLqhYF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8504163482848301e+22
+    },
+    {
+        "timestamp": "2022-09-08T04:43:22.784Z",
+        "balance": 1.0913760653293518e+26,
+        "block_height": 73713089,
+        "epoch_id": "CvB4rPPtg74oee4Zi7HiDZuaowCi1okjfARsvF5nJ8UE",
+        "next_epoch_id": "9Rda19988zsFtL9qJEywyqVBhyTAnEbV1RFeA7XhvTvc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.874285815658987e+22
+    },
+    {
+        "timestamp": "2022-09-07T13:13:31.323Z",
+        "balance": 1.0911886367477859e+26,
+        "block_height": 73669889,
+        "epoch_id": "9skhctKQyvkXfW32NB1eG7ggWRFpVSbHCE4jTr2brWLq",
+        "next_epoch_id": "CvB4rPPtg74oee4Zi7HiDZuaowCi1okjfARsvF5nJ8UE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.3127974828244648e+22
+    },
+    {
+        "timestamp": "2022-09-06T21:27:41.810Z",
+        "balance": 1.0910573569995034e+26,
+        "block_height": 73626689,
+        "epoch_id": "7GqzPJHEkCt99aFKn17FQHLYcyA9pkqmzzhN3AMcsokb",
+        "next_epoch_id": "9skhctKQyvkXfW32NB1eG7ggWRFpVSbHCE4jTr2brWLq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7670911507354844e+22
+    },
+    {
+        "timestamp": "2022-09-06T06:18:03.147Z",
+        "balance": 1.0908806478844299e+26,
+        "block_height": 73583489,
+        "epoch_id": "4krHHN8gu1RufyXu8KXPd88mqsSj9vrpetmQL1Z5MoU5",
+        "next_epoch_id": "7GqzPJHEkCt99aFKn17FQHLYcyA9pkqmzzhN3AMcsokb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7288211492916607e+22
+    },
+    {
+        "timestamp": "2022-09-05T15:29:02.375Z",
+        "balance": 1.0907077657695007e+26,
+        "block_height": 73540289,
+        "epoch_id": "f4p7D9Rbo5BGqV3k5JfWbpm1TJmuz8xiJHS6oWBP13a",
+        "next_epoch_id": "4krHHN8gu1RufyXu8KXPd88mqsSj9vrpetmQL1Z5MoU5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7412330629291806e+22
+    },
+    {
+        "timestamp": "2022-09-05T00:58:00.320Z",
+        "balance": 1.0905336424632078e+26,
+        "block_height": 73497089,
+        "epoch_id": "12YA4z68k3NnQPj2q2L3UxPRkGpVgyKVvhJpoMRcj2Nt",
+        "next_epoch_id": "f4p7D9Rbo5BGqV3k5JfWbpm1TJmuz8xiJHS6oWBP13a",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.731921360251319e+22
+    },
+    {
+        "timestamp": "2022-09-04T10:18:07.149Z",
+        "balance": 1.0903604503271827e+26,
+        "block_height": 73453797,
+        "epoch_id": "6cfRUaj95Zo3APV18DoTMPs5vWLbKgekopNuX7KzKCNn",
+        "next_epoch_id": "12YA4z68k3NnQPj2q2L3UxPRkGpVgyKVvhJpoMRcj2Nt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7456787045223842e+22
+    },
+    {
+        "timestamp": "2022-09-03T19:48:58.368Z",
+        "balance": 1.0901858824567304e+26,
+        "block_height": 73410689,
+        "epoch_id": "61CarXj1CJbGyFXuGVwU42jxMzvZQYakYmpxJUAEA3wU",
+        "next_epoch_id": "6cfRUaj95Zo3APV18DoTMPs5vWLbKgekopNuX7KzKCNn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8270726261411076e+22
+    },
+    {
+        "timestamp": "2022-09-03T05:18:13.744Z",
+        "balance": 1.0900031751941163e+26,
+        "block_height": 73367489,
+        "epoch_id": "DJfWnC4eMWRm3CCvVgqf257cw2AXFkJBAMUXoVXd7qao",
+        "next_epoch_id": "61CarXj1CJbGyFXuGVwU42jxMzvZQYakYmpxJUAEA3wU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7838826128018439e+22
+    },
+    {
+        "timestamp": "2022-09-02T14:07:40.523Z",
+        "balance": 1.0898247869328361e+26,
+        "block_height": 73324289,
+        "epoch_id": "49VuFJpUemZYFb2h5XBfrNoj7JtouBbk5Xq19FLYLkuE",
+        "next_epoch_id": "DJfWnC4eMWRm3CCvVgqf257cw2AXFkJBAMUXoVXd7qao",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9401135493038117e+22
+    },
+    {
+        "timestamp": "2022-09-01T18:41:31.355Z",
+        "balance": 1.0896307755779057e+26,
+        "block_height": 73267960,
+        "epoch_id": "CTfyyky9NGNS43GtdBCZLZjbk3GfFCuLksa2t3dYG37J",
+        "next_epoch_id": "49VuFJpUemZYFb2h5XBfrNoj7JtouBbk5Xq19FLYLkuE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9295090180975562e+22
+    },
+    {
+        "timestamp": "2022-09-01T08:06:11.998Z",
+        "balance": 1.089437824676096e+26,
+        "block_height": 73237889,
+        "epoch_id": "53Yk9F2LmNHEi61iaPTxZRv2atnNSDZgcDvVNQXcaixb",
+        "next_epoch_id": "CTfyyky9NGNS43GtdBCZLZjbk3GfFCuLksa2t3dYG37J",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9193403902346377e+22
+    },
+    {
+        "timestamp": "2022-08-31T17:02:34.067Z",
+        "balance": 1.0892458906370725e+26,
+        "block_height": 73194689,
+        "epoch_id": "Gefwb7u5fj3RiZ28ueV8AhkAPX1jK4QfVAXFBaVWq5KC",
+        "next_epoch_id": "53Yk9F2LmNHEi61iaPTxZRv2atnNSDZgcDvVNQXcaixb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9223620108398956e+22
+    },
+    {
+        "timestamp": "2022-08-31T02:00:06.010Z",
+        "balance": 1.0890536544359885e+26,
+        "block_height": 73151489,
+        "epoch_id": "BkvtjYYfBMCXsBV3YeKBydLq4TieePNVGGXsmWm9izjG",
+        "next_epoch_id": "Gefwb7u5fj3RiZ28ueV8AhkAPX1jK4QfVAXFBaVWq5KC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.899228620092554e+22
+    },
+    {
+        "timestamp": "2022-08-30T10:54:47.335Z",
+        "balance": 1.0888637315739793e+26,
+        "block_height": 73108289,
+        "epoch_id": "2HmFmAU64JLy78KsnSnR2nbLk9nmTs5AtuijEDqB4fwW",
+        "next_epoch_id": "BkvtjYYfBMCXsBV3YeKBydLq4TieePNVGGXsmWm9izjG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8728521440289922e+22
+    },
+    {
+        "timestamp": "2022-08-29T15:51:59.951Z",
+        "balance": 1.0886764463595764e+26,
+        "block_height": 73052764,
+        "epoch_id": "6K9BbG6SmeUwtKyYqojXSvYoZPFpFFa4SXA5KkomirDm",
+        "next_epoch_id": "2HmFmAU64JLy78KsnSnR2nbLk9nmTs5AtuijEDqB4fwW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8780102174232545e+22
+    },
+    {
+        "timestamp": "2022-08-29T05:20:41.287Z",
+        "balance": 1.088488645337834e+26,
+        "block_height": 73021889,
+        "epoch_id": "CwST3YNNLec5yWYebYvU8YYNwBVEShB6UZDxGkLSZufh",
+        "next_epoch_id": "6K9BbG6SmeUwtKyYqojXSvYoZPFpFFa4SXA5KkomirDm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8743564331985943e+22
+    },
+    {
+        "timestamp": "2022-08-28T14:36:49.046Z",
+        "balance": 1.0883012096945142e+26,
+        "block_height": 72978689,
+        "epoch_id": "3ed4oeHKpxfgVK8oZ2NHXY5RECR3jsC32N1EA1PdMQcP",
+        "next_epoch_id": "CwST3YNNLec5yWYebYvU8YYNwBVEShB6UZDxGkLSZufh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8683396829512232e+22
+    },
+    {
+        "timestamp": "2022-08-27T23:54:34.739Z",
+        "balance": 1.088114375726219e+26,
+        "block_height": 72935489,
+        "epoch_id": "6Ah5TjTMxNvg4oXWExGz7sTcwepAT8pz6KWX1BmaxbrF",
+        "next_epoch_id": "3ed4oeHKpxfgVK8oZ2NHXY5RECR3jsC32N1EA1PdMQcP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.857137659307474e+22
+    },
+    {
+        "timestamp": "2022-08-26T20:22:31.038Z",
+        "balance": 1.0879286619602883e+26,
+        "block_height": 72853616,
+        "epoch_id": "4FUkt7h9Q3g25jeiGftNssUG677fQ47w43CWKmgQDGYf",
+        "next_epoch_id": "6Ah5TjTMxNvg4oXWExGz7sTcwepAT8pz6KWX1BmaxbrF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8635027311362627e+22
+    },
+    {
+        "timestamp": "2022-08-26T18:50:41.984Z",
+        "balance": 1.0877423116871747e+26,
+        "block_height": 72849089,
+        "epoch_id": "H3XgaZnyDPiSgNMY6uRHnFiwJNXQpTzamtYkpDVrZRex",
+        "next_epoch_id": "4FUkt7h9Q3g25jeiGftNssUG677fQ47w43CWKmgQDGYf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.900451702933932e+22
+    },
+    {
+        "timestamp": "2022-08-26T04:25:50.968Z",
+        "balance": 1.0875522665168813e+26,
+        "block_height": 72805889,
+        "epoch_id": "Cdu7T49ivw256uZDYXK1feMM3UHCMueQF6rQXegBaFx8",
+        "next_epoch_id": "H3XgaZnyDPiSgNMY6uRHnFiwJNXQpTzamtYkpDVrZRex",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.898351778707777e+22
+    },
+    {
+        "timestamp": "2022-08-25T13:42:21.100Z",
+        "balance": 1.0873624313390105e+26,
+        "block_height": 72762689,
+        "epoch_id": "kdUeK1gef3v9jjw9JvGNPgD4SjW7zpbxj6EW5T8MjyU",
+        "next_epoch_id": "Cdu7T49ivw256uZDYXK1feMM3UHCMueQF6rQXegBaFx8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8711624112265314e+22
+    },
+    {
+        "timestamp": "2022-08-24T22:59:42.687Z",
+        "balance": 1.0871753150978879e+26,
+        "block_height": 72719489,
+        "epoch_id": "CFvSxEBk7RpfWpuEC6xTYRmk1jU6zbWMY5GgxxGzEUFE",
+        "next_epoch_id": "kdUeK1gef3v9jjw9JvGNPgD4SjW7zpbxj6EW5T8MjyU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.895778441799038e+22
+    },
+    {
+        "timestamp": "2022-08-24T08:29:39.036Z",
+        "balance": 1.086985737253708e+26,
+        "block_height": 72676289,
+        "epoch_id": "CQomCQVmC6ooZKd8qzoTFrDF4AEXbeUT2AmUX3AoLNgR",
+        "next_epoch_id": "CFvSxEBk7RpfWpuEC6xTYRmk1jU6zbWMY5GgxxGzEUFE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.923077179430193e+22
+    },
+    {
+        "timestamp": "2022-08-23T17:46:08.306Z",
+        "balance": 1.086793429535765e+26,
+        "block_height": 72633089,
+        "epoch_id": "6CXYvPFchyvhwgXfqB4um4s15g4Vr1APB7mtmo8pbdnM",
+        "next_epoch_id": "CQomCQVmC6ooZKd8qzoTFrDF4AEXbeUT2AmUX3AoLNgR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.889845071303126e+22
+    },
+    {
+        "timestamp": "2022-08-22T15:17:34.572Z",
+        "balance": 1.0866044450286346e+26,
+        "block_height": 72555853,
+        "epoch_id": "FNvBFiLqqjwtgARQEc8caL54ScMH2zvgGnTBC4pVMkeR",
+        "next_epoch_id": "6CXYvPFchyvhwgXfqB4um4s15g4Vr1APB7mtmo8pbdnM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9100732518402275e+22
+    },
+    {
+        "timestamp": "2022-08-22T12:08:18.901Z",
+        "balance": 1.0864134377034506e+26,
+        "block_height": 72546689,
+        "epoch_id": "7aUcJL8Syn7vmm8pFbctP73te7jxevYTNh56sX3VEKYH",
+        "next_epoch_id": "FNvBFiLqqjwtgARQEc8caL54ScMH2zvgGnTBC4pVMkeR",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.981472566280613e+22
+    },
+    {
+        "timestamp": "2022-08-21T18:51:46.548Z",
+        "balance": 1.0862152904468225e+26,
+        "block_height": 72496481,
+        "epoch_id": "3NwJefxgmEBTxyVRXN6wxn1EdfN3BPdy5gvESPHr3KK3",
+        "next_epoch_id": "7aUcJL8Syn7vmm8pFbctP73te7jxevYTNh56sX3VEKYH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.074949160404345e+22
+    },
+    {
+        "timestamp": "2022-08-21T05:55:03.104Z",
+        "balance": 1.0860077955307821e+26,
+        "block_height": 72460289,
+        "epoch_id": "4rveFHwZKQ2N2cwJK7N7RHqsfZx7G37eSAU6qxCC6BqE",
+        "next_epoch_id": "3NwJefxgmEBTxyVRXN6wxn1EdfN3BPdy5gvESPHr3KK3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.929707150536122e+22
+    },
+    {
+        "timestamp": "2022-08-20T13:16:50.600Z",
+        "balance": 1.0858148248157285e+26,
+        "block_height": 72416052,
+        "epoch_id": "9KCUtxd2bvC2Jibij9RkmbXV2grb3fAPhgj7eaAd4gng",
+        "next_epoch_id": "4rveFHwZKQ2N2cwJK7N7RHqsfZx7G37eSAU6qxCC6BqE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8866684060463847e+22
+    },
+    {
+        "timestamp": "2022-08-19T22:31:55.237Z",
+        "balance": 1.0856261579751239e+26,
+        "block_height": 72373889,
+        "epoch_id": "AWifyC8Yb2FFf6Q5NdhJWZzXTqoU7FK4MkEv4ZDbVQzZ",
+        "next_epoch_id": "9KCUtxd2bvC2Jibij9RkmbXV2grb3fAPhgj7eaAd4gng",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8861302885012291e+22
+    },
+    {
+        "timestamp": "2022-08-19T07:43:57.919Z",
+        "balance": 1.0854375449462737e+26,
+        "block_height": 72330689,
+        "epoch_id": "9iHL8q5syRjn6kewnX147TvhgpbY1gY5QdsyqWbi7LQN",
+        "next_epoch_id": "AWifyC8Yb2FFf6Q5NdhJWZzXTqoU7FK4MkEv4ZDbVQzZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8579195946178047e+22
+    },
+    {
+        "timestamp": "2022-08-18T17:05:16.148Z",
+        "balance": 1.085251752986812e+26,
+        "block_height": 72287489,
+        "epoch_id": "FdpenEFnSqmxKudBsuvM5ruHUxJzLWRt27PNqbNJdWsb",
+        "next_epoch_id": "9iHL8q5syRjn6kewnX147TvhgpbY1gY5QdsyqWbi7LQN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8253835673461466e+22
+    },
+    {
+        "timestamp": "2022-08-18T02:32:16.053Z",
+        "balance": 1.0850692146300773e+26,
+        "block_height": 72244289,
+        "epoch_id": "CHtke5mpg9PidcZHnSvqKpTksRFTjECwMdy9pQXBKeqD",
+        "next_epoch_id": "FdpenEFnSqmxKudBsuvM5ruHUxJzLWRt27PNqbNJdWsb",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8273428207263768e+22
+    },
+    {
+        "timestamp": "2022-08-17T12:06:19.943Z",
+        "balance": 1.0848864803480047e+26,
+        "block_height": 72201089,
+        "epoch_id": "F5DjtxYDoV8rZ8WoA7wFVDnyPvZjThJ4F7FMC5MAF6Nr",
+        "next_epoch_id": "CHtke5mpg9PidcZHnSvqKpTksRFTjECwMdy9pQXBKeqD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8357366790215304e+22
+    },
+    {
+        "timestamp": "2022-08-16T21:39:48.252Z",
+        "balance": 1.0847029066801026e+26,
+        "block_height": 72157889,
+        "epoch_id": "HF8QqSZs3LGsTg625y8MBEqbFwjHd8daM9hrgDb4QVUL",
+        "next_epoch_id": "F5DjtxYDoV8rZ8WoA7wFVDnyPvZjThJ4F7FMC5MAF6Nr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8207188646259386e+22
+    },
+    {
+        "timestamp": "2022-08-16T07:12:51.170Z",
+        "balance": 1.08452083479364e+26,
+        "block_height": 72114689,
+        "epoch_id": "ErWV5t6tnZoxrYJfr9C8dYRpwdt2PAJzPt99wLggADM7",
+        "next_epoch_id": "HF8QqSZs3LGsTg625y8MBEqbFwjHd8daM9hrgDb4QVUL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.827222229471036e+22
+    },
+    {
+        "timestamp": "2022-08-15T16:53:51.250Z",
+        "balance": 1.0843381125706929e+26,
+        "block_height": 72071489,
+        "epoch_id": "EF2i6TUsCfiQprSPAmopLTyPQbxGBh33ihUZwWfPa2L",
+        "next_epoch_id": "ErWV5t6tnZoxrYJfr9C8dYRpwdt2PAJzPt99wLggADM7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8213236944635838e+22
+    },
+    {
+        "timestamp": "2022-08-15T02:32:00.445Z",
+        "balance": 1.0841559802012465e+26,
+        "block_height": 72028289,
+        "epoch_id": "BCdz4pxukL4fWoA5ByUeq3Z1pWeABok3ebRPEsuevXGV",
+        "next_epoch_id": "EF2i6TUsCfiQprSPAmopLTyPQbxGBh33ihUZwWfPa2L",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8240143066998807e+22
+    },
+    {
+        "timestamp": "2022-08-14T12:12:43.832Z",
+        "balance": 1.0839735787705765e+26,
+        "block_height": 71985089,
+        "epoch_id": "HtwQvDu7ZHjrVyxcTBa1XHKGZb4tDAhvS8ZhMvAkxJrF",
+        "next_epoch_id": "BCdz4pxukL4fWoA5ByUeq3Z1pWeABok3ebRPEsuevXGV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.894536201396911e+22
+    },
+    {
+        "timestamp": "2022-08-13T21:51:29.037Z",
+        "balance": 1.0837841251504368e+26,
+        "block_height": 71941889,
+        "epoch_id": "2S4uxt8YcTSRAAKLFooTuSdW4qKYGvUBnukvZS73VJyp",
+        "next_epoch_id": "HtwQvDu7ZHjrVyxcTBa1XHKGZb4tDAhvS8ZhMvAkxJrF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.863101455293299e+22
+    },
+    {
+        "timestamp": "2022-08-12T20:47:26.251Z",
+        "balance": 1.0835978150049075e+26,
+        "block_height": 71868568,
+        "epoch_id": "Gn5zPF2PrzyRew7W97iHhEwPjcCCLSjjLBUqgxW36A4d",
+        "next_epoch_id": "2S4uxt8YcTSRAAKLFooTuSdW4qKYGvUBnukvZS73VJyp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8726522900335311e+22
+    },
+    {
+        "timestamp": "2022-08-12T16:18:47.677Z",
+        "balance": 1.0834105497759041e+26,
+        "block_height": 71855489,
+        "epoch_id": "FUn898gv215mcreUoTYveVy4hYr5anGGCpcG77zbTdwv",
+        "next_epoch_id": "Gn5zPF2PrzyRew7W97iHhEwPjcCCLSjjLBUqgxW36A4d",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.908866000981883e+22
+    },
+    {
+        "timestamp": "2022-08-12T01:34:44.640Z",
+        "balance": 1.083219663175806e+26,
+        "block_height": 71812289,
+        "epoch_id": "GrnU3fWS4wJoTb4tBG72PzLLBnknjw2hVEgCFZ5mAWLT",
+        "next_epoch_id": "FUn898gv215mcreUoTYveVy4hYr5anGGCpcG77zbTdwv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8779193997384852e+22
+    },
+    {
+        "timestamp": "2022-08-11T10:33:12.699Z",
+        "balance": 1.0830318712358321e+26,
+        "block_height": 71769089,
+        "epoch_id": "9zNTXcdMy5ZNue4hKPE4xsZJm14mjzbALfFFeZ4Kr9ph",
+        "next_epoch_id": "GrnU3fWS4wJoTb4tBG72PzLLBnknjw2hVEgCFZ5mAWLT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.891143974700265e+22
+    },
+    {
+        "timestamp": "2022-08-10T17:58:13.318Z",
+        "balance": 1.082842756838362e+26,
+        "block_height": 71720599,
+        "epoch_id": "AKabBj7ZjQmrJ6mqBU7A95sCHCB38XtbrWSfSfgruzGW",
+        "next_epoch_id": "9zNTXcdMy5ZNue4hKPE4xsZJm14mjzbALfFFeZ4Kr9ph",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9204570340815125e+22
+    },
+    {
+        "timestamp": "2022-08-10T04:53:35.861Z",
+        "balance": 1.082650711134954e+26,
+        "block_height": 71682689,
+        "epoch_id": "BkiKNKkHvoA4TJ2qPz2K5AtSQjxUZDjEon9aqaNrPvsD",
+        "next_epoch_id": "AKabBj7ZjQmrJ6mqBU7A95sCHCB38XtbrWSfSfgruzGW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.89729039921184e+22
+    },
+    {
+        "timestamp": "2022-08-09T13:54:29.361Z",
+        "balance": 1.0824609820950327e+26,
+        "block_height": 71639489,
+        "epoch_id": "GAxfxJMfqpUUu4uJEpJ2xGvs3DSZmUN3spZzqAJhEg1H",
+        "next_epoch_id": "BkiKNKkHvoA4TJ2qPz2K5AtSQjxUZDjEon9aqaNrPvsD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.011450937643003e+22
+    },
+    {
+        "timestamp": "2022-08-08T18:48:21.198Z",
+        "balance": 1.0822598370012684e+26,
+        "block_height": 71584509,
+        "epoch_id": "DKRmfXizqJFmX7AqpWZT3298MDAT2dzByTCFieHQNG2n",
+        "next_epoch_id": "GAxfxJMfqpUUu4uJEpJ2xGvs3DSZmUN3spZzqAJhEg1H",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.0186595993537663e+22
+    },
+    {
+        "timestamp": "2022-08-08T07:18:21.836Z",
+        "balance": 1.082057971041333e+26,
+        "block_height": 71553089,
+        "epoch_id": "9eMwAPHbfUqkpZRNdJAoWdJE74w5r6XRU6wFC16St2d6",
+        "next_epoch_id": "DKRmfXizqJFmX7AqpWZT3298MDAT2dzByTCFieHQNG2n",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9924968756623964e+22
+    },
+    {
+        "timestamp": "2022-08-07T15:30:25.332Z",
+        "balance": 1.0818587213537668e+26,
+        "block_height": 71509889,
+        "epoch_id": "FwFzM3XJh6ca1F5J4eHkEFort7n84csvkpici1sdjPPk",
+        "next_epoch_id": "9eMwAPHbfUqkpZRNdJAoWdJE74w5r6XRU6wFC16St2d6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9587555001668284e+22
+    },
+    {
+        "timestamp": "2022-08-07T00:04:21.396Z",
+        "balance": 1.0816628458037501e+26,
+        "block_height": 71466689,
+        "epoch_id": "89HTeHkAxUHTVxTnraWtuB5gkcM5aKYuhQo2GAWjKkmu",
+        "next_epoch_id": "FwFzM3XJh6ca1F5J4eHkEFort7n84csvkpici1sdjPPk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.0513787782919352e+22
+    },
+    {
+        "timestamp": "2022-08-06T08:53:40.827Z",
+        "balance": 1.081457707925921e+26,
+        "block_height": 71423489,
+        "epoch_id": "5jDrFpNkPY1sDKptwkwctvRZDcdKhdSnLfTz9693iTxj",
+        "next_epoch_id": "89HTeHkAxUHTVxTnraWtuB5gkcM5aKYuhQo2GAWjKkmu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.0441971473529864e+22
+    },
+    {
+        "timestamp": "2022-08-05T17:01:02.973Z",
+        "balance": 1.0812532882111856e+26,
+        "block_height": 71380289,
+        "epoch_id": "AyP4W6GeTiDPRn3sedYUZ7FdxtkrbFpEAJBUo41RqTPg",
+        "next_epoch_id": "5jDrFpNkPY1sDKptwkwctvRZDcdKhdSnLfTz9693iTxj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.991254072476961e+22
+    },
+    {
+        "timestamp": "2022-08-05T01:11:42.650Z",
+        "balance": 1.081054162803938e+26,
+        "block_height": 71337089,
+        "epoch_id": "FX3q3dEX5ztVpWSZgnZid23g759K39L1hArkaXkgZm34",
+        "next_epoch_id": "AyP4W6GeTiDPRn3sedYUZ7FdxtkrbFpEAJBUo41RqTPg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9574176254905763e+22
+    },
+    {
+        "timestamp": "2022-08-04T09:45:36.401Z",
+        "balance": 1.0808584210413889e+26,
+        "block_height": 71293889,
+        "epoch_id": "nyxB7DxMbgm7gZ2pdbHyxvFoGVqW7KVsQTXCbKThFAz",
+        "next_epoch_id": "FX3q3dEX5ztVpWSZgnZid23g759K39L1hArkaXkgZm34",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9895521309825713e+22
+    },
+    {
+        "timestamp": "2022-08-03T18:34:56.836Z",
+        "balance": 1.0806594658282906e+26,
+        "block_height": 71250689,
+        "epoch_id": "9C3XTmxCkQbooiixsEfVczf56vvaL3iYEq66gsaxAcY5",
+        "next_epoch_id": "nyxB7DxMbgm7gZ2pdbHyxvFoGVqW7KVsQTXCbKThFAz",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9908413237713273e+22
+    },
+    {
+        "timestamp": "2022-08-03T03:02:29.865Z",
+        "balance": 1.0804603816959135e+26,
+        "block_height": 71207489,
+        "epoch_id": "TrPTis9SKkVgQqR6hJnZDtQjm2sxo3YsWqRs28ebTFn",
+        "next_epoch_id": "9C3XTmxCkQbooiixsEfVczf56vvaL3iYEq66gsaxAcY5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7631933671613036e+22
+    },
+    {
+        "timestamp": "2022-08-02T11:29:24.744Z",
+        "balance": 1.0802840623591974e+26,
+        "block_height": 71164289,
+        "epoch_id": "H2nUHLELmEHAmwMi9i9ERPUZW26ofCoJCj8WzEXH65Rr",
+        "next_epoch_id": "TrPTis9SKkVgQqR6hJnZDtQjm2sxo3YsWqRs28ebTFn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.964660960090927e+22
+    },
+    {
+        "timestamp": "2022-08-01T20:40:23.686Z",
+        "balance": 1.0800875962631883e+26,
+        "block_height": 71121089,
+        "epoch_id": "BmNVy5pUFW5gsStAXC6mfPgVTzNeXHzyiyWXF797QAuu",
+        "next_epoch_id": "H2nUHLELmEHAmwMi9i9ERPUZW26ofCoJCj8WzEXH65Rr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8821779076051473e+22
+    },
+    {
+        "timestamp": "2022-08-01T05:39:54.917Z",
+        "balance": 1.0798993784724278e+26,
+        "block_height": 71077889,
+        "epoch_id": "By57FY9uPz7cLPNH2v3jbgVrW93nVPA7jbRh5mvbk4Yg",
+        "next_epoch_id": "BmNVy5pUFW5gsStAXC6mfPgVTzNeXHzyiyWXF797QAuu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9432995179270087e+22
+    },
+    {
+        "timestamp": "2022-07-31T14:54:47.515Z",
+        "balance": 1.079705048520635e+26,
+        "block_height": 71034689,
+        "epoch_id": "HzUwJp81Fjcq5WY2f5rd6stZBwiig8QrZhqMaLycKzVn",
+        "next_epoch_id": "By57FY9uPz7cLPNH2v3jbgVrW93nVPA7jbRh5mvbk4Yg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8767408356813934e+22
+    },
+    {
+        "timestamp": "2022-07-30T23:40:54.342Z",
+        "balance": 1.079517374437067e+26,
+        "block_height": 70991489,
+        "epoch_id": "13WrXirfqu11HHecQQJcfweNzU7vokZXtritJC3Jucor",
+        "next_epoch_id": "HzUwJp81Fjcq5WY2f5rd6stZBwiig8QrZhqMaLycKzVn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.911344085231213e+22
+    },
+    {
+        "timestamp": "2022-07-30T09:06:04.298Z",
+        "balance": 1.0793262400285438e+26,
+        "block_height": 70948289,
+        "epoch_id": "6iG2xJdFiQk6d7K1geqDEfsXSpnkJvCFT4JPFPwAYjqT",
+        "next_epoch_id": "13WrXirfqu11HHecQQJcfweNzU7vokZXtritJC3Jucor",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.933213915855269e+22
+    },
+    {
+        "timestamp": "2022-07-29T18:08:38.597Z",
+        "balance": 1.0791329186369583e+26,
+        "block_height": 70905089,
+        "epoch_id": "4Vy5uiCGFy6zzhuUbbGRn5BRySFcKvVSsSSsqDrorPrd",
+        "next_epoch_id": "6iG2xJdFiQk6d7K1geqDEfsXSpnkJvCFT4JPFPwAYjqT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9591682800762585e+22
+    },
+    {
+        "timestamp": "2022-07-28T19:05:31.713Z",
+        "balance": 1.0789370018089507e+26,
+        "block_height": 70838951,
+        "epoch_id": "G6ptxNHz96CFYDoLCK4tg9rSqDjKRoTL9z6X7kGaYmnY",
+        "next_epoch_id": "4Vy5uiCGFy6zzhuUbbGRn5BRySFcKvVSsSSsqDrorPrd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.0579666375493286e+22
+    },
+    {
+        "timestamp": "2022-07-28T11:39:15.558Z",
+        "balance": 1.0787312051451957e+26,
+        "block_height": 70818689,
+        "epoch_id": "GtnVeyLWtyePu2c6AkbkPgfyFhujHTotmAN8EeCTf5e1",
+        "next_epoch_id": "G6ptxNHz96CFYDoLCK4tg9rSqDjKRoTL9z6X7kGaYmnY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8629943441965437e+22
+    },
+    {
+        "timestamp": "2022-07-27T19:27:58.570Z",
+        "balance": 1.078544905710776e+26,
+        "block_height": 70775489,
+        "epoch_id": "3ZRB1AqnhC118okN4qZCMF8kC1gDPxchVZB3s5EUBmkk",
+        "next_epoch_id": "GtnVeyLWtyePu2c6AkbkPgfyFhujHTotmAN8EeCTf5e1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8722800465906583e+22
+    },
+    {
+        "timestamp": "2022-07-27T04:48:44.798Z",
+        "balance": 1.078357677706117e+26,
+        "block_height": 70732289,
+        "epoch_id": "9H3mEzWkkDX59o4xaseNR8nJS7U4b7iHM1VzNvYpa4tX",
+        "next_epoch_id": "3ZRB1AqnhC118okN4qZCMF8kC1gDPxchVZB3s5EUBmkk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8630851749929892e+22
+    },
+    {
+        "timestamp": "2022-07-26T14:05:20.731Z",
+        "balance": 1.0781713691886177e+26,
+        "block_height": 70689089,
+        "epoch_id": "GrZ5Qj1vJZgY1MhvUXQcFv9n9mjVHH8BeYJR1ESA2dvC",
+        "next_epoch_id": "9H3mEzWkkDX59o4xaseNR8nJS7U4b7iHM1VzNvYpa4tX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8689446528065202e+22
+    },
+    {
+        "timestamp": "2022-07-25T23:27:36.612Z",
+        "balance": 1.077984474723337e+26,
+        "block_height": 70645889,
+        "epoch_id": "FU1LxUAPj1VLfCzcFt5BLJaRgTD1ECGSzwRyXkRKguud",
+        "next_epoch_id": "GrZ5Qj1vJZgY1MhvUXQcFv9n9mjVHH8BeYJR1ESA2dvC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8448054588662444e+22
+    },
+    {
+        "timestamp": "2022-07-25T08:47:03.542Z",
+        "balance": 1.0777999941774504e+26,
+        "block_height": 70602689,
+        "epoch_id": "DRCMwsoBjR6UKdcJ2jwnUZ2fhbyJZ5FW7ZfeVAdURart",
+        "next_epoch_id": "FU1LxUAPj1VLfCzcFt5BLJaRgTD1ECGSzwRyXkRKguud",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8478668097555184e+22
+    },
+    {
+        "timestamp": "2022-07-24T18:17:10.614Z",
+        "balance": 1.0776152074964749e+26,
+        "block_height": 70559489,
+        "epoch_id": "DL7ub7K6x8AzDMmeHkhVP6Txm3MfYUMRM4J4mp75Lyij",
+        "next_epoch_id": "DRCMwsoBjR6UKdcJ2jwnUZ2fhbyJZ5FW7ZfeVAdURart",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8410143418974994e+22
+    },
+    {
+        "timestamp": "2022-07-24T03:46:03.764Z",
+        "balance": 1.0774311060622851e+26,
+        "block_height": 70516289,
+        "epoch_id": "9nRHpK5dWfQohbkTqkRpTP4WWo5SptEjM2a4aC2CPjEY",
+        "next_epoch_id": "DL7ub7K6x8AzDMmeHkhVP6Txm3MfYUMRM4J4mp75Lyij",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8338339429750734e+22
+    },
+    {
+        "timestamp": "2022-07-23T13:18:03.279Z",
+        "balance": 1.0772477226679876e+26,
+        "block_height": 70473089,
+        "epoch_id": "Ft9Gwa6BhmJS5oNRd5C1u4EoaWBRbnE1BKtq9mbgJcpu",
+        "next_epoch_id": "9nRHpK5dWfQohbkTqkRpTP4WWo5SptEjM2a4aC2CPjEY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.853704102159436e+22
+    },
+    {
+        "timestamp": "2022-07-22T22:54:21.712Z",
+        "balance": 1.0770623522577717e+26,
+        "block_height": 70429889,
+        "epoch_id": "GbuqMY2Qfimr8E7qQCg4tEAs8Jo3ddXHqMKffp3CWPtY",
+        "next_epoch_id": "Ft9Gwa6BhmJS5oNRd5C1u4EoaWBRbnE1BKtq9mbgJcpu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8663692031088789e+22
+    },
+    {
+        "timestamp": "2022-07-22T08:21:07.007Z",
+        "balance": 1.0768757153374608e+26,
+        "block_height": 70386689,
+        "epoch_id": "6ozN4mGht24jkRNWuqam6G5zu1duxygNxDXMKnKHerRg",
+        "next_epoch_id": "GbuqMY2Qfimr8E7qQCg4tEAs8Jo3ddXHqMKffp3CWPtY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.867976335229152e+22
+    },
+    {
+        "timestamp": "2022-07-21T17:40:43.552Z",
+        "balance": 1.0766889177039379e+26,
+        "block_height": 70343489,
+        "epoch_id": "2GTxFkPQppV2ACDVXwVXsKwmssqTu9PhZhYsMrjhbv26",
+        "next_epoch_id": "6ozN4mGht24jkRNWuqam6G5zu1duxygNxDXMKnKHerRg",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9116300075675314e+22
+    },
+    {
+        "timestamp": "2022-07-21T03:00:10.541Z",
+        "balance": 1.0764977547031811e+26,
+        "block_height": 70300289,
+        "epoch_id": "3onVLytwKeoLMD84nkTRPpgt2BGYop4xpFcmj8EfCjNw",
+        "next_epoch_id": "2GTxFkPQppV2ACDVXwVXsKwmssqTu9PhZhYsMrjhbv26",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8524583039386864e+22
+    },
+    {
+        "timestamp": "2022-07-20T12:01:37.015Z",
+        "balance": 1.0763125088727872e+26,
+        "block_height": 70257089,
+        "epoch_id": "E7Eumy4Ve4NWwWYr8sLj289T2sqdunf5WVtbS3KjQ3Tc",
+        "next_epoch_id": "3onVLytwKeoLMD84nkTRPpgt2BGYop4xpFcmj8EfCjNw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8294497420486803e+22
+    },
+    {
+        "timestamp": "2022-07-19T20:05:53.965Z",
+        "balance": 1.0761295638985824e+26,
+        "block_height": 70209510,
+        "epoch_id": "BYjJhbvhySt13X8qeZoJxKZbfFT7YEELiMnN2DQgRSmA",
+        "next_epoch_id": "E7Eumy4Ve4NWwWYr8sLj289T2sqdunf5WVtbS3KjQ3Tc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.812208581513267e+22
+    },
+    {
+        "timestamp": "2022-07-19T07:12:08.340Z",
+        "balance": 1.075948343040431e+26,
+        "block_height": 70170689,
+        "epoch_id": "HN7MbCyMDJ6zvd51z1hrp9fzKDHL83tbei3b7zvLhTg4",
+        "next_epoch_id": "BYjJhbvhySt13X8qeZoJxKZbfFT7YEELiMnN2DQgRSmA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8278383808682433e+22
+    },
+    {
+        "timestamp": "2022-07-18T17:00:21.247Z",
+        "balance": 1.0757655592023442e+26,
+        "block_height": 70127489,
+        "epoch_id": "36RHXN5XBGZmBrnm8o5iQNtPAbTX2sigaNCu6p1Z7EHU",
+        "next_epoch_id": "HN7MbCyMDJ6zvd51z1hrp9fzKDHL83tbei3b7zvLhTg4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8212117345617817e+22
+    },
+    {
+        "timestamp": "2022-07-18T02:41:07.689Z",
+        "balance": 1.075583438028888e+26,
+        "block_height": 70084289,
+        "epoch_id": "7LxpYGA1KrEZD53Y4kvGc5Eob7VTLZVHGZjgtG4bK72Q",
+        "next_epoch_id": "36RHXN5XBGZmBrnm8o5iQNtPAbTX2sigaNCu6p1Z7EHU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8146975858509499e+22
+    },
+    {
+        "timestamp": "2022-07-17T10:57:05.730Z",
+        "balance": 1.075401968270303e+26,
+        "block_height": 70036714,
+        "epoch_id": "BiUE9zMQiTiwQjvn9VsZWWEEtr5ueee1gsA4Fd5tJJy7",
+        "next_epoch_id": "7LxpYGA1KrEZD53Y4kvGc5Eob7VTLZVHGZjgtG4bK72Q",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8212937945247667e+22
+    },
+    {
+        "timestamp": "2022-07-16T22:09:48.948Z",
+        "balance": 1.0752198388908505e+26,
+        "block_height": 69997889,
+        "epoch_id": "3yKpEqT1AEJ8de54m5J4goDZ4cqKn9PjvjbCqf3CwAsx",
+        "next_epoch_id": "BiUE9zMQiTiwQjvn9VsZWWEEtr5ueee1gsA4Fd5tJJy7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8282198742413066e+22
+    },
+    {
+        "timestamp": "2022-07-15T21:12:16.242Z",
+        "balance": 1.0750370169034263e+26,
+        "block_height": 69922581,
+        "epoch_id": "85pDyj5x41CS6xbcQNmVjEpqwR9PQxuzYQQyFX7MSMMX",
+        "next_epoch_id": "3yKpEqT1AEJ8de54m5J4goDZ4cqKn9PjvjbCqf3CwAsx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.835855674519568e+22
+    },
+    {
+        "timestamp": "2022-07-15T17:29:17.538Z",
+        "balance": 1.0748534313359744e+26,
+        "block_height": 69911489,
+        "epoch_id": "5Bn5M7GQA2NWA3tcQjkHWQAH4gH9JyEeXCxZCryQx82C",
+        "next_epoch_id": "85pDyj5x41CS6xbcQNmVjEpqwR9PQxuzYQQyFX7MSMMX",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8176637644980642e+22
+    },
+    {
+        "timestamp": "2022-07-15T03:04:22.022Z",
+        "balance": 1.0746716649595246e+26,
+        "block_height": 69868289,
+        "epoch_id": "HXrkqqsC2vqRdWLWLoxw6GMyPZYjmtBWSZHRspJNnzy3",
+        "next_epoch_id": "5Bn5M7GQA2NWA3tcQjkHWQAH4gH9JyEeXCxZCryQx82C",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7964452671333257e+22
+    },
+    {
+        "timestamp": "2022-07-14T12:44:29.655Z",
+        "balance": 1.0744920204328112e+26,
+        "block_height": 69825089,
+        "epoch_id": "AoXD4tb617NXTH1Y3SoWJTsFDVhnJLNEBr2q5UVg8V4H",
+        "next_epoch_id": "HXrkqqsC2vqRdWLWLoxw6GMyPZYjmtBWSZHRspJNnzy3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8109146206356434e+22
+    },
+    {
+        "timestamp": "2022-07-13T22:34:41.209Z",
+        "balance": 1.0743109289707477e+26,
+        "block_height": 69781889,
+        "epoch_id": "4xCzbSAHqvgsvHnP1BzNm7CeEWgmSNenkzsavUfYQfiq",
+        "next_epoch_id": "AoXD4tb617NXTH1Y3SoWJTsFDVhnJLNEBr2q5UVg8V4H",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7786107537907733e+22
+    },
+    {
+        "timestamp": "2022-07-13T08:18:22.180Z",
+        "balance": 1.0741330678953686e+26,
+        "block_height": 69738689,
+        "epoch_id": "8ARatrUqdYdRQU3oKXGZX1poCTCSkxB6ohhq38Ka7EWL",
+        "next_epoch_id": "4xCzbSAHqvgsvHnP1BzNm7CeEWgmSNenkzsavUfYQfiq",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7984534215148215e+22
+    },
+    {
+        "timestamp": "2022-07-12T18:17:23.548Z",
+        "balance": 1.0739532225532171e+26,
+        "block_height": 69695489,
+        "epoch_id": "CUvjiQbw48eUQmyZXPwiDy7x7pvhVTYKsrKbDTDC2uZt",
+        "next_epoch_id": "8ARatrUqdYdRQU3oKXGZX1poCTCSkxB6ohhq38Ka7EWL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7979445577100376e+22
+    },
+    {
+        "timestamp": "2022-07-12T04:07:50.721Z",
+        "balance": 1.0737734280974461e+26,
+        "block_height": 69652289,
+        "epoch_id": "7usjuGiHyQYJv6ZASzrwXVz7LFQZGCKGYYqboomcHb1P",
+        "next_epoch_id": "CUvjiQbw48eUQmyZXPwiDy7x7pvhVTYKsrKbDTDC2uZt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7687256788114612e+22
+    },
+    {
+        "timestamp": "2022-07-11T13:58:58.053Z",
+        "balance": 1.073596555529565e+26,
+        "block_height": 69609089,
+        "epoch_id": "94YaKtL8TwbYgzW7AsGg91oGBbEZKv8Q7yyQKRp2nbNu",
+        "next_epoch_id": "7usjuGiHyQYJv6ZASzrwXVz7LFQZGCKGYYqboomcHb1P",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8077359385996987e+22
+    },
+    {
+        "timestamp": "2022-07-10T23:51:40.004Z",
+        "balance": 1.073415781935705e+26,
+        "block_height": 69565889,
+        "epoch_id": "CuQkCamZjWmT5zHatp5zkZjDgBUr3uBYLnd3842ac8ti",
+        "next_epoch_id": "94YaKtL8TwbYgzW7AsGg91oGBbEZKv8Q7yyQKRp2nbNu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8105433645902901e+22
+    },
+    {
+        "timestamp": "2022-07-10T09:38:02.568Z",
+        "balance": 1.073234727599246e+26,
+        "block_height": 69522689,
+        "epoch_id": "HgZA4ycDV7VWSXNjw2Apzfffa8hsBZWak6NBVErd59r7",
+        "next_epoch_id": "CuQkCamZjWmT5zHatp5zkZjDgBUr3uBYLnd3842ac8ti",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8148545427936723e+22
+    },
+    {
+        "timestamp": "2022-07-09T19:23:08.058Z",
+        "balance": 1.0730532421449666e+26,
+        "block_height": 69479489,
+        "epoch_id": "5kbKroLwZhys5cpurRxSmfV6riiXS8A8Yo5XmdjvyssL",
+        "next_epoch_id": "HgZA4ycDV7VWSXNjw2Apzfffa8hsBZWak6NBVErd59r7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8371139841844914e+22
+    },
+    {
+        "timestamp": "2022-07-09T05:06:34.850Z",
+        "balance": 1.0728695307465482e+26,
+        "block_height": 69436289,
+        "epoch_id": "GwgsRgeML3wD59ue71VSsA6ZDzrqTRTmG5iG4DyZgVy8",
+        "next_epoch_id": "5kbKroLwZhys5cpurRxSmfV6riiXS8A8Yo5XmdjvyssL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8438251449435663e+22
+    },
+    {
+        "timestamp": "2022-07-08T14:47:18.005Z",
+        "balance": 1.0726851482320538e+26,
+        "block_height": 69393089,
+        "epoch_id": "3cZKXLynmY5R1qZ9s7bQ1989JszfgEdyY1k3gZV86rFZ",
+        "next_epoch_id": "GwgsRgeML3wD59ue71VSsA6ZDzrqTRTmG5iG4DyZgVy8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.913505836040734e+22
+    },
+    {
+        "timestamp": "2022-07-08T00:24:44.615Z",
+        "balance": 1.0724937976484497e+26,
+        "block_height": 69349889,
+        "epoch_id": "F67mSADfy9M3UcxaTHBwwqykvUnRHgeESMhvQ4a4ysNL",
+        "next_epoch_id": "3cZKXLynmY5R1qZ9s7bQ1989JszfgEdyY1k3gZV86rFZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.941977644651352e+22
+    },
+    {
+        "timestamp": "2022-07-07T09:30:03.115Z",
+        "balance": 1.0722995998839846e+26,
+        "block_height": 69306689,
+        "epoch_id": "CsTbYDHyXGjbLMjb8QJjFUQasc2ExLd7Bhtpe77iRE4N",
+        "next_epoch_id": "F67mSADfy9M3UcxaTHBwwqykvUnRHgeESMhvQ4a4ysNL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 2.054259779996321e+22
+    },
+    {
+        "timestamp": "2022-07-06T17:42:11.031Z",
+        "balance": 1.072094173905985e+26,
+        "block_height": 69263489,
+        "epoch_id": "3yWyMcC1HxkuB1mYZZQVm4M6WYM1CD1FULY7fnhwhCBj",
+        "next_epoch_id": "CsTbYDHyXGjbLMjb8QJjFUQasc2ExLd7Bhtpe77iRE4N",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8822302999990717e+22
+    },
+    {
+        "timestamp": "2022-07-06T02:12:30.783Z",
+        "balance": 1.071905950875985e+26,
+        "block_height": 69220289,
+        "epoch_id": "BhRGY73MqSTZgp4dAR44E8jknYTrAf9K9CTRHak1AAvj",
+        "next_epoch_id": "3yWyMcC1HxkuB1mYZZQVm4M6WYM1CD1FULY7fnhwhCBj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.915844173465121e+22
+    },
+    {
+        "timestamp": "2022-07-05T11:30:28.769Z",
+        "balance": 1.0717143664586385e+26,
+        "block_height": 69177089,
+        "epoch_id": "3txb6ssganpF1CdafmwYD1tTgwf5UWXFppYw5hhy4zN6",
+        "next_epoch_id": "BhRGY73MqSTZgp4dAR44E8jknYTrAf9K9CTRHak1AAvj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9507835814774684e+22
+    },
+    {
+        "timestamp": "2022-07-04T20:32:25.031Z",
+        "balance": 1.0715192881004908e+26,
+        "block_height": 69133889,
+        "epoch_id": "DSLXDf6H6b2uqZ7i4YiPZ8MWgx9x5DqzPBnjuhpD9vGH",
+        "next_epoch_id": "3txb6ssganpF1CdafmwYD1tTgwf5UWXFppYw5hhy4zN6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9452014147780877e+22
+    },
+    {
+        "timestamp": "2022-07-04T05:09:56.315Z",
+        "balance": 1.071324767959013e+26,
+        "block_height": 69090689,
+        "epoch_id": "DPJNswZC7ZLLC276nzwvDkGphRx8LfaijBVkoyX1wcEp",
+        "next_epoch_id": "DSLXDf6H6b2uqZ7i4YiPZ8MWgx9x5DqzPBnjuhpD9vGH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8336098294340845e+22
+    },
+    {
+        "timestamp": "2022-07-03T13:49:29.396Z",
+        "balance": 1.0711414069760696e+26,
+        "block_height": 69047489,
+        "epoch_id": "6vC4nzw7SS1XhyX9VYj778VTRVMkBGg2PkfAX64r4pJN",
+        "next_epoch_id": "DPJNswZC7ZLLC276nzwvDkGphRx8LfaijBVkoyX1wcEp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8427659541320397e+22
+    },
+    {
+        "timestamp": "2022-07-02T23:29:52.622Z",
+        "balance": 1.0709571303806564e+26,
+        "block_height": 69004289,
+        "epoch_id": "AHFqXzBz9SN7SLtjFkji9xuzMTqMqm5HvsXxFPb9W6Pu",
+        "next_epoch_id": "6vC4nzw7SS1XhyX9VYj778VTRVMkBGg2PkfAX64r4pJN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9442693047663033e+22
+    },
+    {
+        "timestamp": "2022-07-02T09:05:13.038Z",
+        "balance": 1.0707627034501797e+26,
+        "block_height": 68961089,
+        "epoch_id": "HNQSZadzUZuuRPri3nPwqzK9wJiNyqqv54PuDevriqpE",
+        "next_epoch_id": "AHFqXzBz9SN7SLtjFkji9xuzMTqMqm5HvsXxFPb9W6Pu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.930163336250911e+22
+    },
+    {
+        "timestamp": "2022-07-01T17:45:05.317Z",
+        "balance": 1.0705696871165547e+26,
+        "block_height": 68917889,
+        "epoch_id": "GEhZmzhBYPpYMhz2EHAZ2FZp29fxwUA8UZBJahUhjvF9",
+        "next_epoch_id": "HNQSZadzUZuuRPri3nPwqzK9wJiNyqqv54PuDevriqpE",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8772147910330955e+22
+    },
+    {
+        "timestamp": "2022-07-01T02:31:00.726Z",
+        "balance": 1.0703819656374513e+26,
+        "block_height": 68874689,
+        "epoch_id": "7RQvApr98mq7uD7vnDL4u58XTKkF88Dy9PwXqAQowmC6",
+        "next_epoch_id": "GEhZmzhBYPpYMhz2EHAZ2FZp29fxwUA8UZBJahUhjvF9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.836398802582161e+22
+    },
+    {
+        "timestamp": "2022-06-30T11:48:00.948Z",
+        "balance": 1.0701983257571931e+26,
+        "block_height": 68831489,
+        "epoch_id": "6AyL5pZNcFXQZ9uWWNp8ipnCBFeQHn6yXp1N9yX2SqNQ",
+        "next_epoch_id": "7RQvApr98mq7uD7vnDL4u58XTKkF88Dy9PwXqAQowmC6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9775910887988797e+22
+    },
+    {
+        "timestamp": "2022-06-29T21:25:05.880Z",
+        "balance": 1.0700005666483132e+26,
+        "block_height": 68788289,
+        "epoch_id": "MX8GiaedjsxjVfSSAn1EMVMV33muo2exPAZwLL6Zrru",
+        "next_epoch_id": "6AyL5pZNcFXQZ9uWWNp8ipnCBFeQHn6yXp1N9yX2SqNQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.979860612825904e+22
+    },
+    {
+        "timestamp": "2022-06-29T06:06:12.894Z",
+        "balance": 1.0698025805870306e+26,
+        "block_height": 68745089,
+        "epoch_id": "DLiunvnXykSWGuf7cus9sQXtvHwcX9VCuKyJPtY8W8D4",
+        "next_epoch_id": "MX8GiaedjsxjVfSSAn1EMVMV33muo2exPAZwLL6Zrru",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.867038710139198e+22
+    },
+    {
+        "timestamp": "2022-06-28T14:39:19.302Z",
+        "balance": 1.0696158767160167e+26,
+        "block_height": 68701889,
+        "epoch_id": "6vSqk91yjm9vvRRBwg8SmJhgUR7QVwUQG3YMV73zeTTc",
+        "next_epoch_id": "DLiunvnXykSWGuf7cus9sQXtvHwcX9VCuKyJPtY8W8D4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.958786727126845e+22
+    },
+    {
+        "timestamp": "2022-06-27T23:50:52.088Z",
+        "balance": 1.069419998043304e+26,
+        "block_height": 68658689,
+        "epoch_id": "o4S5suBDY7NPdCoAry9FLPkceUWzR8u1xhG96yvwqLw",
+        "next_epoch_id": "6vSqk91yjm9vvRRBwg8SmJhgUR7QVwUQG3YMV73zeTTc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8157910938085128e+22
+    },
+    {
+        "timestamp": "2022-06-27T08:18:19.460Z",
+        "balance": 1.0692384189339232e+26,
+        "block_height": 68615489,
+        "epoch_id": "HxYagQDN8AFaftZDVnuvE9mQiQ4qoparbAZh1bnPWb38",
+        "next_epoch_id": "o4S5suBDY7NPdCoAry9FLPkceUWzR8u1xhG96yvwqLw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8006843295011954e+22
+    },
+    {
+        "timestamp": "2022-06-26T17:53:57.749Z",
+        "balance": 1.069058350500973e+26,
+        "block_height": 68572289,
+        "epoch_id": "BRS3q8Xd7oakvBMNjLCvyb9LSTnWaGKFLHnkmwmsgLSV",
+        "next_epoch_id": "HxYagQDN8AFaftZDVnuvE9mQiQ4qoparbAZh1bnPWb38",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7838709104350195e+22
+    },
+    {
+        "timestamp": "2022-06-26T03:36:58.790Z",
+        "balance": 1.0688799634099296e+26,
+        "block_height": 68529089,
+        "epoch_id": "EDUVzJzTnpAuvxcb9yGTX8A2PpJfwQ7bKim8J23Tqz1Y",
+        "next_epoch_id": "BRS3q8Xd7oakvBMNjLCvyb9LSTnWaGKFLHnkmwmsgLSV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8258961494948153e+22
+    },
+    {
+        "timestamp": "2022-06-25T13:27:57.293Z",
+        "balance": 1.0686973737949801e+26,
+        "block_height": 68485889,
+        "epoch_id": "2qsFrnpHwqqiRUyFviNfH9GnExWNkkqcQpXDNzA467y2",
+        "next_epoch_id": "EDUVzJzTnpAuvxcb9yGTX8A2PpJfwQ7bKim8J23Tqz1Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8146964339390031e+22
+    },
+    {
+        "timestamp": "2022-06-24T22:58:39.554Z",
+        "balance": 1.0685159041515862e+26,
+        "block_height": 68442689,
+        "epoch_id": "4DMabFn9xJUn94poopyvcbXwL7iduNwSnhpsx9zmYG5E",
+        "next_epoch_id": "2qsFrnpHwqqiRUyFviNfH9GnExWNkkqcQpXDNzA467y2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8312499661094921e+22
+    },
+    {
+        "timestamp": "2022-06-24T08:33:44.061Z",
+        "balance": 1.0683327791549752e+26,
+        "block_height": 68399489,
+        "epoch_id": "4BjsqtxpDvGCdXVwXXx1sas9BSwjhbj5jRdV2oZ5f6oW",
+        "next_epoch_id": "4DMabFn9xJUn94poopyvcbXwL7iduNwSnhpsx9zmYG5E",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8458885019779358e+22
+    },
+    {
+        "timestamp": "2022-06-23T18:09:15.921Z",
+        "balance": 1.0681481903047774e+26,
+        "block_height": 68356289,
+        "epoch_id": "H1fN9RHGbFZKmPzDHvQMx6v9EUo7dtnzVnLPzRBTXxTL",
+        "next_epoch_id": "4BjsqtxpDvGCdXVwXXx1sas9BSwjhbj5jRdV2oZ5f6oW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8558212854471e+22
+    },
+    {
+        "timestamp": "2022-06-23T03:38:19.069Z",
+        "balance": 1.0679626081762327e+26,
+        "block_height": 68313089,
+        "epoch_id": "3vhwCWzP2ojqzedDz3vDWSce9MsLDh4J2tbenTtm4PKk",
+        "next_epoch_id": "H1fN9RHGbFZKmPzDHvQMx6v9EUo7dtnzVnLPzRBTXxTL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7286566931590868e+22
+    },
+    {
+        "timestamp": "2022-06-22T12:53:39.630Z",
+        "balance": 1.0677897425069168e+26,
+        "block_height": 68269889,
+        "epoch_id": "HH76rrsEB2cFnUdpbyrCnVnFXoYTsf7FcQURxzbB423e",
+        "next_epoch_id": "3vhwCWzP2ojqzedDz3vDWSce9MsLDh4J2tbenTtm4PKk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7015825316094105e+22
+    },
+    {
+        "timestamp": "2022-06-21T21:56:03.018Z",
+        "balance": 1.0676195842537559e+26,
+        "block_height": 68226689,
+        "epoch_id": "GfatR1ft7aaq8KSaTivU7VgKrcheNKXvs3cbBaBhMcc1",
+        "next_epoch_id": "HH76rrsEB2cFnUdpbyrCnVnFXoYTsf7FcQURxzbB423e",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6884140526262144e+22
+    },
+    {
+        "timestamp": "2022-06-21T07:11:15.272Z",
+        "balance": 1.0674507428484933e+26,
+        "block_height": 68183489,
+        "epoch_id": "GX8x79Y9L7mowMATZcrTqcDH759o2DH3ANGpaMTBtoqf",
+        "next_epoch_id": "GfatR1ft7aaq8KSaTivU7VgKrcheNKXvs3cbBaBhMcc1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6844985400626908e+22
+    },
+    {
+        "timestamp": "2022-06-20T16:33:40.666Z",
+        "balance": 1.067282292994487e+26,
+        "block_height": 68140289,
+        "epoch_id": "BCiXbp8xLtas7RSEbTmZAsW8cRBJnQa6CcyN7GmsGArm",
+        "next_epoch_id": "GX8x79Y9L7mowMATZcrTqcDH759o2DH3ANGpaMTBtoqf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6939818520088729e+22
+    },
+    {
+        "timestamp": "2022-06-20T01:58:16.793Z",
+        "balance": 1.0671128948092861e+26,
+        "block_height": 68097089,
+        "epoch_id": "7rDnoWcXdbAsHbaUJr2bGnCcRLDdSyBwn4MavsBQv22e",
+        "next_epoch_id": "BCiXbp8xLtas7RSEbTmZAsW8cRBJnQa6CcyN7GmsGArm",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7017727517750423e+22
+    },
+    {
+        "timestamp": "2022-06-19T11:17:16.071Z",
+        "balance": 1.0669427175341086e+26,
+        "block_height": 68053889,
+        "epoch_id": "9NDU3ihUmPNu3zEhSpcRN1GqtJSfkouTUmjqry47zhsa",
+        "next_epoch_id": "7rDnoWcXdbAsHbaUJr2bGnCcRLDdSyBwn4MavsBQv22e",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.700703114665031e+22
+    },
+    {
+        "timestamp": "2022-06-18T14:07:16.330Z",
+        "balance": 1.0667726472226421e+26,
+        "block_height": 67991817,
+        "epoch_id": "9UjofDX2jReEfbkd5RhrxRFhHZ3QYgwQNYWXb7MnbTfQ",
+        "next_epoch_id": "9NDU3ihUmPNu3zEhSpcRN1GqtJSfkouTUmjqry47zhsa",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.659172170879233e+22
+    },
+    {
+        "timestamp": "2022-06-18T05:46:21.003Z",
+        "balance": 1.0666067300055542e+26,
+        "block_height": 67967489,
+        "epoch_id": "2b45F8TRknB5SAymBD96bCSuz1LSikjrJnzyjTxhA4Br",
+        "next_epoch_id": "9UjofDX2jReEfbkd5RhrxRFhHZ3QYgwQNYWXb7MnbTfQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6682727866192728e+22
+    },
+    {
+        "timestamp": "2022-06-17T15:15:25.231Z",
+        "balance": 1.0664399027268923e+26,
+        "block_height": 67924289,
+        "epoch_id": "CUamMw5SLuKMQjyaLDQXbW2vfiUeHv5mLs624aKb3aSU",
+        "next_epoch_id": "2b45F8TRknB5SAymBD96bCSuz1LSikjrJnzyjTxhA4Br",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6878752300054836e+22
+    },
+    {
+        "timestamp": "2022-06-17T00:40:23.235Z",
+        "balance": 1.0662711152038917e+26,
+        "block_height": 67881089,
+        "epoch_id": "78QzqPj2P6zVi7k14d8bPyu1xSwuLAoWNkK6JZBM8vgi",
+        "next_epoch_id": "CUamMw5SLuKMQjyaLDQXbW2vfiUeHv5mLs624aKb3aSU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6539304855664771e+22
+    },
+    {
+        "timestamp": "2022-06-16T09:54:23.926Z",
+        "balance": 1.066105722155335e+26,
+        "block_height": 67837889,
+        "epoch_id": "7DzmHk1QaQiwMHPLxzb5W4YwpnZYNJTY2cu4XrbZ5Nw8",
+        "next_epoch_id": "78QzqPj2P6zVi7k14d8bPyu1xSwuLAoWNkK6JZBM8vgi",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.663693466429852e+22
+    },
+    {
+        "timestamp": "2022-06-15T19:24:20.808Z",
+        "balance": 1.065939352808692e+26,
+        "block_height": 67794689,
+        "epoch_id": "6oZmvetPYQxAeFik8127FYmsjzQLvoSJs44JhigS13Ud",
+        "next_epoch_id": "7DzmHk1QaQiwMHPLxzb5W4YwpnZYNJTY2cu4XrbZ5Nw8",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6440954495812474e+22
+    },
+    {
+        "timestamp": "2022-06-15T04:49:34.991Z",
+        "balance": 1.065774943263734e+26,
+        "block_height": 67751489,
+        "epoch_id": "3Nzu9T213aZB5GD6uKhhWiVffTTti3hQYinaSh7F7TfY",
+        "next_epoch_id": "6oZmvetPYQxAeFik8127FYmsjzQLvoSJs44JhigS13Ud",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6494064409705007e+22
+    },
+    {
+        "timestamp": "2022-06-14T14:25:36.480Z",
+        "balance": 1.0656100026196369e+26,
+        "block_height": 67708289,
+        "epoch_id": "AxuJYjUBrrfnu2YFV3rbJn7QMDdh11HEXcVFZA7CeahG",
+        "next_epoch_id": "3Nzu9T213aZB5GD6uKhhWiVffTTti3hQYinaSh7F7TfY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.657222408995334e+22
+    },
+    {
+        "timestamp": "2022-06-13T23:59:08.306Z",
+        "balance": 1.0654442803787374e+26,
+        "block_height": 67665089,
+        "epoch_id": "4gNSQzD2DWBYXj7ouemVHZB8TvE6xeMMva3VJ3mFCtJW",
+        "next_epoch_id": "AxuJYjUBrrfnu2YFV3rbJn7QMDdh11HEXcVFZA7CeahG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6853680252868993e+22
+    },
+    {
+        "timestamp": "2022-06-13T09:31:18.936Z",
+        "balance": 1.0652757435762087e+26,
+        "block_height": 67621889,
+        "epoch_id": "6J6uAHu6di2XTWpziDHzHYqpJTJYgMHacNN2gw7SfFDr",
+        "next_epoch_id": "4gNSQzD2DWBYXj7ouemVHZB8TvE6xeMMva3VJ3mFCtJW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6384583746455651e+22
+    },
+    {
+        "timestamp": "2022-06-12T19:01:13.818Z",
+        "balance": 1.0651118977387441e+26,
+        "block_height": 67578689,
+        "epoch_id": "5fEsiJqEY7LJjHRF16KKMqinBxrmSXhWnYV1dxFDHyiw",
+        "next_epoch_id": "6J6uAHu6di2XTWpziDHzHYqpJTJYgMHacNN2gw7SfFDr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6939859236447414e+22
+    },
+    {
+        "timestamp": "2022-06-11T18:58:16.847Z",
+        "balance": 1.0649424991463796e+26,
+        "block_height": 67507234,
+        "epoch_id": "2yNq3G9vHFv21uztUXF7yviq4XpqfUFdkbUepSXiuyvF",
+        "next_epoch_id": "5fEsiJqEY7LJjHRF16KKMqinBxrmSXhWnYV1dxFDHyiw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6512962275668652e+22
+    },
+    {
+        "timestamp": "2022-06-11T13:34:34.000Z",
+        "balance": 1.064777369523623e+26,
+        "block_height": 67492289,
+        "epoch_id": "G3jo5yt9PrEs2gSV2MMnKz4c472wF63B3ZnNkgPtmPMW",
+        "next_epoch_id": "2yNq3G9vHFv21uztUXF7yviq4XpqfUFdkbUepSXiuyvF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6798164066678245e+22
+    },
+    {
+        "timestamp": "2022-06-10T22:58:26.401Z",
+        "balance": 1.0646093878829562e+26,
+        "block_height": 67449089,
+        "epoch_id": "95otjEUgGkGHwpUNFXd3afjde6DTAYkTBcB1cBtgEpTt",
+        "next_epoch_id": "G3jo5yt9PrEs2gSV2MMnKz4c472wF63B3ZnNkgPtmPMW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.687737818325054e+22
+    },
+    {
+        "timestamp": "2022-06-10T08:07:56.498Z",
+        "balance": 1.0644406141011237e+26,
+        "block_height": 67405889,
+        "epoch_id": "GMWYKukMmQ7UmGY5nUaEEsdT7XB3rQSLonTV8EmUnL4A",
+        "next_epoch_id": "95otjEUgGkGHwpUNFXd3afjde6DTAYkTBcB1cBtgEpTt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7601755904263626e+22
+    },
+    {
+        "timestamp": "2022-06-09T17:13:08.532Z",
+        "balance": 1.064264596542081e+26,
+        "block_height": 67362689,
+        "epoch_id": "AYFD6nrBmuwuK2kpTu1twXw8f1i742enE8QL7zao5FKW",
+        "next_epoch_id": "GMWYKukMmQ7UmGY5nUaEEsdT7XB3rQSLonTV8EmUnL4A",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.784184990365618e+22
+    },
+    {
+        "timestamp": "2022-06-09T01:51:50.101Z",
+        "balance": 1.0640861780430445e+26,
+        "block_height": 67319489,
+        "epoch_id": "7Wp5DXkr5KiEzPLsSMuy48Qk81PNVG6nfFcn9UKa7PyC",
+        "next_epoch_id": "AYFD6nrBmuwuK2kpTu1twXw8f1i742enE8QL7zao5FKW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.808663279697982e+22
+    },
+    {
+        "timestamp": "2022-06-08T10:17:04.490Z",
+        "balance": 1.0639053117150747e+26,
+        "block_height": 67276289,
+        "epoch_id": "F8S4oGevMSRxSrkVADMaU28VPZ4omVosX3oLxEMZvsvM",
+        "next_epoch_id": "7Wp5DXkr5KiEzPLsSMuy48Qk81PNVG6nfFcn9UKa7PyC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7255929390122725e+22
+    },
+    {
+        "timestamp": "2022-06-07T18:15:47.025Z",
+        "balance": 1.0637327524211734e+26,
+        "block_height": 67233089,
+        "epoch_id": "zrpzn6dUxo3nYAnpcN3wXdFg7srqTcwJYNw6YanSk6y",
+        "next_epoch_id": "F8S4oGevMSRxSrkVADMaU28VPZ4omVosX3oLxEMZvsvM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7555297151196393e+22
+    },
+    {
+        "timestamp": "2022-06-07T02:55:20.278Z",
+        "balance": 1.0635571994496615e+26,
+        "block_height": 67189889,
+        "epoch_id": "8cLGkbRAXAwj1yXeTvuwn6QMZj1DRJKvc2rNcxgx7rRp",
+        "next_epoch_id": "zrpzn6dUxo3nYAnpcN3wXdFg7srqTcwJYNw6YanSk6y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7095459298137996e+22
+    },
+    {
+        "timestamp": "2022-06-06T06:13:36.807Z",
+        "balance": 1.0633862448566801e+26,
+        "block_height": 67131853,
+        "epoch_id": "6LmoJ4KiJFaNcT347hL6k6UubcKsS2RoRyvip9huYZKo",
+        "next_epoch_id": "8cLGkbRAXAwj1yXeTvuwn6QMZj1DRJKvc2rNcxgx7rRp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7297144794046385e+22
+    },
+    {
+        "timestamp": "2022-06-05T20:06:28.819Z",
+        "balance": 1.0632132734087396e+26,
+        "block_height": 67103489,
+        "epoch_id": "CFgKi1d1jSSKvFAhB14ChueY1qGJVHTndwu6WoQCWNef",
+        "next_epoch_id": "6LmoJ4KiJFaNcT347hL6k6UubcKsS2RoRyvip9huYZKo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7302683288978852e+22
+    },
+    {
+        "timestamp": "2022-06-05T04:44:29.718Z",
+        "balance": 1.0630402465758498e+26,
+        "block_height": 67060289,
+        "epoch_id": "J6xhoaTMtdiRF5EZ9TEArxV6rq4UABvgnhjuDogsdkiC",
+        "next_epoch_id": "CFgKi1d1jSSKvFAhB14ChueY1qGJVHTndwu6WoQCWNef",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.742616804439078e+22
+    },
+    {
+        "timestamp": "2022-06-04T13:22:09.626Z",
+        "balance": 1.062865984895406e+26,
+        "block_height": 67017089,
+        "epoch_id": "CV7MYpWjcbfZYuGZzmG3nTj3VRrbCa55BiUzZCxACcBs",
+        "next_epoch_id": "J6xhoaTMtdiRF5EZ9TEArxV6rq4UABvgnhjuDogsdkiC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7552340966180544e+22
+    },
+    {
+        "timestamp": "2022-06-03T21:53:10.623Z",
+        "balance": 1.0626904614857441e+26,
+        "block_height": 66973889,
+        "epoch_id": "9RzyZdf4nvW4uAtBSrWGWeQectSugEzsaHJzUgMLjMiA",
+        "next_epoch_id": "CV7MYpWjcbfZYuGZzmG3nTj3VRrbCa55BiUzZCxACcBs",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7720957872735007e+22
+    },
+    {
+        "timestamp": "2022-06-02T20:48:34.167Z",
+        "balance": 1.0625132519070168e+26,
+        "block_height": 66903934,
+        "epoch_id": "8vRL1eRYLeHykUiTxtCPHAvNsCaHw7iYnhefHENfiC6d",
+        "next_epoch_id": "9RzyZdf4nvW4uAtBSrWGWeQectSugEzsaHJzUgMLjMiA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7444399343627793e+22
+    },
+    {
+        "timestamp": "2022-06-02T14:37:08.832Z",
+        "balance": 1.0623388079135805e+26,
+        "block_height": 66887489,
+        "epoch_id": "DLkufCHxjnVe2b8xx1GmaNaViHuuMEcQ9ZRT9KhszLPw",
+        "next_epoch_id": "8vRL1eRYLeHykUiTxtCPHAvNsCaHw7iYnhefHENfiC6d",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7666526483596899e+22
+    },
+    {
+        "timestamp": "2022-06-01T23:11:09.454Z",
+        "balance": 1.0621621426487445e+26,
+        "block_height": 66844289,
+        "epoch_id": "BFqpd2cu3rVMdMmRQUDx6NBmvdd3GAiRg6zJnXVV75Xp",
+        "next_epoch_id": "DLkufCHxjnVe2b8xx1GmaNaViHuuMEcQ9ZRT9KhszLPw",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7585687537397099e+22
+    },
+    {
+        "timestamp": "2022-06-01T07:33:44.605Z",
+        "balance": 1.0619862857733706e+26,
+        "block_height": 66801089,
+        "epoch_id": "F67ikeLGzGSMx4zrThxCWdjUGQNAvjCa3RwJrTJYzt6c",
+        "next_epoch_id": "BFqpd2cu3rVMdMmRQUDx6NBmvdd3GAiRg6zJnXVV75Xp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.825960428518251e+22
+    },
+    {
+        "timestamp": "2022-05-31T16:05:02.127Z",
+        "balance": 1.0618036897305187e+26,
+        "block_height": 66757889,
+        "epoch_id": "3Qv3ePtbr1fLPfn2UWV1NsMb9gsnTE99rotY31oJYbsh",
+        "next_epoch_id": "F67ikeLGzGSMx4zrThxCWdjUGQNAvjCa3RwJrTJYzt6c",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.091254593192279e+22
+    },
+    {
+        "timestamp": "2022-05-30T23:57:34.473Z",
+        "balance": 1.0616945642711995e+26,
+        "block_height": 66714689,
+        "epoch_id": "FUr9gT7WJgYbh2Gar8D4s3JKrmwDbD2MBFKBU5JA5Rdr",
+        "next_epoch_id": "3Qv3ePtbr1fLPfn2UWV1NsMb9gsnTE99rotY31oJYbsh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7122020402307745e+22
+    },
+    {
+        "timestamp": "2022-05-30T08:28:37.908Z",
+        "balance": 1.0615233440671764e+26,
+        "block_height": 66671489,
+        "epoch_id": "Gc8UhUGW4uMEsNdNxENoEKA5wqV24cdRAU6hyX2bMR1M",
+        "next_epoch_id": "FUr9gT7WJgYbh2Gar8D4s3JKrmwDbD2MBFKBU5JA5Rdr",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6936989643882128e+22
+    },
+    {
+        "timestamp": "2022-05-29T07:09:01.391Z",
+        "balance": 1.0613539741707376e+26,
+        "block_height": 66598746,
+        "epoch_id": "8dhdxKrhQg6qUj6kn3ZiFFUaPEmN8Q8burMR19ihmp6V",
+        "next_epoch_id": "Gc8UhUGW4uMEsNdNxENoEKA5wqV24cdRAU6hyX2bMR1M",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7153499335806274e+22
+    },
+    {
+        "timestamp": "2022-05-29T02:14:44.528Z",
+        "balance": 1.0611824391773796e+26,
+        "block_height": 66585089,
+        "epoch_id": "G1H1Px69JUJs7xNX83Kc1DziorPJKZNxpUXgGEQH6tdA",
+        "next_epoch_id": "8dhdxKrhQg6qUj6kn3ZiFFUaPEmN8Q8burMR19ihmp6V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.731853530643703e+22
+    },
+    {
+        "timestamp": "2022-05-28T11:00:57.839Z",
+        "balance": 1.0610092538243152e+26,
+        "block_height": 66541889,
+        "epoch_id": "7jVZVZvdzUsj4959ncozTSS8Lcs6pLNfq7SykwRKzhp3",
+        "next_epoch_id": "G1H1Px69JUJs7xNX83Kc1DziorPJKZNxpUXgGEQH6tdA",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7404722819717422e+22
+    },
+    {
+        "timestamp": "2022-05-27T19:57:40.608Z",
+        "balance": 1.060835206596118e+26,
+        "block_height": 66498689,
+        "epoch_id": "2PEoMzFVqzsxG83MkgBGaPS69Q7SHRTDKKncHXFPBEK2",
+        "next_epoch_id": "7jVZVZvdzUsj4959ncozTSS8Lcs6pLNfq7SykwRKzhp3",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7737494081678894e+22
+    },
+    {
+        "timestamp": "2022-05-27T04:47:08.805Z",
+        "balance": 1.0606578316553012e+26,
+        "block_height": 66455489,
+        "epoch_id": "7W4cksb3zTz64Rr8h5SS1k9rqh29k48peMmUBgBC1nPL",
+        "next_epoch_id": "2PEoMzFVqzsxG83MkgBGaPS69Q7SHRTDKKncHXFPBEK2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6956915714210298e+22
+    },
+    {
+        "timestamp": "2022-05-26T13:20:54.578Z",
+        "balance": 1.0604882624981591e+26,
+        "block_height": 66412289,
+        "epoch_id": "B9DWKxgwKE45bV5fnwLTLQJxNYZ1bkup7YePpXEPJpCp",
+        "next_epoch_id": "7W4cksb3zTz64Rr8h5SS1k9rqh29k48peMmUBgBC1nPL",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6424353780101934e+22
+    },
+    {
+        "timestamp": "2022-05-25T22:37:22.868Z",
+        "balance": 1.0603240189603581e+26,
+        "block_height": 66369089,
+        "epoch_id": "7UPr82VhDdBsBz4mti9sxS7WoMDeGbfYgZjEyc88cLmH",
+        "next_epoch_id": "B9DWKxgwKE45bV5fnwLTLQJxNYZ1bkup7YePpXEPJpCp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.77080379752645e+22
+    },
+    {
+        "timestamp": "2022-05-25T07:51:10.628Z",
+        "balance": 1.0601469385806055e+26,
+        "block_height": 66325889,
+        "epoch_id": "88mkP4MYCQFMs2WpjzunNCn48dcZAgPDMcoWcyuenGJS",
+        "next_epoch_id": "7UPr82VhDdBsBz4mti9sxS7WoMDeGbfYgZjEyc88cLmH",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.656246269201906e+22
+    },
+    {
+        "timestamp": "2022-05-24T15:55:56.549Z",
+        "balance": 1.0599813139536853e+26,
+        "block_height": 66282689,
+        "epoch_id": "H2BbkesbfAsZCzC42D52FFCyySHuoYGHDPts1FcZJ12C",
+        "next_epoch_id": "88mkP4MYCQFMs2WpjzunNCn48dcZAgPDMcoWcyuenGJS",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6774579661404843e+22
+    },
+    {
+        "timestamp": "2022-05-24T01:02:44.074Z",
+        "balance": 1.0598135681570712e+26,
+        "block_height": 66239489,
+        "epoch_id": "H8uYv2fhFNKREpsawg8NaiF7cUCz9pggArMi5JuFq41T",
+        "next_epoch_id": "H2BbkesbfAsZCzC42D52FFCyySHuoYGHDPts1FcZJ12C",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.610967478038693e+22
+    },
+    {
+        "timestamp": "2022-05-23T09:58:27.676Z",
+        "balance": 1.0596524714092673e+26,
+        "block_height": 66196289,
+        "epoch_id": "5r1BmdScedd7YjS6A6VCMx6newdmVRE4dAPMmPvzhE7S",
+        "next_epoch_id": "H8uYv2fhFNKREpsawg8NaiF7cUCz9pggArMi5JuFq41T",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.598660305864828e+22
+    },
+    {
+        "timestamp": "2022-05-22T10:01:46.207Z",
+        "balance": 1.0594926053786809e+26,
+        "block_height": 66124566,
+        "epoch_id": "GtJXc1AXpMAjuetu4rXC8CE2CQ4SBqJhjt5nEhZTLF2Y",
+        "next_epoch_id": "5r1BmdScedd7YjS6A6VCMx6newdmVRE4dAPMmPvzhE7S",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.5933195789309258e+22
+    },
+    {
+        "timestamp": "2022-05-21T16:06:32.465Z",
+        "balance": 1.0593332734207878e+26,
+        "block_height": 66070432,
+        "epoch_id": "5U4dRxNES8tBNjb4o7QGbQJz4GaRJWUxaahgRB5Zibvc",
+        "next_epoch_id": "GtJXc1AXpMAjuetu4rXC8CE2CQ4SBqJhjt5nEhZTLF2Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.589495503082372e+22
+    },
+    {
+        "timestamp": "2022-05-21T14:49:32.982Z",
+        "balance": 1.0591743238704795e+26,
+        "block_height": 66066689,
+        "epoch_id": "3jchZGzrJcLg57KB8x5xFRvdPjCJ4BAVCT8JtP4Qaj6E",
+        "next_epoch_id": "5U4dRxNES8tBNjb4o7QGbQJz4GaRJWUxaahgRB5Zibvc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6095999866251774e+22
+    },
+    {
+        "timestamp": "2022-05-21T00:28:32.766Z",
+        "balance": 1.059013363871817e+26,
+        "block_height": 66023489,
+        "epoch_id": "9v6jZyCqSgessXCbq7rxX5miSrcLAcjGQmFLL82Yp6Vd",
+        "next_epoch_id": "3jchZGzrJcLg57KB8x5xFRvdPjCJ4BAVCT8JtP4Qaj6E",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.606862842125644e+22
+    },
+    {
+        "timestamp": "2022-05-20T09:56:41.678Z",
+        "balance": 1.0588526775876044e+26,
+        "block_height": 65980289,
+        "epoch_id": "CuQe5bgy9wHCjpkUbMiLmXwDKXkGDDs1MMRyWrNwX1AY",
+        "next_epoch_id": "9v6jZyCqSgessXCbq7rxX5miSrcLAcjGQmFLL82Yp6Vd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6433393240196065e+22
+    },
+    {
+        "timestamp": "2022-05-19T19:26:48.289Z",
+        "balance": 1.0586883436552025e+26,
+        "block_height": 65937089,
+        "epoch_id": "5GZNqy7YUd2dir7xfkEEgjbcZRYFKZzCVNEFbRAgCM3V",
+        "next_epoch_id": "CuQe5bgy9wHCjpkUbMiLmXwDKXkGDDs1MMRyWrNwX1AY",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.663652086012529e+22
+    },
+    {
+        "timestamp": "2022-05-19T04:35:30.667Z",
+        "balance": 1.0585219784466012e+26,
+        "block_height": 65893889,
+        "epoch_id": "8aLhNoTsaW67n2t7cPcQNGi1qhL6vMogkp8cpqP1LDP6",
+        "next_epoch_id": "5GZNqy7YUd2dir7xfkEEgjbcZRYFKZzCVNEFbRAgCM3V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6313917885855019e+22
+    },
+    {
+        "timestamp": "2022-05-18T13:33:09.391Z",
+        "balance": 1.0583588392677427e+26,
+        "block_height": 65850689,
+        "epoch_id": "AK37BH8TPLmoZEHx3qc2wWvTjZNeMkQY5NVeo35xAF2H",
+        "next_epoch_id": "8aLhNoTsaW67n2t7cPcQNGi1qhL6vMogkp8cpqP1LDP6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6368927821622067e+22
+    },
+    {
+        "timestamp": "2022-05-17T22:48:24.242Z",
+        "balance": 1.0581951499895265e+26,
+        "block_height": 65807489,
+        "epoch_id": "5kHzPHvarD7EPuKUMfqCYwCW4VLJLehfMhBFU3FgChgQ",
+        "next_epoch_id": "AK37BH8TPLmoZEHx3qc2wWvTjZNeMkQY5NVeo35xAF2H",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6411624532896802e+22
+    },
+    {
+        "timestamp": "2022-05-17T08:01:04.448Z",
+        "balance": 1.0580310337441975e+26,
+        "block_height": 65764289,
+        "epoch_id": "96A9QhRcKdK5yv4UhaQMqrBtUefjR4VEL42qVP16JNVN",
+        "next_epoch_id": "5kHzPHvarD7EPuKUMfqCYwCW4VLJLehfMhBFU3FgChgQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6171948225928553e+22
+    },
+    {
+        "timestamp": "2022-05-16T17:11:53.038Z",
+        "balance": 1.0578693142619382e+26,
+        "block_height": 65721089,
+        "epoch_id": "E4keJ35YAt2D5LCwXrMRSPLbNkd2Q9qDAgKUBkiHM6hu",
+        "next_epoch_id": "96A9QhRcKdK5yv4UhaQMqrBtUefjR4VEL42qVP16JNVN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6401319711614056e+22
+    },
+    {
+        "timestamp": "2022-05-16T02:35:26.234Z",
+        "balance": 1.057705301064822e+26,
+        "block_height": 65677889,
+        "epoch_id": "Hr2NWeXFLx43R2Pw5EDXWa9bo2Ujw2jme9AJ2J5sDpid",
+        "next_epoch_id": "E4keJ35YAt2D5LCwXrMRSPLbNkd2Q9qDAgKUBkiHM6hu",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.617968092341092e+22
+    },
+    {
+        "timestamp": "2022-05-15T11:49:09.006Z",
+        "balance": 1.057543504255588e+26,
+        "block_height": 65634689,
+        "epoch_id": "Ck8iAeDvuc1A3HbfEkS11jitHQmpegkYBmcRncUCZMtT",
+        "next_epoch_id": "Hr2NWeXFLx43R2Pw5EDXWa9bo2Ujw2jme9AJ2J5sDpid",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6946830949133194e+22
+    },
+    {
+        "timestamp": "2022-05-14T21:14:15.248Z",
+        "balance": 1.0573740359460966e+26,
+        "block_height": 65591489,
+        "epoch_id": "Dj2DQkDDt3KUnBYMdv8idXgPTLNZucwReEJ1a6n3gFKM",
+        "next_epoch_id": "Ck8iAeDvuc1A3HbfEkS11jitHQmpegkYBmcRncUCZMtT",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6655248881607214e+22
+    },
+    {
+        "timestamp": "2022-05-14T06:17:13.378Z",
+        "balance": 1.0572074834572806e+26,
+        "block_height": 65548289,
+        "epoch_id": "EmH4KygS1YxpDgQEcKsThXdYYFahgg7KpykM6cuWybS5",
+        "next_epoch_id": "Dj2DQkDDt3KUnBYMdv8idXgPTLNZucwReEJ1a6n3gFKM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.743084538243748e+22
+    },
+    {
+        "timestamp": "2022-05-13T14:51:48.843Z",
+        "balance": 1.0570331750034562e+26,
+        "block_height": 65502962,
+        "epoch_id": "7mcexsJbAkxpoNJDo5wsFFBqoc41cAf1qRRayxAZcA1o",
+        "next_epoch_id": "EmH4KygS1YxpDgQEcKsThXdYYFahgg7KpykM6cuWybS5",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7679823310506858e+22
+    },
+    {
+        "timestamp": "2022-05-13T00:34:55.129Z",
+        "balance": 1.0568563767703511e+26,
+        "block_height": 65461886,
+        "epoch_id": "9MeENgQdZEaSimaFACBQ1SKB9m3ZkzbuBhHC9e8HTrYf",
+        "next_epoch_id": "7mcexsJbAkxpoNJDo5wsFFBqoc41cAf1qRRayxAZcA1o",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7754281716960316e+22
+    },
+    {
+        "timestamp": "2022-05-12T09:28:42.939Z",
+        "balance": 1.0566788339531815e+26,
+        "block_height": 65418686,
+        "epoch_id": "HTwGEC7pDrCs3CosYY3SQV5LW8TYiPn56yeeYXGuxVMF",
+        "next_epoch_id": "9MeENgQdZEaSimaFACBQ1SKB9m3ZkzbuBhHC9e8HTrYf",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8170467747885243e+22
+    },
+    {
+        "timestamp": "2022-05-11T18:19:41.236Z",
+        "balance": 1.0564971292757027e+26,
+        "block_height": 65375486,
+        "epoch_id": "Gdrd5A5yFrCjSgeXgUmzSsxkAeAs1TkE7xRR3hVmf6Jn",
+        "next_epoch_id": "HTwGEC7pDrCs3CosYY3SQV5LW8TYiPn56yeeYXGuxVMF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.77220098675075e+22
+    },
+    {
+        "timestamp": "2022-05-11T02:34:47.282Z",
+        "balance": 1.0563199091770276e+26,
+        "block_height": 65332286,
+        "epoch_id": "D6UuHGCdkkCvWsTcsTSTKxC2SYuRKu3nZxv8rdWPGvbD",
+        "next_epoch_id": "Gdrd5A5yFrCjSgeXgUmzSsxkAeAs1TkE7xRR3hVmf6Jn",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7196988478425546e+22
+    },
+    {
+        "timestamp": "2022-05-10T11:12:22.124Z",
+        "balance": 1.0561479392922433e+26,
+        "block_height": 65289086,
+        "epoch_id": "FYpC1AnFgPKhqWXbh7J5VaXJEq4eoUH7wmJqCgyMcgf1",
+        "next_epoch_id": "D6UuHGCdkkCvWsTcsTSTKxC2SYuRKu3nZxv8rdWPGvbD",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7748190844651823e+22
+    },
+    {
+        "timestamp": "2022-05-09T20:14:56.104Z",
+        "balance": 1.0559704573837968e+26,
+        "block_height": 65245885,
+        "epoch_id": "2ZVDWfbMUC6WC4X88syaeuSKCjcRJPmnmgyZivzV6odj",
+        "next_epoch_id": "FYpC1AnFgPKhqWXbh7J5VaXJEq4eoUH7wmJqCgyMcgf1",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6898788962045667e+22
+    },
+    {
+        "timestamp": "2022-05-09T04:46:38.077Z",
+        "balance": 1.0558014694941764e+26,
+        "block_height": 65202685,
+        "epoch_id": "7pX5S5W1nMP8S8XsXu4bRvbepeSRM6554BAKwDALbtyh",
+        "next_epoch_id": "2ZVDWfbMUC6WC4X88syaeuSKCjcRJPmnmgyZivzV6odj",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.717821614047463e+22
+    },
+    {
+        "timestamp": "2022-05-08T14:02:23.961Z",
+        "balance": 1.0556296873327716e+26,
+        "block_height": 65159485,
+        "epoch_id": "2RG54VF1ZGkVea6TSpzrKxcPkvAkncbN3Tv2U1Y45nE9",
+        "next_epoch_id": "7pX5S5W1nMP8S8XsXu4bRvbepeSRM6554BAKwDALbtyh",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.673961729497295e+22
+    },
+    {
+        "timestamp": "2022-05-07T23:03:33.522Z",
+        "balance": 1.0554622911598219e+26,
+        "block_height": 65116285,
+        "epoch_id": "3zCX8tXEGuBscWx3x6CZ84gZxtac5Cjex2s8ebkUFwzZ",
+        "next_epoch_id": "2RG54VF1ZGkVea6TSpzrKxcPkvAkncbN3Tv2U1Y45nE9",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7172185773741256e+22
+    },
+    {
+        "timestamp": "2022-05-06T20:47:04.563Z",
+        "balance": 1.0552905693020845e+26,
+        "block_height": 65039210,
+        "epoch_id": "JBAEhXoNB4uc8kuWikNF5gyX2Zmc5MEBgZPudjDAopap",
+        "next_epoch_id": "3zCX8tXEGuBscWx3x6CZ84gZxtac5Cjex2s8ebkUFwzZ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7095556166469613e+22
+    },
+    {
+        "timestamp": "2022-05-06T17:30:14.921Z",
+        "balance": 1.0551196137404198e+26,
+        "block_height": 65029885,
+        "epoch_id": "3SEDB1qdP15tFjAbfAL9qr7RYg54dTq7ydxyyfXDYFet",
+        "next_epoch_id": "JBAEhXoNB4uc8kuWikNF5gyX2Zmc5MEBgZPudjDAopap",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7405396802787422e+22
+    },
+    {
+        "timestamp": "2022-05-05T15:45:56.737Z",
+        "balance": 1.0549455597723919e+26,
+        "block_height": 64954741,
+        "epoch_id": "DyAxtBGRjnHFr9kDzjcwJd7ozAgyMuaDKMHFUETnFFz2",
+        "next_epoch_id": "3SEDB1qdP15tFjAbfAL9qr7RYg54dTq7ydxyyfXDYFet",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7538016392869833e+22
+    },
+    {
+        "timestamp": "2022-05-05T11:42:52.955Z",
+        "balance": 1.0547701796084632e+26,
+        "block_height": 64943485,
+        "epoch_id": "J1fKg7cbk3g3bYdM1SNzNM4dwAkqH3gZnDTY14DcKM29",
+        "next_epoch_id": "DyAxtBGRjnHFr9kDzjcwJd7ozAgyMuaDKMHFUETnFFz2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7123396039427385e+22
+    },
+    {
+        "timestamp": "2022-05-04T20:36:54.513Z",
+        "balance": 1.054598945648069e+26,
+        "block_height": 64900285,
+        "epoch_id": "9RADdSYBxDESER6vB62Nrm8oZ1dyrd7sW8cQJDPidMC6",
+        "next_epoch_id": "J1fKg7cbk3g3bYdM1SNzNM4dwAkqH3gZnDTY14DcKM29",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.668020536075795e+22
+    },
+    {
+        "timestamp": "2022-05-04T05:52:47.089Z",
+        "balance": 1.0544321435944613e+26,
+        "block_height": 64857085,
+        "epoch_id": "B34CLQFi6rVszQWhs73VZ3wdDG76m9iSJQjJ4VmDuu7w",
+        "next_epoch_id": "9RADdSYBxDESER6vB62Nrm8oZ1dyrd7sW8cQJDPidMC6",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8622370248779486e+22
+    },
+    {
+        "timestamp": "2022-05-03T14:30:33.543Z",
+        "balance": 1.0542459198919735e+26,
+        "block_height": 64813885,
+        "epoch_id": "27oDay6AMZ2jHraeBx2TwKynGbxgJdVz9Ar9aGoAdiig",
+        "next_epoch_id": "B34CLQFi6rVszQWhs73VZ3wdDG76m9iSJQjJ4VmDuu7w",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8377175995977998e+22
+    },
+    {
+        "timestamp": "2022-05-02T22:33:34.882Z",
+        "balance": 1.0540621481320138e+26,
+        "block_height": 64770685,
+        "epoch_id": "CcEoaFJdgpmFe24rPc4QZeyfmczv6V24i9oMV7FUnXsG",
+        "next_epoch_id": "27oDay6AMZ2jHraeBx2TwKynGbxgJdVz9Ar9aGoAdiig",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8470808796084883e+22
+    },
+    {
+        "timestamp": "2022-05-02T06:49:46.280Z",
+        "balance": 1.053877440044053e+26,
+        "block_height": 64727485,
+        "epoch_id": "8uNRwBVJRdnyPtSaj4F8755tJ2AzGAJ7gsqZr64PNYEv",
+        "next_epoch_id": "CcEoaFJdgpmFe24rPc4QZeyfmczv6V24i9oMV7FUnXsG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7761559409747693e+22
+    },
+    {
+        "timestamp": "2022-05-01T15:00:06.865Z",
+        "balance": 1.0536998244499554e+26,
+        "block_height": 64684285,
+        "epoch_id": "EaN5YMqiPC8AQ2MRN648Xi3XvN65mQZh3isn3fuQYFFo",
+        "next_epoch_id": "8uNRwBVJRdnyPtSaj4F8755tJ2AzGAJ7gsqZr64PNYEv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8295596301304142e+22
+    },
+    {
+        "timestamp": "2022-04-30T23:44:28.154Z",
+        "balance": 1.0535168684869424e+26,
+        "block_height": 64641085,
+        "epoch_id": "3Zf2cDgA1csyQX6AJhYkMNzH2KhxwnscGVMGSpjgpEau",
+        "next_epoch_id": "EaN5YMqiPC8AQ2MRN648Xi3XvN65mQZh3isn3fuQYFFo",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.774628013612558e+22
+    },
+    {
+        "timestamp": "2022-04-29T18:04:04.503Z",
+        "balance": 1.0533394056855811e+26,
+        "block_height": 64558317,
+        "epoch_id": "2UPvLeBxpWyHGKrXbohxbLUB5uDUZRSvoLGki1RbCBt7",
+        "next_epoch_id": "3Zf2cDgA1csyQX6AJhYkMNzH2KhxwnscGVMGSpjgpEau",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8101739172896681e+22
+    },
+    {
+        "timestamp": "2022-04-29T16:46:04.680Z",
+        "balance": 1.0531583882938522e+26,
+        "block_height": 64554685,
+        "epoch_id": "FvQtBrxe2W1FczzNfazNUz9fEoYiLsMiM4ScUestHXma",
+        "next_epoch_id": "2UPvLeBxpWyHGKrXbohxbLUB5uDUZRSvoLGki1RbCBt7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6544849151311349e+22
+    },
+    {
+        "timestamp": "2022-04-29T01:10:29.449Z",
+        "balance": 1.052992939802339e+26,
+        "block_height": 64511485,
+        "epoch_id": "GMoJGEPaRaWuW7PUQ7v1Ee9B6gPtAHNN6sQoMcpU9BMt",
+        "next_epoch_id": "FvQtBrxe2W1FczzNfazNUz9fEoYiLsMiM4ScUestHXma",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7182028551410191e+22
+    },
+    {
+        "timestamp": "2022-04-28T03:44:31.710Z",
+        "balance": 1.052821119516825e+26,
+        "block_height": 64451388,
+        "epoch_id": "DDKGuAXX1cJNSP8L9pfWkwVhEeoc9wXJqaRLDFX86Wji",
+        "next_epoch_id": "GMoJGEPaRaWuW7PUQ7v1Ee9B6gPtAHNN6sQoMcpU9BMt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7880304782754097e+22
+    },
+    {
+        "timestamp": "2022-04-27T18:17:59.245Z",
+        "balance": 1.0526423164689974e+26,
+        "block_height": 64425085,
+        "epoch_id": "4TiX7CYuDbJLdX8Gdq3cTwbDZpdhon7yHgFuTVPKY8Cd",
+        "next_epoch_id": "DDKGuAXX1cJNSP8L9pfWkwVhEeoc9wXJqaRLDFX86Wji",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8105790035623334e+22
+    },
+    {
+        "timestamp": "2022-04-27T03:02:18.565Z",
+        "balance": 1.0524612585686412e+26,
+        "block_height": 64381885,
+        "epoch_id": "3WMQiEP59Qn61eMAUZgN1tQkgwJKqsowToRBLs3Xjs7U",
+        "next_epoch_id": "4TiX7CYuDbJLdX8Gdq3cTwbDZpdhon7yHgFuTVPKY8Cd",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7315496871715131e+22
+    },
+    {
+        "timestamp": "2022-04-26T11:37:23.745Z",
+        "balance": 1.052288103599924e+26,
+        "block_height": 64338685,
+        "epoch_id": "EqR3HEip47eHQhmTGP8KYFv97b6K1G6VWXr1q5EJ3v5C",
+        "next_epoch_id": "3WMQiEP59Qn61eMAUZgN1tQkgwJKqsowToRBLs3Xjs7U",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7988558535080058e+22
+    },
+    {
+        "timestamp": "2022-04-25T20:46:06.774Z",
+        "balance": 1.0521082180145732e+26,
+        "block_height": 64295485,
+        "epoch_id": "5NyYGdzg6tZhjkRWfs4udXGuVT2BZ2T4CUNBJSytFvhU",
+        "next_epoch_id": "EqR3HEip47eHQhmTGP8KYFv97b6K1G6VWXr1q5EJ3v5C",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.778087088913648e+22
+    },
+    {
+        "timestamp": "2022-04-25T05:22:28.722Z",
+        "balance": 1.0519304093056819e+26,
+        "block_height": 64252285,
+        "epoch_id": "Gieie9taQd2bxLLQbkXi4XVYpPhPfJt2jKzWzYWXwz8V",
+        "next_epoch_id": "5NyYGdzg6tZhjkRWfs4udXGuVT2BZ2T4CUNBJSytFvhU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7633822051858437e+22
+    },
+    {
+        "timestamp": "2022-04-24T08:05:52.067Z",
+        "balance": 1.0517540710851633e+26,
+        "block_height": 64191618,
+        "epoch_id": "6JFryQaptP4LjaMYHSzpqcMi2iVbTATNoi5vmKsfLRcG",
+        "next_epoch_id": "Gieie9taQd2bxLLQbkXi4XVYpPhPfJt2jKzWzYWXwz8V",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7427730059829524e+22
+    },
+    {
+        "timestamp": "2022-04-23T23:01:39.782Z",
+        "balance": 1.051579793784565e+26,
+        "block_height": 64165885,
+        "epoch_id": "9xrjdZmgjoVkjVE3ui7tY37x9Mkw5wH385qNXE6cho7T",
+        "next_epoch_id": "6JFryQaptP4LjaMYHSzpqcMi2iVbTATNoi5vmKsfLRcG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9852415042031683e+22
+    },
+    {
+        "timestamp": "2022-04-23T08:03:29.714Z",
+        "balance": 1.0513812696341447e+26,
+        "block_height": 64122685,
+        "epoch_id": "4pA78eekczWH3PaXqfjhShMuvDn5sitD8RM4g5BEtFnF",
+        "next_epoch_id": "9xrjdZmgjoVkjVE3ui7tY37x9Mkw5wH385qNXE6cho7T",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.9816689206061544e+22
+    },
+    {
+        "timestamp": "2022-04-22T17:06:48.203Z",
+        "balance": 1.051183102742084e+26,
+        "block_height": 64079485,
+        "epoch_id": "Dyx4MYWW4tpDEUKy1UoVhDfFgu9RJKbrWzZ4vvTRnG9c",
+        "next_epoch_id": "4pA78eekczWH3PaXqfjhShMuvDn5sitD8RM4g5BEtFnF",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.758404963449044e+22
+    },
+    {
+        "timestamp": "2022-04-22T02:11:46.962Z",
+        "balance": 1.0510072622457392e+26,
+        "block_height": 64036285,
+        "epoch_id": "5Dmn2jqCxP6DeCB1AYoAmknynriFcxwm9XondNm6FTyt",
+        "next_epoch_id": "Dyx4MYWW4tpDEUKy1UoVhDfFgu9RJKbrWzZ4vvTRnG9c",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7089808846413283e+22
+    },
+    {
+        "timestamp": "2022-04-21T11:03:41.303Z",
+        "balance": 1.050836364157275e+26,
+        "block_height": 63993085,
+        "epoch_id": "5yE59GmmRs399FnWM1uuCc7nXgDFgYZyMK7W144z6FMx",
+        "next_epoch_id": "5Dmn2jqCxP6DeCB1AYoAmknynriFcxwm9XondNm6FTyt",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7193678702307134e+22
+    },
+    {
+        "timestamp": "2022-04-20T20:20:24.703Z",
+        "balance": 1.050664427370252e+26,
+        "block_height": 63949885,
+        "epoch_id": "DbjBanEHYH7SpWvxqFKa1GVFjvRUqLWSSTiqrtpB9KFN",
+        "next_epoch_id": "5yE59GmmRs399FnWM1uuCc7nXgDFgYZyMK7W144z6FMx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7237153624787905e+22
+    },
+    {
+        "timestamp": "2022-04-20T05:31:24.114Z",
+        "balance": 1.050492055834004e+26,
+        "block_height": 63906685,
+        "epoch_id": "72j4UiiBcToRJcg3VALXBGMmbqhiQge5Zc5fastKPo3t",
+        "next_epoch_id": "DbjBanEHYH7SpWvxqFKa1GVFjvRUqLWSSTiqrtpB9KFN",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.721036302484749e+22
+    },
+    {
+        "timestamp": "2022-04-19T14:46:00.879Z",
+        "balance": 1.0503199522037556e+26,
+        "block_height": 63863485,
+        "epoch_id": "4JygcEUkdkeiYrcktqb2726Y8ufTo9MEWcQXSpyW35mc",
+        "next_epoch_id": "72j4UiiBcToRJcg3VALXBGMmbqhiQge5Zc5fastKPo3t",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7734897910236364e+22
+    },
+    {
+        "timestamp": "2022-04-19T00:04:21.890Z",
+        "balance": 1.0501426032246532e+26,
+        "block_height": 63820285,
+        "epoch_id": "DfMdKYr6GpQGRfBHJPZrkLihLTVAb3CgbwmeyTBJYHcM",
+        "next_epoch_id": "4JygcEUkdkeiYrcktqb2726Y8ufTo9MEWcQXSpyW35mc",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8246402388818003e+22
+    },
+    {
+        "timestamp": "2022-04-18T08:47:59.031Z",
+        "balance": 1.049960139200765e+26,
+        "block_height": 63777085,
+        "epoch_id": "EtramCKTgBa5jtGodNnbHf47pv7nayNbZXMy8NEWzvTQ",
+        "next_epoch_id": "DfMdKYr6GpQGRfBHJPZrkLihLTVAb3CgbwmeyTBJYHcM",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8295580901784802e+22
+    },
+    {
+        "timestamp": "2022-04-17T17:03:08.733Z",
+        "balance": 1.0497771833917472e+26,
+        "block_height": 63733882,
+        "epoch_id": "FkxDYGjuhTpUCBrQYaTbvQX8sfUtdfKvVYEXZbEyfLtU",
+        "next_epoch_id": "EtramCKTgBa5jtGodNnbHf47pv7nayNbZXMy8NEWzvTQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7181140061249474e+22
+    },
+    {
+        "timestamp": "2022-04-17T01:17:04.857Z",
+        "balance": 1.0496053719911347e+26,
+        "block_height": 63690682,
+        "epoch_id": "AFcEzuNVeNVy7rKS6mL8C3fcrKxZm7vUjPp5bhSZbX3Y",
+        "next_epoch_id": "FkxDYGjuhTpUCBrQYaTbvQX8sfUtdfKvVYEXZbEyfLtU",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.700896800822885e+22
+    },
+    {
+        "timestamp": "2022-04-16T10:28:16.597Z",
+        "balance": 1.0494352823110524e+26,
+        "block_height": 63647482,
+        "epoch_id": "8sX6cjUfv4PqUyQyofSMD1sAABo2GKokCdGjJMT1aeuV",
+        "next_epoch_id": "AFcEzuNVeNVy7rKS6mL8C3fcrKxZm7vUjPp5bhSZbX3Y",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.71366904006997e+22
+    },
+    {
+        "timestamp": "2022-04-15T11:22:42.388Z",
+        "balance": 1.0492639154070454e+26,
+        "block_height": 63579455,
+        "epoch_id": "4JUNfHZppQQyRquqioeGKs1jX6w99d42D6wVh3XakMtp",
+        "next_epoch_id": "8sX6cjUfv4PqUyQyofSMD1sAABo2GKokCdGjJMT1aeuV",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7068751548632118e+22
+    },
+    {
+        "timestamp": "2022-04-15T05:02:04.963Z",
+        "balance": 1.0490932278915591e+26,
+        "block_height": 63561082,
+        "epoch_id": "Edn2exQ2Z3pnarQPnCMkBMdJcrt86VCsmoaaMyYMcNPG",
+        "next_epoch_id": "4JUNfHZppQQyRquqioeGKs1jX6w99d42D6wVh3XakMtp",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7090534606447908e+22
+    },
+    {
+        "timestamp": "2022-04-14T14:18:35.800Z",
+        "balance": 1.0489223225454946e+26,
+        "block_height": 63517882,
+        "epoch_id": "2rxhEAuwFf57UthWGfNqBj4iGLeKz2LwRhQ2FxurhqAv",
+        "next_epoch_id": "Edn2exQ2Z3pnarQPnCMkBMdJcrt86VCsmoaaMyYMcNPG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7135226584585757e+22
+    },
+    {
+        "timestamp": "2022-04-13T14:56:19.088Z",
+        "balance": 1.0487509702796488e+26,
+        "block_height": 63449282,
+        "epoch_id": "BuTNcEgRzvWXjzG9Hm5N4sKriYMnRinMQNRggeg4vLJx",
+        "next_epoch_id": "2rxhEAuwFf57UthWGfNqBj4iGLeKz2LwRhQ2FxurhqAv",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7168549919084348e+22
+    },
+    {
+        "timestamp": "2022-04-13T08:45:20.022Z",
+        "balance": 1.048579284780458e+26,
+        "block_height": 63431482,
+        "epoch_id": "22Ua57TGdHHgLs7Xf3PpojSLLbD31ZAVhNsqWpFzTnQG",
+        "next_epoch_id": "BuTNcEgRzvWXjzG9Hm5N4sKriYMnRinMQNRggeg4vLJx",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7022586765477633e+22
+    },
+    {
+        "timestamp": "2022-04-12T17:53:05.776Z",
+        "balance": 1.0484090589128031e+26,
+        "block_height": 63388282,
+        "epoch_id": "5ziL4wL8rpsH1bcjhtHhPhiyekLmVDaBVC4U7MBPAUa4",
+        "next_epoch_id": "22Ua57TGdHHgLs7Xf3PpojSLLbD31ZAVhNsqWpFzTnQG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.732854352322255e+22
+    },
+    {
+        "timestamp": "2022-04-11T16:18:08.130Z",
+        "balance": 1.048235773477571e+26,
+        "block_height": 63313588,
+        "epoch_id": "E1KMJPC2ev9kaKz4JcVmf8rEqnavZSGYpYZ43LJxwpSP",
+        "next_epoch_id": "5ziL4wL8rpsH1bcjhtHhPhiyekLmVDaBVC4U7MBPAUa4",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7293447730865648e+22
+    },
+    {
+        "timestamp": "2022-04-11T12:10:09.310Z",
+        "balance": 1.0480628390002623e+26,
+        "block_height": 63301881,
+        "epoch_id": "HfrXPAdy7iG8E38G8P65VUgsUs2QcJX9VspAAjWafqvW",
+        "next_epoch_id": "E1KMJPC2ev9kaKz4JcVmf8rEqnavZSGYpYZ43LJxwpSP",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.6973581852511958e+22
+    },
+    {
+        "timestamp": "2022-04-10T19:24:24.668Z",
+        "balance": 1.0478931031817371e+26,
+        "block_height": 63253343,
+        "epoch_id": "5wxPh1GZAZrAozfoZHAyS18fX8p4VMYNpZuoV2o3hp7",
+        "next_epoch_id": "HfrXPAdy7iG8E38G8P65VUgsUs2QcJX9VspAAjWafqvW",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7675152939498407e+22
+    },
+    {
+        "timestamp": "2022-04-10T06:31:10.472Z",
+        "balance": 1.0477163516523422e+26,
+        "block_height": 63215481,
+        "epoch_id": "7HFS5SLH3fYFtHtK6ypWNarRzTiCyBNgPAR4fr8a7yvC",
+        "next_epoch_id": "5wxPh1GZAZrAozfoZHAyS18fX8p4VMYNpZuoV2o3hp7",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7969882319820075e+22
+    },
+    {
+        "timestamp": "2022-04-09T06:13:13.538Z",
+        "balance": 1.047536652829144e+26,
+        "block_height": 63145204,
+        "epoch_id": "7HfJAhMgscNwW3bgEmR6Nj8g6Qh2iMmMotygFqqQRUJ2",
+        "next_epoch_id": "7HFS5SLH3fYFtHtK6ypWNarRzTiCyBNgPAR4fr8a7yvC",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.7740228945483791e+22
+    },
+    {
+        "timestamp": "2022-04-09T00:32:54.949Z",
+        "balance": 1.0473592505396891e+26,
+        "block_height": 63129081,
+        "epoch_id": "HAAes5MV5Pr3esTB4DoXYPtYJGBtDu9cgFdKGDZ3JhnG",
+        "next_epoch_id": "7HfJAhMgscNwW3bgEmR6Nj8g6Qh2iMmMotygFqqQRUJ2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8175401225996087e+22
+    },
+    {
+        "timestamp": "2022-04-08T09:41:21.492Z",
+        "balance": 1.0471774965274292e+26,
+        "block_height": 63085881,
+        "epoch_id": "DRrikPt2U816YsQt1JdDbvjwLXkapCUqvFfQNeykonz2",
+        "next_epoch_id": "HAAes5MV5Pr3esTB4DoXYPtYJGBtDu9cgFdKGDZ3JhnG",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.77500486625456e+22
+    },
+    {
+        "timestamp": "2022-04-07T18:26:32.906Z",
+        "balance": 1.0469999960408037e+26,
+        "block_height": 63042681,
+        "epoch_id": "35pR4X2ZoHM56gXU37cMemkXAro1hu1GZA13WAL4uo9m",
+        "next_epoch_id": "DRrikPt2U816YsQt1JdDbvjwLXkapCUqvFfQNeykonz2",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8032826919920855e+22
+    },
+    {
+        "timestamp": "2022-04-06T18:57:04.033Z",
+        "balance": 1.0468196677716045e+26,
+        "block_height": 62974599,
+        "epoch_id": "EN2tdzYsEP4ExZcGYjsAAY7vBAKw9WJyWJ1ePtCygQkk",
+        "next_epoch_id": "35pR4X2ZoHM56gXU37cMemkXAro1hu1GZA13WAL4uo9m",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.799157494828486e+22
+    },
+    {
+        "timestamp": "2022-04-06T12:28:41.841Z",
+        "balance": 1.0466397520221216e+26,
+        "block_height": 62956281,
+        "epoch_id": "7WaZwKxc82FmP892QaqCzCoPuAXJMShmFhmJJeYaHuxQ",
+        "next_epoch_id": "EN2tdzYsEP4ExZcGYjsAAY7vBAKw9WJyWJ1ePtCygQkk",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.82050627906064e+22
+    },
+    {
+        "timestamp": "2022-04-05T19:20:20.541Z",
+        "balance": 1.0464577013942156e+26,
+        "block_height": 62906821,
+        "epoch_id": "5abrfyAF7b9uzqE8hB8VCS7mCQRcpympSAMirywMw3Pt",
+        "next_epoch_id": "7WaZwKxc82FmP892QaqCzCoPuAXJMShmFhmJJeYaHuxQ",
+        "deposit": 0,
+        "withdrawal": 0,
+        "earnings": 1.8187901714051803e+22
+    },
+    {
+        "timestamp": "2022-04-04T17:52:36.339Z",
+        "balance": 1.046275822377075e+26,
+        "block_height": 62833026,
+        "epoch_id": "83ThnbvGZzubau15DrcCErx2sZ1LiAFUrLBbFKKQysgP",
+        "next_epoch_id": "5abrfyAF7b9uzqE8hB8VCS7mCQRcpympSAMirywMw3Pt",
+        "earnings": 1.834504882480065e+22,
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-04-04T15:39:30.024Z",
+        "balance": 1.046092371888827e+26,
+        "block_height": 62826681,
+        "epoch_id": "6q59336JVYnLT81nc13Tw3k57ziYLZ379GmLTMQQFtd5",
+        "next_epoch_id": "83ThnbvGZzubau15DrcCErx2sZ1LiAFUrLBbFKKQysgP",
+        "earnings": 1.906339965987648e+22,
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-04-03T11:51:36.445Z",
+        "balance": 1.0459017378922283e+26,
+        "block_height": 62748450,
+        "epoch_id": "2trqfXuQRmfgpnhNgNaS7SS5JsqmHLJUaA31vv98Q35D",
+        "next_epoch_id": "6q59336JVYnLT81nc13Tw3k57ziYLZ379GmLTMQQFtd5",
+        "earnings": 1.9054640866618012e+22,
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-04-03T05:54:50.869Z",
+        "balance": 1.0457111914835621e+26,
+        "earnings": 1.82873113353833e+22,
+        "block_height": 62732264,
+        "epoch_id": "6i4dDToL81E6LDT2WX5Dbmq8LyWYhoN5xiWX9F2EgWcm",
+        "next_epoch_id": "2trqfXuQRmfgpnhNgNaS7SS5JsqmHLJUaA31vv98Q35D",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-04-02T16:16:50.375Z",
+        "balance": 1.0455283183702083e+26,
+        "earnings": 1.8335062207233863e+22,
+        "block_height": 62694893,
+        "epoch_id": "mic51uWJNWQfBNZ7JXfRU6y6wWefj8YZiooBdqrG1o3",
+        "next_epoch_id": "6i4dDToL81E6LDT2WX5Dbmq8LyWYhoN5xiWX9F2EgWcm",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-04-02T02:04:04.517Z",
+        "balance": 1.045344967748136e+26,
+        "earnings": 1.8231394643681179e+22,
+        "block_height": 62653881,
+        "epoch_id": "BjFfiw2jBhAkAVGF7YpqqZgGP7cbY6uhxqkj6LbeiGQd",
+        "next_epoch_id": "mic51uWJNWQfBNZ7JXfRU6y6wWefj8YZiooBdqrG1o3",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-04-01T11:03:00.566Z",
+        "balance": 1.0451626538016991e+26,
+        "earnings": 1.8419838672986987e+22,
+        "block_height": 62610681,
+        "epoch_id": "HuA4BNCCWkyYRvCaDhTowFWnZoPNBimR8AHKdSYK5Ed6",
+        "next_epoch_id": "BjFfiw2jBhAkAVGF7YpqqZgGP7cbY6uhxqkj6LbeiGQd",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-31T20:13:58.843Z",
+        "balance": 1.0449784554149693e+26,
+        "earnings": 1.8644926014900234e+22,
+        "block_height": 62567481,
+        "epoch_id": "2ibG2DztT612hMGEm6TcAG6rBptYZT1FPhtKymbRDKob",
+        "next_epoch_id": "HuA4BNCCWkyYRvCaDhTowFWnZoPNBimR8AHKdSYK5Ed6",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-31T05:15:31.850Z",
+        "balance": 1.0447920061548203e+26,
+        "earnings": 1.8660560960811442e+22,
+        "block_height": 62524281,
+        "epoch_id": "Hza2ZtqRT3E8MxCBRdJbiJKjZiy7HPZkPo1XjBsPd68p",
+        "next_epoch_id": "2ibG2DztT612hMGEm6TcAG6rBptYZT1FPhtKymbRDKob",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-30T14:07:03.555Z",
+        "balance": 1.0446054005452121e+26,
+        "earnings": 1.8626451543222036e+22,
+        "block_height": 62481081,
+        "epoch_id": "2Gj4HF32iFbv7V6inRYKMSLKNkq5MnBPefSMd2k7hMUy",
+        "next_epoch_id": "Hza2ZtqRT3E8MxCBRdJbiJKjZiy7HPZkPo1XjBsPd68p",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-29T22:39:58.041Z",
+        "balance": 1.04441913602978e+26,
+        "earnings": 1.868466681584805e+22,
+        "block_height": 62437881,
+        "epoch_id": "EvpZveCr1SB3Pp1feVfMogijFqTo5KK79HsCnFneGNAf",
+        "next_epoch_id": "2Gj4HF32iFbv7V6inRYKMSLKNkq5MnBPefSMd2k7hMUy",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-29T07:11:05.041Z",
+        "balance": 1.0442322893616214e+26,
+        "earnings": 1.8258540570595318e+22,
+        "block_height": 62394681,
+        "epoch_id": "FYptv4h4ZES53G8vyZr5Y6wDN7SrgLUJxFdotNJ1uzXe",
+        "next_epoch_id": "EvpZveCr1SB3Pp1feVfMogijFqTo5KK79HsCnFneGNAf",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-28T15:44:48.169Z",
+        "balance": 1.0440497039559155e+26,
+        "earnings": 1.8138321510574974e+22,
+        "block_height": 62351481,
+        "epoch_id": "6XWcYyTTxPbRuHcjRUjAC17BWPy65qiejVS72STcj8tf",
+        "next_epoch_id": "FYptv4h4ZES53G8vyZr5Y6wDN7SrgLUJxFdotNJ1uzXe",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-28T00:38:59.293Z",
+        "balance": 1.0438683207408097e+26,
+        "earnings": 1.7745801773079153e+22,
+        "block_height": 62308281,
+        "epoch_id": "Gtj2uPRrgNnXYpNbKRdYZiGryQJx1s5hQhzV9zMD42sX",
+        "next_epoch_id": "6XWcYyTTxPbRuHcjRUjAC17BWPy65qiejVS72STcj8tf",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-27T09:37:58.461Z",
+        "balance": 1.043690862723079e+26,
+        "earnings": 1.8164736604359377e+22,
+        "block_height": 62265081,
+        "epoch_id": "EsgS6y3Us3H7aDQaiNqvRYwpCCC8LTmr5BxqyD6TZge6",
+        "next_epoch_id": "Gtj2uPRrgNnXYpNbKRdYZiGryQJx1s5hQhzV9zMD42sX",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-26T15:37:00.225Z",
+        "balance": 1.0435092153570354e+26,
+        "earnings": 1.8090343488057428e+22,
+        "block_height": 62212406,
+        "epoch_id": "G4NFwjTm2opLeCUjXLdeiWhp3DhUT6AGrvBvujpBk7w8",
+        "next_epoch_id": "EsgS6y3Us3H7aDQaiNqvRYwpCCC8LTmr5BxqyD6TZge6",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-26T03:54:02.707Z",
+        "balance": 1.0433283119221548e+26,
+        "earnings": 1.8721290441442095e+22,
+        "block_height": 62178681,
+        "epoch_id": "4tm6ZnpC8CECGShNYFTLApoddk11GwmVPc9U8572dnxE",
+        "next_epoch_id": "G4NFwjTm2opLeCUjXLdeiWhp3DhUT6AGrvBvujpBk7w8",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-25T12:57:16.482Z",
+        "balance": 1.0431410990177404e+26,
+        "earnings": 1.8215614764029848e+22,
+        "block_height": 62135481,
+        "epoch_id": "2AjF3geDkWsm8EbsvGfRunXciQV84jFfto7JMvhnB8wv",
+        "next_epoch_id": "4tm6ZnpC8CECGShNYFTLApoddk11GwmVPc9U8572dnxE",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-24T21:28:29.021Z",
+        "balance": 1.0429589428701e+26,
+        "earnings": 1.9058280504058777e+22,
+        "block_height": 62092281,
+        "epoch_id": "7stbSG12zgd1CibTkZEQckrYoqp9px3QU3ZUUrhpCJR",
+        "next_epoch_id": "2AjF3geDkWsm8EbsvGfRunXciQV84jFfto7JMvhnB8wv",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-24T06:26:38.368Z",
+        "balance": 1.0427683600650595e+26,
+        "earnings": 1.8979396328042392e+22,
+        "block_height": 62049081,
+        "epoch_id": "8uagguDDqyvTcN1fTkT7AEbh443QmCS452KZVwq36i8p",
+        "next_epoch_id": "7stbSG12zgd1CibTkZEQckrYoqp9px3QU3ZUUrhpCJR",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-23T14:42:33.897Z",
+        "balance": 1.042578566101779e+26,
+        "earnings": 1.9429050719925787e+22,
+        "block_height": 62005881,
+        "epoch_id": "25moYcVoPvaRmbLUt6Vn5X5hECdcy6w9SdiDraNnDLUa",
+        "next_epoch_id": "8uagguDDqyvTcN1fTkT7AEbh443QmCS452KZVwq36i8p",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-22T23:02:17.952Z",
+        "balance": 1.0423842755945798e+26,
+        "earnings": 1.8868933800565836e+22,
+        "block_height": 61962681,
+        "epoch_id": "2ypQRvX2TxpQZ6Jbn8jP1Wf4mddBdshxVP7UzQWTc8SH",
+        "next_epoch_id": "25moYcVoPvaRmbLUt6Vn5X5hECdcy6w9SdiDraNnDLUa",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-22T07:12:36.238Z",
+        "balance": 1.0421955862565741e+26,
+        "earnings": 2.0777403722560208e+22,
+        "block_height": 61919481,
+        "epoch_id": "86JBveiBRvB1nCoHUczWUwFopptweVMeNh5owUvqDVCh",
+        "next_epoch_id": "2ypQRvX2TxpQZ6Jbn8jP1Wf4mddBdshxVP7UzQWTc8SH",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-21T15:37:39.410Z",
+        "balance": 1.0419878122193485e+26,
+        "earnings": 1.9256999330163053e+22,
+        "block_height": 61876280,
+        "epoch_id": "CrHFCjPb6FEW3cfgACy2txU1Knf8CAzPTpVdkTp6wRs",
+        "next_epoch_id": "86JBveiBRvB1nCoHUczWUwFopptweVMeNh5owUvqDVCh",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-20T22:27:21.359Z",
+        "balance": 1.0417952422260469e+26,
+        "earnings": 1.953463647553855e+22,
+        "block_height": 61833080,
+        "epoch_id": "3xv1jZd2nJy6cSUizMRUj2MvjKCwtgbPJyV2uhuhh3gV",
+        "next_epoch_id": "CrHFCjPb6FEW3cfgACy2txU1Knf8CAzPTpVdkTp6wRs",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-20T06:32:21.491Z",
+        "balance": 1.0415998958612915e+26,
+        "earnings": 1.9025744492230104e+22,
+        "block_height": 61789880,
+        "epoch_id": "4vxivvL57B9hsiHruGXPzv8tivihKNj3H6u5KhmhWu4M",
+        "next_epoch_id": "3xv1jZd2nJy6cSUizMRUj2MvjKCwtgbPJyV2uhuhh3gV",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-19T14:23:48.900Z",
+        "balance": 1.0414096384163692e+26,
+        "earnings": 1.959005517784297e+22,
+        "block_height": 61746680,
+        "epoch_id": "3Koixf4qJ3zd46TZqGVqXbyi1qsi2KMqm8jpPpct7Pei",
+        "next_epoch_id": "4vxivvL57B9hsiHruGXPzv8tivihKNj3H6u5KhmhWu4M",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-18T22:50:38.171Z",
+        "balance": 1.0412137378645908e+26,
+        "earnings": 2.041429363536016e+22,
+        "block_height": 61703480,
+        "epoch_id": "6rUb9mt1HMF9ox7fRhvXUo6rPyQFXsi1E7ELYKaX5CyX",
+        "next_epoch_id": "3Koixf4qJ3zd46TZqGVqXbyi1qsi2KMqm8jpPpct7Pei",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-18T06:41:51.183Z",
+        "balance": 1.0410095949282372e+26,
+        "earnings": 1.9443841319676563e+22,
+        "block_height": 61660280,
+        "epoch_id": "66XfqGhwafxieV5VdM75s8gMbX5FkLQn3AtwvncvLWev",
+        "next_epoch_id": "6rUb9mt1HMF9ox7fRhvXUo6rPyQFXsi1E7ELYKaX5CyX",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-17T14:02:18.815Z",
+        "balance": 1.0408151565150404e+26,
+        "earnings": 2.009106684667388e+22,
+        "block_height": 61617080,
+        "epoch_id": "8wK9KcfoNfTV5MGfrdnNFhd5kwrcm9qpJoYUC19JjHNP",
+        "next_epoch_id": "66XfqGhwafxieV5VdM75s8gMbX5FkLQn3AtwvncvLWev",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-16T22:12:04.700Z",
+        "balance": 1.0406142458465737e+26,
+        "earnings": 1.924868967331704e+22,
+        "block_height": 61573880,
+        "epoch_id": "He8aiwTQnpC7iYY6tMVNw8NnAxj5ojKDmFWU6D6dCmR",
+        "next_epoch_id": "8wK9KcfoNfTV5MGfrdnNFhd5kwrcm9qpJoYUC19JjHNP",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-16T05:43:50.170Z",
+        "balance": 1.0404217589498405e+26,
+        "earnings": 1.9294588366531525e+22,
+        "block_height": 61530680,
+        "epoch_id": "EAwjrha9U6KdF1MTHHoaccUzxVVyLayRCEPGEpH5d8fU",
+        "next_epoch_id": "He8aiwTQnpC7iYY6tMVNw8NnAxj5ojKDmFWU6D6dCmR",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-15T14:07:04.707Z",
+        "balance": 1.0402288130661752e+26,
+        "earnings": 1.9529289189801322e+22,
+        "block_height": 61487480,
+        "epoch_id": "2Ri3EriB9b5hBHmSPLLfJQhUyqCDx8Q8zsrpVK6aMFCo",
+        "next_epoch_id": "EAwjrha9U6KdF1MTHHoaccUzxVVyLayRCEPGEpH5d8fU",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-14T22:34:40.888Z",
+        "balance": 1.0400335201742772e+26,
+        "earnings": 1.889518702765001e+22,
+        "block_height": 61444280,
+        "epoch_id": "9tqM9PSuQQXjvrAEhvRb45Q7XpDNS8itEcjr8yACDe2C",
+        "next_epoch_id": "2Ri3EriB9b5hBHmSPLLfJQhUyqCDx8Q8zsrpVK6aMFCo",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-14T06:35:32.592Z",
+        "balance": 1.0398445683040007e+26,
+        "earnings": 1.85734117120804e+22,
+        "block_height": 61401080,
+        "epoch_id": "Gk85KcRSFCwFZV5Loe6KcfqGLjyYDmKDFTQNTgKGBTxJ",
+        "next_epoch_id": "9tqM9PSuQQXjvrAEhvRb45Q7XpDNS8itEcjr8yACDe2C",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-13T15:07:49.722Z",
+        "balance": 1.0396588341868799e+26,
+        "earnings": 1.852412636071978e+22,
+        "block_height": 61357880,
+        "epoch_id": "4vqwuC6Rot2iseY7PSZKM9x9LN3DCHGWLrJ4wypc1U6S",
+        "next_epoch_id": "Gk85KcRSFCwFZV5Loe6KcfqGLjyYDmKDFTQNTgKGBTxJ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-12T23:55:14.032Z",
+        "balance": 1.0394735929232727e+26,
+        "earnings": 1.8375661347843776e+22,
+        "block_height": 61314680,
+        "epoch_id": "2aYdkDvzWf83zTZHJtV3J3y6LLrTnTuYAsEs3Am2ZqMa",
+        "next_epoch_id": "4vqwuC6Rot2iseY7PSZKM9x9LN3DCHGWLrJ4wypc1U6S",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-12T08:48:23.239Z",
+        "balance": 1.0392898363097942e+26,
+        "earnings": 1.8572537828914477e+22,
+        "block_height": 61271480,
+        "epoch_id": "Fsw6jhvzh7PhR2zRqvZc8hXjLxvyCxY6fJmgmeCtt7WM",
+        "next_epoch_id": "2aYdkDvzWf83zTZHJtV3J3y6LLrTnTuYAsEs3Am2ZqMa",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-11T17:48:14.111Z",
+        "balance": 1.0391041109315051e+26,
+        "earnings": 1.8635491907269344e+22,
+        "block_height": 61228280,
+        "epoch_id": "8b9qvMAMGcaLGhkbkHJNgX4yL5xwpxHCRnJSw1C2zv9R",
+        "next_epoch_id": "Fsw6jhvzh7PhR2zRqvZc8hXjLxvyCxY6fJmgmeCtt7WM",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-11T02:43:42.011Z",
+        "balance": 1.0389177560124324e+26,
+        "earnings": 1.8667123464337703e+22,
+        "block_height": 61185080,
+        "epoch_id": "9dZCzgdMnpJuDHyb8axCdQU48gVzFhYQkSKPo81kN2Lq",
+        "next_epoch_id": "8b9qvMAMGcaLGhkbkHJNgX4yL5xwpxHCRnJSw1C2zv9R",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-10T11:35:49.287Z",
+        "balance": 1.038731084777789e+26,
+        "earnings": 1.8580307962826443e+22,
+        "block_height": 61141880,
+        "epoch_id": "DMysmTQb5Jbisug4AYcQXEukRecMwMVGW5cCSYhVhaFV",
+        "next_epoch_id": "9dZCzgdMnpJuDHyb8axCdQU48gVzFhYQkSKPo81kN2Lq",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-09T20:23:45.964Z",
+        "balance": 1.0385452816981608e+26,
+        "earnings": 1.8788641739251984e+22,
+        "block_height": 61098680,
+        "epoch_id": "4wBmC3nVWvHhmvLrbQcQyhXu1qc2Pv91yyVkSGMV7d3X",
+        "next_epoch_id": "DMysmTQb5Jbisug4AYcQXEukRecMwMVGW5cCSYhVhaFV",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-09T05:12:23.383Z",
+        "balance": 1.0383573952807682e+26,
+        "earnings": 1.8306519203547976e+22,
+        "block_height": 61055480,
+        "epoch_id": "DqAA9Sf3RMdkNq9QiSnGK8oGa4ApWuHZGWyJcZCGYpjJ",
+        "next_epoch_id": "4wBmC3nVWvHhmvLrbQcQyhXu1qc2Pv91yyVkSGMV7d3X",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-08T13:59:20.390Z",
+        "balance": 1.0381743300887328e+26,
+        "earnings": 1.8587590642311369e+22,
+        "block_height": 61012280,
+        "epoch_id": "AndRWQ8sCiAPLustPKBGM8EkLt7xE7Ti5S4vyN8ivD3U",
+        "next_epoch_id": "DqAA9Sf3RMdkNq9QiSnGK8oGa4ApWuHZGWyJcZCGYpjJ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-07T23:01:07.144Z",
+        "balance": 1.0379884541823096e+26,
+        "earnings": 1.8383008594654394e+22,
+        "block_height": 60969080,
+        "epoch_id": "4X1PVEaVCL91qADDC8qphT2SRqzMXEdKfWnxkatgfUFF",
+        "next_epoch_id": "AndRWQ8sCiAPLustPKBGM8EkLt7xE7Ti5S4vyN8ivD3U",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-07T07:49:48.371Z",
+        "balance": 1.0378046240963631e+26,
+        "earnings": 1.84458626377921e+22,
+        "block_height": 60925880,
+        "epoch_id": "HG6SHsML3UYwMaqd1Kb2c7odP2muFcRdoRoa1gvisBQT",
+        "next_epoch_id": "4X1PVEaVCL91qADDC8qphT2SRqzMXEdKfWnxkatgfUFF",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-06T16:48:34.935Z",
+        "balance": 1.0376201654699852e+26,
+        "earnings": 1.8337730652788322e+22,
+        "block_height": 60882680,
+        "epoch_id": "BTdEknewqXQJdK7tavapEfQJAu4V5FHhDUG8dyb8PHCy",
+        "next_epoch_id": "HG6SHsML3UYwMaqd1Kb2c7odP2muFcRdoRoa1gvisBQT",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-06T01:44:12.547Z",
+        "balance": 1.0374367881634573e+26,
+        "earnings": 1.8470220695095034e+22,
+        "block_height": 60839480,
+        "epoch_id": "CgSUe7yceuN6Fcmvfs87wwUg2R4yaPgLVRqfTtv4KzKW",
+        "next_epoch_id": "BTdEknewqXQJdK7tavapEfQJAu4V5FHhDUG8dyb8PHCy",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-05T10:44:36.495Z",
+        "balance": 1.0372520859565063e+26,
+        "earnings": 1.844071842013585e+22,
+        "block_height": 60796280,
+        "epoch_id": "HweVdHbhynwABsy81eHuPWaSu5HtARwATKXPtrefY9x6",
+        "next_epoch_id": "CgSUe7yceuN6Fcmvfs87wwUg2R4yaPgLVRqfTtv4KzKW",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-04T19:41:34.196Z",
+        "balance": 1.037067678772305e+26,
+        "earnings": 1.8466876623954821e+22,
+        "block_height": 60753080,
+        "epoch_id": "H2p1T21TF7YGVopsnwRmQQkEMUYMr51myzTcX5pYRaXN",
+        "next_epoch_id": "HweVdHbhynwABsy81eHuPWaSu5HtARwATKXPtrefY9x6",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-04T04:43:16.683Z",
+        "balance": 1.0368830100060654e+26,
+        "earnings": 1.8429311629078106e+22,
+        "block_height": 60709880,
+        "epoch_id": "G9YWmbYUonmSazk9J2gJ7mRg1SVFZy2XrWyEveeeY5vh",
+        "next_epoch_id": "H2p1T21TF7YGVopsnwRmQQkEMUYMr51myzTcX5pYRaXN",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-03T13:44:03.645Z",
+        "balance": 1.0366987168897747e+26,
+        "earnings": 1.0719729892609944e+22,
+        "block_height": 60666680,
+        "epoch_id": "8BFHW6PPbEGeACCLUAAMy6ASfqeEacPPF76xjwoeVu7f",
+        "next_epoch_id": "G9YWmbYUonmSazk9J2gJ7mRg1SVFZy2XrWyEveeeY5vh",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-02T22:46:53.878Z",
+        "balance": 1.0365915195908486e+26,
+        "earnings": 1.8553301926519008e+22,
+        "block_height": 60623479,
+        "epoch_id": "J1CExMV4bF9ZCUj1sPSu63WzQsKahLtxQ4Faz5UmmBGS",
+        "next_epoch_id": "8BFHW6PPbEGeACCLUAAMy6ASfqeEacPPF76xjwoeVu7f",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-02T07:42:08.363Z",
+        "balance": 1.0364059865715834e+26,
+        "earnings": 1.9258073888855473e+22,
+        "block_height": 60580279,
+        "epoch_id": "JCiSb8e2AMGfGJ2NZjPHdx3UUBC5BqL1BSoYGzfR8cEQ",
+        "next_epoch_id": "J1CExMV4bF9ZCUj1sPSu63WzQsKahLtxQ4Faz5UmmBGS",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-01T16:36:50.292Z",
+        "balance": 1.0362134058326948e+26,
+        "earnings": 1.9267054173869453e+22,
+        "block_height": 60537079,
+        "epoch_id": "Gn85kCEm1PArKGMMZXAZrcpxMKQDG9ehimgdaU4zhF8y",
+        "next_epoch_id": "JCiSb8e2AMGfGJ2NZjPHdx3UUBC5BqL1BSoYGzfR8cEQ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-03-01T01:48:40.946Z",
+        "balance": 1.0360207352909561e+26,
+        "earnings": 1.932445210475293e+22,
+        "block_height": 60493879,
+        "epoch_id": "HqysjycN4WcQqeMk2b3BiaHdtYGW8xZMHBsWH8pgu7sB",
+        "next_epoch_id": "Gn85kCEm1PArKGMMZXAZrcpxMKQDG9ehimgdaU4zhF8y",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-28T11:00:40.043Z",
+        "balance": 1.0358274907699086e+26,
+        "earnings": 1.9565547221834898e+22,
+        "block_height": 60450679,
+        "epoch_id": "4pgvKFH89B62U55X3SSGdu3ZMckfK1QNZFDd7hpjtgN8",
+        "next_epoch_id": "HqysjycN4WcQqeMk2b3BiaHdtYGW8xZMHBsWH8pgu7sB",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-27T20:09:17.518Z",
+        "balance": 1.0356318352976902e+26,
+        "earnings": 1.91321787280124e+22,
+        "block_height": 60407479,
+        "epoch_id": "GfYLt4VCp6dLCRwqNHiqnohECAYaKVorhGG7JvKgnKdD",
+        "next_epoch_id": "4pgvKFH89B62U55X3SSGdu3ZMckfK1QNZFDd7hpjtgN8",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-27T05:10:16.902Z",
+        "balance": 1.0354405135104101e+26,
+        "earnings": 1.942279955639697e+22,
+        "block_height": 60364278,
+        "epoch_id": "6QMpaJzGBthPGkdpScHght2opHgvUY6jbwyabE4mFf4M",
+        "next_epoch_id": "GfYLt4VCp6dLCRwqNHiqnohECAYaKVorhGG7JvKgnKdD",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-26T14:32:14.032Z",
+        "balance": 1.0352462855148462e+26,
+        "earnings": 1.9565049592355454e+22,
+        "block_height": 60321078,
+        "epoch_id": "5jG4Y1fzmbeUemDVKsnqGSH7xCvj1zXUSmCyRoWJccRw",
+        "next_epoch_id": "6QMpaJzGBthPGkdpScHght2opHgvUY6jbwyabE4mFf4M",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-25T23:39:22.179Z",
+        "balance": 1.0350506350189226e+26,
+        "earnings": 1.9559152050749886e+22,
+        "block_height": 60277878,
+        "epoch_id": "3b5mF3NrmtdsHoS1SmX5UWV3d2CHnLFqQe6cwnxMLhaD",
+        "next_epoch_id": "5jG4Y1fzmbeUemDVKsnqGSH7xCvj1zXUSmCyRoWJccRw",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-25T08:40:56.265Z",
+        "balance": 1.0348550434984151e+26,
+        "earnings": 1.9580656955952328e+22,
+        "block_height": 60234678,
+        "epoch_id": "8sMK2Vge8PdB8utMSPMKKtS95Lhi8GPogj49sh74MqAP",
+        "next_epoch_id": "3b5mF3NrmtdsHoS1SmX5UWV3d2CHnLFqQe6cwnxMLhaD",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-24T17:43:20.667Z",
+        "balance": 1.0346592369288556e+26,
+        "earnings": 2.001231536015023e+22,
+        "block_height": 60191478,
+        "epoch_id": "5EfufBErmc1RKdW5SbbBr6EdvjGFcmStSFLLtedaZqaW",
+        "next_epoch_id": "8sMK2Vge8PdB8utMSPMKKtS95Lhi8GPogj49sh74MqAP",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-24T02:42:57.773Z",
+        "balance": 1.034459113775254e+26,
+        "earnings": 1.9496880277977767e+22,
+        "block_height": 60148278,
+        "epoch_id": "5ziQ4o6XSfPXyDEeaEEqZnT27i9jUURhqUU7bR3CXYt",
+        "next_epoch_id": "5EfufBErmc1RKdW5SbbBr6EdvjGFcmStSFLLtedaZqaW",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-23T11:22:48.372Z",
+        "balance": 1.0342641449724743e+26,
+        "earnings": 2.0056052622394537e+22,
+        "block_height": 60105078,
+        "epoch_id": "EYm5pzJJUKwqhETWCf9y3xDDa2LpmGBnwJ3CT9zUTiWD",
+        "next_epoch_id": "5ziQ4o6XSfPXyDEeaEEqZnT27i9jUURhqUU7bR3CXYt",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-22T20:31:40.871Z",
+        "balance": 1.0340635844462503e+26,
+        "earnings": 2.2426035387430926e+22,
+        "block_height": 60061878,
+        "epoch_id": "3CTHAkyKj9xTvMczEpf9jZcQJk8mfkiNY3KbHSMRwNXo",
+        "next_epoch_id": "EYm5pzJJUKwqhETWCf9y3xDDa2LpmGBnwJ3CT9zUTiWD",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-22T05:14:51.779Z",
+        "balance": 1.033839324092376e+26,
+        "earnings": 2.024575042486104e+22,
+        "block_height": 60018678,
+        "epoch_id": "2fz8WkRCQc2t5JNk5njaJUctZrUsg9k57CSqU9Anp74k",
+        "next_epoch_id": "3CTHAkyKj9xTvMczEpf9jZcQJk8mfkiNY3KbHSMRwNXo",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-21T13:46:04.190Z",
+        "balance": 1.0336368665881274e+26,
+        "earnings": 2.1153509699822297e+22,
+        "block_height": 59975478,
+        "epoch_id": "BRkrSmRwNMYvbb58hkmyGteXPj5Hn7EtxW5Am3oxNMKo",
+        "next_epoch_id": "2fz8WkRCQc2t5JNk5njaJUctZrUsg9k57CSqU9Anp74k",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-20T22:16:47.006Z",
+        "balance": 1.0334253314911292e+26,
+        "earnings": 2.1725065325471955e+22,
+        "block_height": 59932278,
+        "epoch_id": "EbVp3ToJg8HN6cUWUGRAWj3MoMEPReARhZJ15XmTdoeS",
+        "next_epoch_id": "BRkrSmRwNMYvbb58hkmyGteXPj5Hn7EtxW5Am3oxNMKo",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-20T06:09:11.646Z",
+        "balance": 1.0332080808378745e+26,
+        "earnings": 2.1185254410896445e+22,
+        "block_height": 59889078,
+        "epoch_id": "59nd1uMeYkypPrhZA2n6FPn9afPsUdwH3VwVQinEjtu",
+        "next_epoch_id": "EbVp3ToJg8HN6cUWUGRAWj3MoMEPReARhZJ15XmTdoeS",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-19T13:56:24.690Z",
+        "balance": 1.0329962282937655e+26,
+        "earnings": 2.1081963646680065e+22,
+        "block_height": 59845878,
+        "epoch_id": "aJYCyHyC5paUdTJmfxfJVLyZkMFo5wVG9923R1ejXzA",
+        "next_epoch_id": "59nd1uMeYkypPrhZA2n6FPn9afPsUdwH3VwVQinEjtu",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-18T21:42:40.251Z",
+        "balance": 1.0327854086572987e+26,
+        "earnings": 2.041692088315882e+22,
+        "block_height": 59802678,
+        "epoch_id": "7e9d6PpawigPWTy8tHbfLvkipngXZ6FM9ZCyCJmXcX7P",
+        "next_epoch_id": "aJYCyHyC5paUdTJmfxfJVLyZkMFo5wVG9923R1ejXzA",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-18T05:33:16.642Z",
+        "balance": 1.0325812394484671e+26,
+        "earnings": 2.0251796137976416e+22,
+        "block_height": 59759478,
+        "epoch_id": "4nPtiGyPLm3LHrnVU9bwL2Jp7pv7nggRTHXfVSJzyRgW",
+        "next_epoch_id": "7e9d6PpawigPWTy8tHbfLvkipngXZ6FM9ZCyCJmXcX7P",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-17T13:55:47.441Z",
+        "balance": 1.0323787214870874e+26,
+        "earnings": 2.0061596719562086e+22,
+        "block_height": 59716278,
+        "epoch_id": "54RwQmovJiTMFWyGVXw9M6ouFrTzbk49hb8yMjhQsx9z",
+        "next_epoch_id": "4nPtiGyPLm3LHrnVU9bwL2Jp7pv7nggRTHXfVSJzyRgW",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-16T22:25:52.025Z",
+        "balance": 1.0321781055198917e+26,
+        "earnings": 1.933625963725319e+22,
+        "block_height": 59673077,
+        "epoch_id": "sxRYEX9Pii3kedoyGCbggxzeBZutAecm6fewQd9WoS9",
+        "next_epoch_id": "54RwQmovJiTMFWyGVXw9M6ouFrTzbk49hb8yMjhQsx9z",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-16T07:04:37.454Z",
+        "balance": 1.0319847429235192e+26,
+        "earnings": 1.9570142569316695e+22,
+        "block_height": 59629877,
+        "epoch_id": "DK1NzPEq3y72LqPgPPpQcA4EZBhFU8xzwcHDkwhExZn8",
+        "next_epoch_id": "sxRYEX9Pii3kedoyGCbggxzeBZutAecm6fewQd9WoS9",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-15T16:17:02.154Z",
+        "balance": 1.031789041497826e+26,
+        "earnings": 1.929884296264677e+22,
+        "block_height": 59586677,
+        "epoch_id": "35hm9zwtorMVYs7zTDiAqDGjdkm7DpeGoRUZFPq48LDJ",
+        "next_epoch_id": "DK1NzPEq3y72LqPgPPpQcA4EZBhFU8xzwcHDkwhExZn8",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-15T01:19:27.850Z",
+        "balance": 1.0315960530681996e+26,
+        "earnings": 1.9356804729140284e+22,
+        "block_height": 59543477,
+        "epoch_id": "AGgW3DAPMvH2yHHwTue3SjJ2aF2XJbVQ91gxUeWyJebn",
+        "next_epoch_id": "35hm9zwtorMVYs7zTDiAqDGjdkm7DpeGoRUZFPq48LDJ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-14T10:34:21.981Z",
+        "balance": 1.0314024850209082e+26,
+        "earnings": 1.9100786895385482e+22,
+        "block_height": 59500277,
+        "epoch_id": "Dj1QQzTgGu9V4pM8BRNJ5fGkmtbopwUjgHVsDJXqcwpP",
+        "next_epoch_id": "AGgW3DAPMvH2yHHwTue3SjJ2aF2XJbVQ91gxUeWyJebn",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-13T19:46:42.550Z",
+        "balance": 1.0312114771519543e+26,
+        "earnings": 1.9286701263737917e+22,
+        "block_height": 59457077,
+        "epoch_id": "4zwy6HC1FbLbBMD121d9DwCd9WpkaRBXmkC48BwjQ46k",
+        "next_epoch_id": "Dj1QQzTgGu9V4pM8BRNJ5fGkmtbopwUjgHVsDJXqcwpP",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-13T05:10:33.729Z",
+        "balance": 1.031018610139317e+26,
+        "earnings": 1.9222860711623578e+22,
+        "block_height": 59413877,
+        "epoch_id": "8qvzxZXrDA48JvZ9cQFLcynrL75EhFHZg84TjVqdubST",
+        "next_epoch_id": "4zwy6HC1FbLbBMD121d9DwCd9WpkaRBXmkC48BwjQ46k",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-12T14:27:17.041Z",
+        "balance": 1.0308263815322007e+26,
+        "earnings": 1.935146634455098e+22,
+        "block_height": 59370677,
+        "epoch_id": "ARd7BeGMQTDrSnucmfgHmZtvSr5vQk53c74rszjCsVZc",
+        "next_epoch_id": "8qvzxZXrDA48JvZ9cQFLcynrL75EhFHZg84TjVqdubST",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-11T23:43:42.612Z",
+        "balance": 1.0306328668687552e+26,
+        "earnings": 1.9324887225639123e+22,
+        "block_height": 59327477,
+        "epoch_id": "G8a8ukdhmdtGKo1gW9erwqAMemAmvcQwzjtYNTK9zR7J",
+        "next_epoch_id": "ARd7BeGMQTDrSnucmfgHmZtvSr5vQk53c74rszjCsVZc",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-11T08:58:37.449Z",
+        "balance": 1.0304396179964988e+26,
+        "earnings": 1.953111759292438e+22,
+        "block_height": 59284277,
+        "epoch_id": "JCw4pn6xtddBEmukavmGbmHYt3ZVjo2diTn5Q6PFcQC4",
+        "next_epoch_id": "G8a8ukdhmdtGKo1gW9erwqAMemAmvcQwzjtYNTK9zR7J",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-10T18:15:38.956Z",
+        "balance": 1.0302443068205696e+26,
+        "earnings": 1.939140435381845e+22,
+        "block_height": 59241077,
+        "epoch_id": "WV462gjBCnSqbq1nFxX3Nih9hBgN8KgKhPx7ToQMYC6",
+        "next_epoch_id": "JCw4pn6xtddBEmukavmGbmHYt3ZVjo2diTn5Q6PFcQC4",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-10T03:22:37.947Z",
+        "balance": 1.0300503927770314e+26,
+        "earnings": 1.9527822142153987e+22,
+        "block_height": 59197877,
+        "epoch_id": "5FSDN2cMUwfkDDd4CYqEVNeSkisYbrZVkDQNq2PSfSnC",
+        "next_epoch_id": "WV462gjBCnSqbq1nFxX3Nih9hBgN8KgKhPx7ToQMYC6",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-09T12:33:20.717Z",
+        "balance": 1.0298551145556098e+26,
+        "earnings": 1.956678801701317e+22,
+        "block_height": 59154677,
+        "epoch_id": "HmZjTHxqNL5Z6vUq6QWtCPt9UScZAxe2xYN7hQGtygUS",
+        "next_epoch_id": "5FSDN2cMUwfkDDd4CYqEVNeSkisYbrZVkDQNq2PSfSnC",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-08T21:38:35.340Z",
+        "balance": 1.0296594466754397e+26,
+        "earnings": 1.970028860234939e+22,
+        "block_height": 59111477,
+        "epoch_id": "CQENsj2DKGgHj4VRdKzSMYgcg7MGFLtTJPoX3THpmkvN",
+        "next_epoch_id": "HmZjTHxqNL5Z6vUq6QWtCPt9UScZAxe2xYN7hQGtygUS",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-08T06:47:40.119Z",
+        "balance": 1.0294624437894162e+26,
+        "earnings": 1.949914297317859e+22,
+        "block_height": 59068277,
+        "epoch_id": "FCCeKaeJrN2FfWnxdicLgWu5cpVzBTxAXrPahgn5qBBh",
+        "next_epoch_id": "CQENsj2DKGgHj4VRdKzSMYgcg7MGFLtTJPoX3THpmkvN",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-07T15:52:49.824Z",
+        "balance": 1.0292674523596844e+26,
+        "earnings": 2.002260739205116e+22,
+        "block_height": 59025077,
+        "epoch_id": "8VWtx6NtyrqhPaqK3KoYaXowUSbaCxg5mZ8xTkQWxWGq",
+        "next_epoch_id": "FCCeKaeJrN2FfWnxdicLgWu5cpVzBTxAXrPahgn5qBBh",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-07T01:05:21.988Z",
+        "balance": 1.029067226285764e+26,
+        "earnings": 1.965596679979774e+22,
+        "block_height": 58981877,
+        "epoch_id": "EoSLYodS2HpKJib6x1wRnrUaKdSQNxGDCWCWG63t6SUR",
+        "next_epoch_id": "8VWtx6NtyrqhPaqK3KoYaXowUSbaCxg5mZ8xTkQWxWGq",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-06T09:53:54.677Z",
+        "balance": 1.028870666617766e+26,
+        "earnings": 2.0161195675936893e+22,
+        "block_height": 58938677,
+        "epoch_id": "ELQwTeYXcxNtZRt8pW9DidWufHLP5EUT83DW4tQw9ovB",
+        "next_epoch_id": "EoSLYodS2HpKJib6x1wRnrUaKdSQNxGDCWCWG63t6SUR",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-05T19:01:04.534Z",
+        "balance": 1.0286690546610066e+26,
+        "earnings": 1.986098704283312e+22,
+        "block_height": 58895477,
+        "epoch_id": "FmMTNrCiAfHe1Ud2ttJtsWwmhzYJiE981o49MRAgcZre",
+        "next_epoch_id": "ELQwTeYXcxNtZRt8pW9DidWufHLP5EUT83DW4tQw9ovB",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-05T03:45:19.332Z",
+        "balance": 1.0284704447905782e+26,
+        "earnings": 1.9911148656187427e+22,
+        "block_height": 58852277,
+        "epoch_id": "GskXAXVbt5R43spJomT6Ba6zs6dPe5W976umvWGibf9h",
+        "next_epoch_id": "FmMTNrCiAfHe1Ud2ttJtsWwmhzYJiE981o49MRAgcZre",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-04T12:44:20.257Z",
+        "balance": 1.0282713333040164e+26,
+        "earnings": 1.9618542178041535e+22,
+        "block_height": 58809077,
+        "epoch_id": "GLJyb3Hi71iPiR5wRpL2j3xcz5KWtWqExCmUApjV6pfh",
+        "next_epoch_id": "GskXAXVbt5R43spJomT6Ba6zs6dPe5W976umvWGibf9h",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-03T21:41:00.293Z",
+        "balance": 1.028075147882236e+26,
+        "earnings": 1.977555930543628e+22,
+        "block_height": 58765877,
+        "epoch_id": "Fh5batjUSFs5feENKaLkDTtMNUa2eC2Ef32MBm1hpQ4z",
+        "next_epoch_id": "GLJyb3Hi71iPiR5wRpL2j3xcz5KWtWqExCmUApjV6pfh",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-03T06:50:39.197Z",
+        "balance": 1.0278773922891816e+26,
+        "earnings": 1.969085998148768e+22,
+        "block_height": 58722677,
+        "epoch_id": "9nQBcQQwyMGsvAd3A1LAtCWCEfifnJnycmrjmo36mZAE",
+        "next_epoch_id": "Fh5batjUSFs5feENKaLkDTtMNUa2eC2Ef32MBm1hpQ4z",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-02T15:53:11.862Z",
+        "balance": 1.0276804836893667e+26,
+        "earnings": 1.988119412711621e+22,
+        "block_height": 58679477,
+        "epoch_id": "3AQpysPpizV7Yw6EoM15Wb5JebqaHjUkShAAjve5vbJQ",
+        "next_epoch_id": "9nQBcQQwyMGsvAd3A1LAtCWCEfifnJnycmrjmo36mZAE",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-02T01:00:58.572Z",
+        "balance": 1.0274816717480955e+26,
+        "earnings": 1.9433920067371673e+22,
+        "block_height": 58636277,
+        "epoch_id": "A92pXf9FoBagiceA1r8M1TVkLwD8c8YoTrqD8upiPbeR",
+        "next_epoch_id": "3AQpysPpizV7Yw6EoM15Wb5JebqaHjUkShAAjve5vbJQ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-02-01T10:01:37.587Z",
+        "balance": 1.0272873325474218e+26,
+        "earnings": 1.9797725549239103e+22,
+        "block_height": 58593077,
+        "epoch_id": "2vZXgTFCYP1isMXSjF4rgkEnMKnqKBK7CMvnWZ1gt3tc",
+        "next_epoch_id": "A92pXf9FoBagiceA1r8M1TVkLwD8c8YoTrqD8upiPbeR",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-31T19:21:50.526Z",
+        "balance": 1.0270893552919294e+26,
+        "earnings": 1.9746650084251433e+22,
+        "block_height": 58549877,
+        "epoch_id": "3bmQJCzucj6RwgPRi1BANz59J8gnHNPFS4h18BD4t8Wg",
+        "next_epoch_id": "2vZXgTFCYP1isMXSjF4rgkEnMKnqKBK7CMvnWZ1gt3tc",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-31T04:26:08.422Z",
+        "balance": 1.026891888791087e+26,
+        "earnings": 1.979031107481723e+22,
+        "block_height": 58506677,
+        "epoch_id": "APRndEk73pK7Vavyq4ZtLfauQaQnLFRhLPwP6kNvHvVr",
+        "next_epoch_id": "3bmQJCzucj6RwgPRi1BANz59J8gnHNPFS4h18BD4t8Wg",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-30T13:32:35.461Z",
+        "balance": 1.0266939856803388e+26,
+        "earnings": 1.9560170137270973e+22,
+        "block_height": 58463477,
+        "epoch_id": "E4HHqUHkz9CDkZFWD7wXwU29J1MypM3QRoprsiEFo5Bt",
+        "next_epoch_id": "APRndEk73pK7Vavyq4ZtLfauQaQnLFRhLPwP6kNvHvVr",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-29T22:36:53.743Z",
+        "balance": 1.026498383978966e+26,
+        "earnings": 1.978171575297903e+22,
+        "block_height": 58420277,
+        "epoch_id": "4hA81d5DYZUrRhpbs83gvaokRFN8L2B9fJuXETRyAY8o",
+        "next_epoch_id": "E4HHqUHkz9CDkZFWD7wXwU29J1MypM3QRoprsiEFo5Bt",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-29T07:52:35.804Z",
+        "balance": 1.0263005668214363e+26,
+        "earnings": 1.9574878982851845e+22,
+        "block_height": 58377077,
+        "epoch_id": "GkHbEfojeAjPqMZHxqRzY7hZt2t2nLPDut82HJt5NSbs",
+        "next_epoch_id": "4hA81d5DYZUrRhpbs83gvaokRFN8L2B9fJuXETRyAY8o",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-28T16:58:19.596Z",
+        "balance": 1.0261048180316077e+26,
+        "earnings": 1.986217725475562e+22,
+        "block_height": 58333877,
+        "epoch_id": "2pdHP3GLSmu3gBh6WUfgD6qCwSjjmhJ2y182FqND8acP",
+        "next_epoch_id": "GkHbEfojeAjPqMZHxqRzY7hZt2t2nLPDut82HJt5NSbs",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-28T02:12:31.708Z",
+        "balance": 1.0259061962590602e+26,
+        "earnings": 1.954817194983241e+22,
+        "block_height": 58290677,
+        "epoch_id": "BQhSMR9L2m3qSsBRWrq55eVR6kg4HJkiz1R22wBs1BPk",
+        "next_epoch_id": "2pdHP3GLSmu3gBh6WUfgD6qCwSjjmhJ2y182FqND8acP",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-27T11:07:50.218Z",
+        "balance": 1.0257107145395619e+26,
+        "earnings": 1.960376030901438e+22,
+        "block_height": 58247477,
+        "epoch_id": "BXVouqEfBCnuvS72XErEyCrf9hNYwWuhowGC1FJFWQwZ",
+        "next_epoch_id": "BQhSMR9L2m3qSsBRWrq55eVR6kg4HJkiz1R22wBs1BPk",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-26T20:17:38.271Z",
+        "balance": 1.0255146769364717e+26,
+        "earnings": 1.927167227016093e+22,
+        "block_height": 58204277,
+        "epoch_id": "2nJ5TRQA86FuWSiBw7DfCjPRdFWtoyQKK5Gii5qGf3Br",
+        "next_epoch_id": "BXVouqEfBCnuvS72XErEyCrf9hNYwWuhowGC1FJFWQwZ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-26T05:22:45.117Z",
+        "balance": 1.0253219602137701e+26,
+        "earnings": 1.987061721187278e+22,
+        "block_height": 58161077,
+        "epoch_id": "5NxLGHCaFYiSfomxYwgactDGt7HAHTWcKVYFEC9vDci",
+        "next_epoch_id": "2nJ5TRQA86FuWSiBw7DfCjPRdFWtoyQKK5Gii5qGf3Br",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-25T14:41:38.884Z",
+        "balance": 1.0251232540416514e+26,
+        "earnings": 1.9281289167871905e+22,
+        "block_height": 58117877,
+        "epoch_id": "3wiRDDVMKpCQrCddwVtvJxD5C62Ej5nyPQU6ChAuiV3i",
+        "next_epoch_id": "5NxLGHCaFYiSfomxYwgactDGt7HAHTWcKVYFEC9vDci",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-24T23:35:23.065Z",
+        "balance": 1.0249304411499727e+26,
+        "earnings": 1.97466589347531e+22,
+        "block_height": 58074677,
+        "epoch_id": "8bpqDkXaTv9Mt26obUFTYHDPrG8FyyuAjvfe8UL3wD3L",
+        "next_epoch_id": "3wiRDDVMKpCQrCddwVtvJxD5C62Ej5nyPQU6ChAuiV3i",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-24T08:55:34.014Z",
+        "balance": 1.0247329745606251e+26,
+        "earnings": 1.933303956508299e+22,
+        "block_height": 58031477,
+        "epoch_id": "FrBhGvpTUnzf5rWPfRkJNg8mPAsMSitsDSU52Ax71XoP",
+        "next_epoch_id": "8bpqDkXaTv9Mt26obUFTYHDPrG8FyyuAjvfe8UL3wD3L",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-23T18:06:51.938Z",
+        "balance": 1.0245396441649743e+26,
+        "earnings": 2.1481766189365914e+22,
+        "block_height": 57988277,
+        "epoch_id": "DaLh98JfmnWYcWGkeRjt3r2Wa8dBgbQos7vJ4HP2wAgt",
+        "next_epoch_id": "FrBhGvpTUnzf5rWPfRkJNg8mPAsMSitsDSU52Ax71XoP",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-23T03:28:25.879Z",
+        "balance": 1.0243248265030806e+26,
+        "earnings": 1.963828182158619e+22,
+        "block_height": 57945077,
+        "epoch_id": "HQGmRM83QiWH81NvnDKh8yY5XtkR6VDGYgr8EZ9KcBJW",
+        "next_epoch_id": "DaLh98JfmnWYcWGkeRjt3r2Wa8dBgbQos7vJ4HP2wAgt",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-22T12:04:13.105Z",
+        "balance": 1.0241284436848648e+26,
+        "earnings": 2.3098518206972355e+22,
+        "block_height": 57901877,
+        "epoch_id": "9ZiHBfT9oAwSPcXLpWCgs3gRdx4ZhDuhDZ4jUTsVLwHr",
+        "next_epoch_id": "HQGmRM83QiWH81NvnDKh8yY5XtkR6VDGYgr8EZ9KcBJW",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-21T21:23:41.124Z",
+        "balance": 1.023897458502795e+26,
+        "earnings": 2.0054277870456754e+22,
+        "block_height": 57858677,
+        "epoch_id": "2tthztTNbtjfBVmeaLvR6Cj5kQz9erBeDVnpDDANuVsD",
+        "next_epoch_id": "9ZiHBfT9oAwSPcXLpWCgs3gRdx4ZhDuhDZ4jUTsVLwHr",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-21T05:32:46.920Z",
+        "balance": 1.0236969157240905e+26,
+        "earnings": 2.2658765839220404e+22,
+        "block_height": 57815477,
+        "epoch_id": "HBA8rdVDHwCC3zpTfo8ds9xHyjtX7WhBQQkJWYbhrKE7",
+        "next_epoch_id": "2tthztTNbtjfBVmeaLvR6Cj5kQz9erBeDVnpDDANuVsD",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-20T14:29:53.336Z",
+        "balance": 1.0234703280656983e+26,
+        "earnings": 2.0329831043257227e+22,
+        "block_height": 57772277,
+        "epoch_id": "8BLTtQ7SfT1Kyke9hmF3T1QRXrMBe3NdD3LswojrzUo1",
+        "next_epoch_id": "HBA8rdVDHwCC3zpTfo8ds9xHyjtX7WhBQQkJWYbhrKE7",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-19T21:33:10.675Z",
+        "balance": 1.0232670297552657e+26,
+        "earnings": 2.3731214663298763e+22,
+        "block_height": 57729077,
+        "epoch_id": "7fepMxySUaT2K8vwDemSCUWuzhvB3n7KqYcFjQqWq9i8",
+        "next_epoch_id": "8BLTtQ7SfT1Kyke9hmF3T1QRXrMBe3NdD3LswojrzUo1",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-19T06:23:15.474Z",
+        "balance": 1.0230297176086327e+26,
+        "earnings": 2.5269267203583652e+22,
+        "block_height": 57685877,
+        "epoch_id": "Fktg3pHgZLvBfsAF72aNENWufDAiPE8VbD91R9MocJ2C",
+        "next_epoch_id": "7fepMxySUaT2K8vwDemSCUWuzhvB3n7KqYcFjQqWq9i8",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-18T15:03:55.439Z",
+        "balance": 1.0227770249365969e+26,
+        "earnings": 2.8995029468732906e+22,
+        "block_height": 57642677,
+        "epoch_id": "4aXrSoWZJwFpHLKYaiQkzFdSShueq8TSVUMGD76MVfc1",
+        "next_epoch_id": "Fktg3pHgZLvBfsAF72aNENWufDAiPE8VbD91R9MocJ2C",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-17T23:36:21.364Z",
+        "balance": 1.0224870746419096e+26,
+        "earnings": 2.400192812274228e+22,
+        "block_height": 57599477,
+        "epoch_id": "4cx4ARF1maDP6vx9aT6koFYWwh1S4h3kTLbaj3BaPqF2",
+        "next_epoch_id": "4aXrSoWZJwFpHLKYaiQkzFdSShueq8TSVUMGD76MVfc1",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-17T04:01:11.723Z",
+        "balance": 1.0222470553606821e+26,
+        "earnings": 2.2745376944543716e+22,
+        "block_height": 57556277,
+        "epoch_id": "4qkzxyXGTKbMUSeBPBCWCL7VPmF4bKFMptpPE3LJFDhn",
+        "next_epoch_id": "4cx4ARF1maDP6vx9aT6koFYWwh1S4h3kTLbaj3BaPqF2",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-16T11:12:37.760Z",
+        "balance": 1.0220196015912367e+26,
+        "earnings": 2.3030188355822473e+22,
+        "block_height": 57513075,
+        "epoch_id": "51RStgpaUvXLoQLLF41aDMXxJpA4YrBYWEd8CKAitcrf",
+        "next_epoch_id": "4qkzxyXGTKbMUSeBPBCWCL7VPmF4bKFMptpPE3LJFDhn",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-15T18:19:03.466Z",
+        "balance": 1.0217892997076785e+26,
+        "earnings": 1.4464818783143997e+22,
+        "block_height": 57469875,
+        "epoch_id": "8GmX1oLdvE3oioh4YmY5Vqw5s7i4zJfzUdZErDp4UYYc",
+        "next_epoch_id": "51RStgpaUvXLoQLLF41aDMXxJpA4YrBYWEd8CKAitcrf",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-15T01:35:28.183Z",
+        "balance": 1.021644651519847e+26,
+        "earnings": 1.5380569795751123e+22,
+        "block_height": 57426672,
+        "epoch_id": "Ec3daSTTeEew2maxJig9xEdbehooDRnUm9vPRLoX2xgn",
+        "next_epoch_id": "8GmX1oLdvE3oioh4YmY5Vqw5s7i4zJfzUdZErDp4UYYc",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-14T10:05:33.701Z",
+        "balance": 1.0214908458218895e+26,
+        "earnings": 2.0042066454779758e+22,
+        "block_height": 57383472,
+        "epoch_id": "6gRuv1LhheJzGBgDW4kem25Bwx9yF8QcfZv6PHxxK6ik",
+        "next_epoch_id": "Ec3daSTTeEew2maxJig9xEdbehooDRnUm9vPRLoX2xgn",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-13T18:22:19.966Z",
+        "balance": 1.0212904251573417e+26,
+        "earnings": 1.975225056645402e+22,
+        "block_height": 57340272,
+        "epoch_id": "J7SzUcNdpcMP44mZkN62rSThQdo1Py3Z9X7LuetdPD9Q",
+        "next_epoch_id": "6gRuv1LhheJzGBgDW4kem25Bwx9yF8QcfZv6PHxxK6ik",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-13T03:58:03.339Z",
+        "balance": 1.0210929026516772e+26,
+        "earnings": 1.9082269654955527e+22,
+        "block_height": 57297072,
+        "epoch_id": "69Xdw8iJ7dv9mFHzFjw1HfTuzvhQ1h8QVoXnsqhvHrUb",
+        "next_epoch_id": "J7SzUcNdpcMP44mZkN62rSThQdo1Py3Z9X7LuetdPD9Q",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-12T13:43:55.592Z",
+        "balance": 1.0209020799551276e+26,
+        "earnings": 1.8764806033758466e+22,
+        "block_height": 57253872,
+        "epoch_id": "G7sFhKXNvkGihfDhA7nP8kM5kWiqeKgtJyvQBvoj7Yos",
+        "next_epoch_id": "69Xdw8iJ7dv9mFHzFjw1HfTuzvhQ1h8QVoXnsqhvHrUb",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-11T23:19:06.482Z",
+        "balance": 1.02071443189479e+26,
+        "earnings": 1.8330176096204203e+22,
+        "block_height": 57210672,
+        "epoch_id": "3DRfJmdDZy13VUH1bSjdF9UrXThkfAWouPqtxeN9u6mz",
+        "next_epoch_id": "G7sFhKXNvkGihfDhA7nP8kM5kWiqeKgtJyvQBvoj7Yos",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-11T09:08:09.523Z",
+        "balance": 1.020531130133828e+26,
+        "earnings": 1.8561573343106521e+22,
+        "block_height": 57167472,
+        "epoch_id": "CJzeC1XMaMsjNVCvDEe5hes5KtbByZwft4m5Rf5vgLp8",
+        "next_epoch_id": "3DRfJmdDZy13VUH1bSjdF9UrXThkfAWouPqtxeN9u6mz",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-10T19:01:00.990Z",
+        "balance": 1.020345514400397e+26,
+        "earnings": 1.789174761197189e+22,
+        "block_height": 57124272,
+        "epoch_id": "4BpYFdH6dzX8vqHgs4RAcKxncSqE5SgiyokaJDgU6spd",
+        "next_epoch_id": "CJzeC1XMaMsjNVCvDEe5hes5KtbByZwft4m5Rf5vgLp8",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-10T04:44:20.448Z",
+        "balance": 1.0201665969242772e+26,
+        "earnings": 1.918845842401101e+22,
+        "block_height": 57081072,
+        "epoch_id": "3AsZztQZaWexbo6r1MKfrertFQ7BkUFZxA5LVC45mT2v",
+        "next_epoch_id": "4BpYFdH6dzX8vqHgs4RAcKxncSqE5SgiyokaJDgU6spd",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-09T14:45:46.272Z",
+        "balance": 1.0199747123400371e+26,
+        "earnings": 1.8177960151138628e+22,
+        "block_height": 57037872,
+        "epoch_id": "Hrvtg19UH6isqkewz8sDdSi9LpZydYCvfX5cy7qrKEYz",
+        "next_epoch_id": "3AsZztQZaWexbo6r1MKfrertFQ7BkUFZxA5LVC45mT2v",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-08T23:12:55.093Z",
+        "balance": 1.0197929327385257e+26,
+        "earnings": 1.73049904485158e+22,
+        "block_height": 56994672,
+        "epoch_id": "EDHSdP3mjpG21Ej5ZNqvAjQHXqSfNqFEPJwRHbhyhVwy",
+        "next_epoch_id": "Hrvtg19UH6isqkewz8sDdSi9LpZydYCvfX5cy7qrKEYz",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-08T08:29:56.314Z",
+        "balance": 1.0196198828340406e+26,
+        "earnings": 1.7450280640567537e+22,
+        "block_height": 56951472,
+        "epoch_id": "GTRTva4nHcV6obbSn2LvfH9Asvoz9S4Wbvd8uZ2GnJBr",
+        "next_epoch_id": "EDHSdP3mjpG21Ej5ZNqvAjQHXqSfNqFEPJwRHbhyhVwy",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-07T18:00:27.592Z",
+        "balance": 1.0194453800276349e+26,
+        "earnings": 1.7137702481258778e+22,
+        "block_height": 56908272,
+        "epoch_id": "E6vkMAsdi3SRgemy1VF9sgLafQeCLXwgdzeK59THCoaQ",
+        "next_epoch_id": "GTRTva4nHcV6obbSn2LvfH9Asvoz9S4Wbvd8uZ2GnJBr",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-07T03:22:48.661Z",
+        "balance": 1.0192740030028223e+26,
+        "earnings": 1.6888479764277145e+22,
+        "block_height": 56865072,
+        "epoch_id": "F4JDo8c4kdSdPMgzZBqQJAVotdZZZTJoLifS8fd3KDoJ",
+        "next_epoch_id": "E6vkMAsdi3SRgemy1VF9sgLafQeCLXwgdzeK59THCoaQ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-06T12:55:33.804Z",
+        "balance": 1.0191051182051795e+26,
+        "earnings": 1.7232395070077869e+22,
+        "block_height": 56821872,
+        "epoch_id": "9eforTvnHD2w8u3WrMMCWGeMp4pcwSQnR2vvobM8DYdB",
+        "next_epoch_id": "F4JDo8c4kdSdPMgzZBqQJAVotdZZZTJoLifS8fd3KDoJ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-05T22:36:54.331Z",
+        "balance": 1.0189327942544787e+26,
+        "earnings": 1.720490414450402e+22,
+        "block_height": 56778672,
+        "epoch_id": "6rtdPjXXkq9yg7kqVH8BFiwac9xkJ1AsUJDWtiMAbZV4",
+        "next_epoch_id": "9eforTvnHD2w8u3WrMMCWGeMp4pcwSQnR2vvobM8DYdB",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-05T08:12:05.252Z",
+        "balance": 1.0187607452130337e+26,
+        "earnings": 1.7616862725654494e+22,
+        "block_height": 56735472,
+        "epoch_id": "AA2n81EPvjPFLJHpjD9jNgWJFkLzRjFd4UTe9PqDY9H1",
+        "next_epoch_id": "6rtdPjXXkq9yg7kqVH8BFiwac9xkJ1AsUJDWtiMAbZV4",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-04T17:33:55.448Z",
+        "balance": 1.0185845765857772e+26,
+        "earnings": 1.686496332964434e+22,
+        "block_height": 56692272,
+        "epoch_id": "97dxs6oYZqzcyVouyFFwXEP2714g2QE4NY4SAmyjhAzg",
+        "next_epoch_id": "AA2n81EPvjPFLJHpjD9jNgWJFkLzRjFd4UTe9PqDY9H1",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-04T02:38:20.287Z",
+        "balance": 1.0184159269524807e+26,
+        "earnings": 1.7057891911668871e+22,
+        "block_height": 56649072,
+        "epoch_id": "6uWN97kw3Cx7KcR63HtSk1Ev9ZkXYe8xcMWfrwKs6hH7",
+        "next_epoch_id": "97dxs6oYZqzcyVouyFFwXEP2714g2QE4NY4SAmyjhAzg",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-03T12:20:51.695Z",
+        "balance": 1.018245348033364e+26,
+        "earnings": 1.724361764457663e+22,
+        "block_height": 56605872,
+        "epoch_id": "DgA2JrRenumkTDr2eoP62n5VH57gM4jewWdidqZjmtBC",
+        "next_epoch_id": "6uWN97kw3Cx7KcR63HtSk1Ev9ZkXYe8xcMWfrwKs6hH7",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-02T21:50:25.241Z",
+        "balance": 1.0180729118569183e+26,
+        "earnings": 1.6579797813121075e+22,
+        "block_height": 56562672,
+        "epoch_id": "6NyeDo1cfoyiNTaRX9vNWmvw1G3oRybM4A29gDrjd6f8",
+        "next_epoch_id": "DgA2JrRenumkTDr2eoP62n5VH57gM4jewWdidqZjmtBC",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-02T07:17:55.960Z",
+        "balance": 1.017907113878787e+26,
+        "earnings": 1.6930539188785536e+22,
+        "block_height": 56519472,
+        "epoch_id": "3ADcnckB78DuXtRwfShouyQGALgfqA5hnQfmcSAP5Z2j",
+        "next_epoch_id": "6NyeDo1cfoyiNTaRX9vNWmvw1G3oRybM4A29gDrjd6f8",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-01T17:13:31.414Z",
+        "balance": 1.0177378084868992e+26,
+        "earnings": 1.6568078573534827e+22,
+        "block_height": 56476272,
+        "epoch_id": "9b8Kgm7RHxzpLf29e5nEcY48ee6iwjKdTixQtWGLc1kT",
+        "next_epoch_id": "3ADcnckB78DuXtRwfShouyQGALgfqA5hnQfmcSAP5Z2j",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2022-01-01T02:51:40.063Z",
+        "balance": 1.0175721277011638e+26,
+        "earnings": 1.6644390236059859e+22,
+        "block_height": 56433072,
+        "epoch_id": "FUDGFQDN6UQ4g9hwzzSskaPfNnSH5QUHU5k3oKmB5pbW",
+        "next_epoch_id": "9b8Kgm7RHxzpLf29e5nEcY48ee6iwjKdTixQtWGLc1kT",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-31T12:48:08.580Z",
+        "balance": 1.0174056837988032e+26,
+        "earnings": 1.6578581353639818e+22,
+        "block_height": 56389872,
+        "epoch_id": "8BbHGtixj1xMiTqYu61YtxeW8wSBQjFmNBpiUWUTg4DQ",
+        "next_epoch_id": "FUDGFQDN6UQ4g9hwzzSskaPfNnSH5QUHU5k3oKmB5pbW",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-30T22:41:02.817Z",
+        "balance": 1.0172398979852669e+26,
+        "earnings": 1.6724967896549817e+22,
+        "block_height": 56346672,
+        "epoch_id": "oYa2LYziu8b3zpQjZSWS8cKXyrxVYjX3YREkaSMSWMU",
+        "next_epoch_id": "8BbHGtixj1xMiTqYu61YtxeW8wSBQjFmNBpiUWUTg4DQ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-30T08:37:14.970Z",
+        "balance": 1.0170726483063014e+26,
+        "earnings": 1.7068614473651354e+22,
+        "block_height": 56303472,
+        "epoch_id": "8Tu92JDM76maZgwXd8FRskRjQdAmhMHVtTBTdyUC9rYP",
+        "next_epoch_id": "oYa2LYziu8b3zpQjZSWS8cKXyrxVYjX3YREkaSMSWMU",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-29T18:26:18.307Z",
+        "balance": 1.0169019621615648e+26,
+        "earnings": 1.7140459584747932e+22,
+        "block_height": 56260272,
+        "epoch_id": "DWoitCy7mgTeRY21tc7RTDxwQcVDWDd9CJxTgYGbYDY2",
+        "next_epoch_id": "8Tu92JDM76maZgwXd8FRskRjQdAmhMHVtTBTdyUC9rYP",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-29T03:53:05.271Z",
+        "balance": 1.0167305575657174e+26,
+        "earnings": 1.7239080631718604e+22,
+        "block_height": 56217072,
+        "epoch_id": "A1VXHnaQd1tbVbU8R1WbhxNi2CB8Tm9U2a35s9pF2xcz",
+        "next_epoch_id": "DWoitCy7mgTeRY21tc7RTDxwQcVDWDd9CJxTgYGbYDY2",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-28T13:14:47.597Z",
+        "balance": 1.0165581667594002e+26,
+        "earnings": 1.7477681404882239e+22,
+        "block_height": 56173872,
+        "epoch_id": "DhfeYXvSxkGk4D4MSjhxooAuS9K6waomNsa4GgGZmHuN",
+        "next_epoch_id": "A1VXHnaQd1tbVbU8R1WbhxNi2CB8Tm9U2a35s9pF2xcz",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-27T22:54:28.445Z",
+        "balance": 1.0163833899453514e+26,
+        "earnings": 1.759383640779588e+22,
+        "block_height": 56130672,
+        "epoch_id": "4CgM44LouiChDNMFcXNbcZ1t3GqxJCsqp2LnKWXyBKgK",
+        "next_epoch_id": "DhfeYXvSxkGk4D4MSjhxooAuS9K6waomNsa4GgGZmHuN",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-27T08:23:43.874Z",
+        "balance": 1.0162074515812734e+26,
+        "earnings": 1.7713624043007085e+22,
+        "block_height": 56087472,
+        "epoch_id": "2paG9So7YPRYwai3Z3GY8jEthGJTZr1FUPjEdsURFCN3",
+        "next_epoch_id": "4CgM44LouiChDNMFcXNbcZ1t3GqxJCsqp2LnKWXyBKgK",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-26T17:54:54.637Z",
+        "balance": 1.0160303153408433e+26,
+        "earnings": 1.7875134440100277e+22,
+        "block_height": 56044272,
+        "epoch_id": "9ugpSViBksGB5dyfSHC4xYmUmRdPveat4PeFNUVJ48ND",
+        "next_epoch_id": "2paG9So7YPRYwai3Z3GY8jEthGJTZr1FUPjEdsURFCN3",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-26T03:14:06.931Z",
+        "balance": 1.0158515639964423e+26,
+        "earnings": 1.782967881945726e+22,
+        "block_height": 56001072,
+        "epoch_id": "C1EGdqU2tPhYM8PDTrCE7m3svKJLyoT6n1cMvNxby611",
+        "next_epoch_id": "9ugpSViBksGB5dyfSHC4xYmUmRdPveat4PeFNUVJ48ND",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-25T12:29:24.058Z",
+        "balance": 1.0156732672082477e+26,
+        "earnings": 1.7888642112263377e+22,
+        "block_height": 55957872,
+        "epoch_id": "BhS8fRpxjUr3P9oiGZRawwDqCfgAtNXUsYk1pt2cRha6",
+        "next_epoch_id": "C1EGdqU2tPhYM8PDTrCE7m3svKJLyoT6n1cMvNxby611",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-24T21:46:43.166Z",
+        "balance": 1.0154943807871251e+26,
+        "earnings": 1.807289937114798e+22,
+        "block_height": 55914672,
+        "epoch_id": "8S8NS9vDoGmjVdyCrov9crRQCNboec3ubij638iidrNU",
+        "next_epoch_id": "BhS8fRpxjUr3P9oiGZRawwDqCfgAtNXUsYk1pt2cRha6",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-24T07:05:14.353Z",
+        "balance": 1.0153136517934136e+26,
+        "earnings": 1.7111281150219788e+22,
+        "block_height": 55871472,
+        "epoch_id": "J3fDzMGFoamGfoNikZnPR3go2StcYvocr2dYsW4QgdX3",
+        "next_epoch_id": "8S8NS9vDoGmjVdyCrov9crRQCNboec3ubij638iidrNU",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-23T16:12:43.236Z",
+        "balance": 1.0151425389819114e+26,
+        "earnings": 1.6907624056532018e+22,
+        "block_height": 55828272,
+        "epoch_id": "8mTqAgtu1mGQSfs2yrb1tLsC7pDLb5zW2hGmXNEKKfBd",
+        "next_epoch_id": "J3fDzMGFoamGfoNikZnPR3go2StcYvocr2dYsW4QgdX3",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-23T01:50:33.949Z",
+        "balance": 1.0149734627413461e+26,
+        "earnings": 1.7023489404136797e+22,
+        "block_height": 55785072,
+        "epoch_id": "35xMCZo5qRaBNRB888CX25eRSVxNSQfiNFMSfUjkv4JB",
+        "next_epoch_id": "8mTqAgtu1mGQSfs2yrb1tLsC7pDLb5zW2hGmXNEKKfBd",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-22T11:38:11.703Z",
+        "balance": 1.0148032278473047e+26,
+        "earnings": 1.9615659866445998e+22,
+        "block_height": 55741872,
+        "epoch_id": "V3RFjpdTfhxgi1Ym9zuezuFEYQnYgyc7DpZPKNnNPPo",
+        "next_epoch_id": "35xMCZo5qRaBNRB888CX25eRSVxNSQfiNFMSfUjkv4JB",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-21T21:36:03.848Z",
+        "balance": 1.0146070712486403e+26,
+        "earnings": 1.76547897866694e+22,
+        "block_height": 55698672,
+        "epoch_id": "45npue46Sogk9qRGUc6zYNmz2Q3uAueRwZTu7aeYYFFS",
+        "next_epoch_id": "V3RFjpdTfhxgi1Ym9zuezuFEYQnYgyc7DpZPKNnNPPo",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-21T07:36:03.325Z",
+        "balance": 1.0144305233507736e+26,
+        "earnings": 2.093286591420286e+22,
+        "block_height": 55655472,
+        "epoch_id": "5TYLQzNcaWYfbH2Lj8GdZ7FzDcyEFAB1fgc1MDt6iwFU",
+        "next_epoch_id": "45npue46Sogk9qRGUc6zYNmz2Q3uAueRwZTu7aeYYFFS",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-20T17:06:07.898Z",
+        "balance": 1.0142211946916316e+26,
+        "earnings": 1.9276948895027484e+22,
+        "block_height": 55612272,
+        "epoch_id": "8EV77Nh3jN5VmTsHSG2KUk4Knx16UPwLB7Ju6xxj9xup",
+        "next_epoch_id": "5TYLQzNcaWYfbH2Lj8GdZ7FzDcyEFAB1fgc1MDt6iwFU",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-20T02:08:20.773Z",
+        "balance": 1.0140284252026813e+26,
+        "earnings": 1.5149520800465205e+22,
+        "block_height": 55569072,
+        "epoch_id": "7Jm4R1SqnS8j4wi7g8Ze7k3q2FBrwGdAkGkV2yBPPwYq",
+        "next_epoch_id": "8EV77Nh3jN5VmTsHSG2KUk4Knx16UPwLB7Ju6xxj9xup",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-19T12:25:50.541Z",
+        "balance": 1.0138769299946766e+26,
+        "earnings": 1.003107476191175e+22,
+        "block_height": 55525872,
+        "epoch_id": "PX3HWHJQSYSXkMsHBSMdZS5epbrxV9PmzRKdNo8PoRg",
+        "next_epoch_id": "7Jm4R1SqnS8j4wi7g8Ze7k3q2FBrwGdAkGkV2yBPPwYq",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-18T23:03:21.157Z",
+        "balance": 1.0137766192470575e+26,
+        "earnings": 1.5423217550480357e+22,
+        "block_height": 55482672,
+        "epoch_id": "CmCDq51R9UFnR7By5gjfHbJPdR4mJvfhNJ684MNB1nYd",
+        "next_epoch_id": "PX3HWHJQSYSXkMsHBSMdZS5epbrxV9PmzRKdNo8PoRg",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-18T09:26:02.524Z",
+        "balance": 1.0136223870715527e+26,
+        "earnings": 1.6038019351659078e+22,
+        "block_height": 55439471,
+        "epoch_id": "6xsY5QWR1gA8tjcoW9gQ8zqHoYCKMvBDVFXnxk3BEfgq",
+        "next_epoch_id": "CmCDq51R9UFnR7By5gjfHbJPdR4mJvfhNJ684MNB1nYd",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-17T20:38:59.505Z",
+        "balance": 1.0134620068780361e+26,
+        "earnings": 1.700611954812243e+22,
+        "block_height": 55396271,
+        "epoch_id": "14ohjqE3CmKbxqFGeGsHT1WQhL6v1y9uemH6gLYz1Qhx",
+        "next_epoch_id": "6xsY5QWR1gA8tjcoW9gQ8zqHoYCKMvBDVFXnxk3BEfgq",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-17T07:20:54.192Z",
+        "balance": 1.0132919456825549e+26,
+        "earnings": 1.5281983406864427e+22,
+        "block_height": 55353071,
+        "epoch_id": "BqPpXZt231eHHaDFq1ZBU7mJH28cjWg9B9STfAKKqZY6",
+        "next_epoch_id": "14ohjqE3CmKbxqFGeGsHT1WQhL6v1y9uemH6gLYz1Qhx",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-16T19:07:09.900Z",
+        "balance": 1.0131391258484863e+26,
+        "earnings": 1.6599117974786252e+22,
+        "block_height": 55309871,
+        "epoch_id": "3xfTKK5hTvJWcrY7QgGzpNvaiGRYb3JCjyCpbJhoAkGQ",
+        "next_epoch_id": "BqPpXZt231eHHaDFq1ZBU7mJH28cjWg9B9STfAKKqZY6",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-16T06:26:41.930Z",
+        "balance": 1.0129731346687384e+26,
+        "earnings": 1.608318765257927e+22,
+        "block_height": 55266671,
+        "epoch_id": "3qvuvt7XcRZ91emDKwpCHEFiNgFatXLD4i5xf9tNaKky",
+        "next_epoch_id": "3xfTKK5hTvJWcrY7QgGzpNvaiGRYb3JCjyCpbJhoAkGQ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-15T16:39:00.711Z",
+        "balance": 1.0128123027922126e+26,
+        "earnings": 1.5170673104881464e+22,
+        "block_height": 55223471,
+        "epoch_id": "9Nivmtikx3mhFg8Msnn5Dw9K5wx5RieZ8ETocwFBGwaY",
+        "next_epoch_id": "3qvuvt7XcRZ91emDKwpCHEFiNgFatXLD4i5xf9tNaKky",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-15T03:16:14.551Z",
+        "balance": 1.0126605960611638e+26,
+        "earnings": 1.5264695570036626e+22,
+        "block_height": 55180264,
+        "epoch_id": "6RPPbBYf9Yagk8TMuyDcCVWVsR6bSucGNGGSeu432FM",
+        "next_epoch_id": "9Nivmtikx3mhFg8Msnn5Dw9K5wx5RieZ8ETocwFBGwaY",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-14T14:40:09.289Z",
+        "balance": 1.0125079491054634e+26,
+        "earnings": 1.5264867526353766e+22,
+        "block_height": 55137064,
+        "epoch_id": "83ByLFY864LRbx7nxLr3ikyUQG28hGfSsp7GHw7WrcRz",
+        "next_epoch_id": "6RPPbBYf9Yagk8TMuyDcCVWVsR6bSucGNGGSeu432FM",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-14T01:59:42.099Z",
+        "balance": 1.0123553004301999e+26,
+        "earnings": 1.2690582985084198e+22,
+        "block_height": 55093864,
+        "epoch_id": "7kdwLGG7iWHsrjKseuTZpQ7tMnDADYEraEeKpc5S5zTK",
+        "next_epoch_id": "83ByLFY864LRbx7nxLr3ikyUQG28hGfSsp7GHw7WrcRz",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-13T13:18:28.886Z",
+        "balance": 1.012228394600349e+26,
+        "earnings": 1.5018392435483371e+22,
+        "block_height": 55050664,
+        "epoch_id": "4sowsU9oCPANJNpWqF9F5ZneDUjt7F2irE4Hd4nhaGQk",
+        "next_epoch_id": "7kdwLGG7iWHsrjKseuTZpQ7tMnDADYEraEeKpc5S5zTK",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-13T00:57:55.546Z",
+        "balance": 1.0120782106759942e+26,
+        "earnings": 1.4728961195941806e+22,
+        "block_height": 55007464,
+        "epoch_id": "6SFvZetqNsqGUziCqbxAkLwWLHy8wyuJFcosy8TBXQd6",
+        "next_epoch_id": "4sowsU9oCPANJNpWqF9F5ZneDUjt7F2irE4Hd4nhaGQk",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-12T12:29:23.087Z",
+        "balance": 1.0119309210640348e+26,
+        "earnings": 1.5040551791515862e+22,
+        "block_height": 54964264,
+        "epoch_id": "3chhj8t6LYDdy93N8o8HuBHJ3HDvNGFy5PwKJ5EtNC8f",
+        "next_epoch_id": "6SFvZetqNsqGUziCqbxAkLwWLHy8wyuJFcosy8TBXQd6",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-12T00:15:56.196Z",
+        "balance": 1.0117805155461196e+26,
+        "earnings": 1.4651534438857374e+22,
+        "block_height": 54921064,
+        "epoch_id": "CGcEN3sctHYyNdSNDhXVVJNATD49iRZfsmfcqyHpHVK9",
+        "next_epoch_id": "3chhj8t6LYDdy93N8o8HuBHJ3HDvNGFy5PwKJ5EtNC8f",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-11T11:46:40.096Z",
+        "balance": 1.011634000201731e+26,
+        "earnings": 1.5169019790378016e+22,
+        "block_height": 54877864,
+        "epoch_id": "2TqouEHkZM6tMRvwdG5vy9Napo4sMvNxdPzjxxSko5MN",
+        "next_epoch_id": "CGcEN3sctHYyNdSNDhXVVJNATD49iRZfsmfcqyHpHVK9",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-10T23:37:05.915Z",
+        "balance": 1.0114823100038273e+26,
+        "earnings": 1.464023550509713e+22,
+        "block_height": 54834664,
+        "epoch_id": "Cs2nXANZmbQ9ipPqNNsgPKTMTjsD144ZDd86JCVEJdNA",
+        "next_epoch_id": "2TqouEHkZM6tMRvwdG5vy9Napo4sMvNxdPzjxxSko5MN",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-10T11:01:47.568Z",
+        "balance": 1.0113359076487763e+26,
+        "earnings": 1.4984329070027962e+22,
+        "block_height": 54791464,
+        "epoch_id": "G411b5zfditsxVkqfusKHtyhM1aBwq3UiPFGXr9tjCGG",
+        "next_epoch_id": "Cs2nXANZmbQ9ipPqNNsgPKTMTjsD144ZDd86JCVEJdNA",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-09T22:52:11.818Z",
+        "balance": 1.011186064358076e+26,
+        "earnings": 1.4562507526889485e+22,
+        "block_height": 54748264,
+        "epoch_id": "7t7GUgQ4Cf1XEeA6ueFVA92qz15w1Sw5kPsi3fuzYUNA",
+        "next_epoch_id": "G411b5zfditsxVkqfusKHtyhM1aBwq3UiPFGXr9tjCGG",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-09T10:25:05.395Z",
+        "balance": 1.0110404392828071e+26,
+        "earnings": 1.4859831935831604e+22,
+        "block_height": 54705064,
+        "epoch_id": "4UmRFnmJxtVnkpNxsMa5RVMPbJtehC6WmMavCSkS8wyv",
+        "next_epoch_id": "7t7GUgQ4Cf1XEeA6ueFVA92qz15w1Sw5kPsi3fuzYUNA",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-08T22:18:55.566Z",
+        "balance": 1.0108918409634488e+26,
+        "earnings": 1.5050633480915344e+22,
+        "block_height": 54661864,
+        "epoch_id": "FFAWes9qE3kwrb2QzpD4ZEWZi1xmE48HJNSVDYuSqf6i",
+        "next_epoch_id": "4UmRFnmJxtVnkpNxsMa5RVMPbJtehC6WmMavCSkS8wyv",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-08T09:58:07.840Z",
+        "balance": 1.0107413346286397e+26,
+        "earnings": 1.4682335437331875e+22,
+        "block_height": 54618664,
+        "epoch_id": "66NTHnkCTbQgYPN8K9ujuMcP9Xb5k1dWq1ADMSZpGugo",
+        "next_epoch_id": "FFAWes9qE3kwrb2QzpD4ZEWZi1xmE48HJNSVDYuSqf6i",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-07T21:28:13.881Z",
+        "balance": 1.0105945112742663e+26,
+        "earnings": 1.4781417898445952e+22,
+        "block_height": 54575464,
+        "epoch_id": "FACVjSypKtXqMP1NQ3kNPFwtVYQx5LySgVm333Rvc3Xs",
+        "next_epoch_id": "66NTHnkCTbQgYPN8K9ujuMcP9Xb5k1dWq1ADMSZpGugo",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-07T08:57:15.431Z",
+        "balance": 1.0104466970952819e+26,
+        "earnings": 1.4566175658397422e+22,
+        "block_height": 54532264,
+        "epoch_id": "Buuxfjpi7V6cwQq1CiJuJhfqjQSseoaGop3sg1hgrh1B",
+        "next_epoch_id": "FACVjSypKtXqMP1NQ3kNPFwtVYQx5LySgVm333Rvc3Xs",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-06T20:21:31.476Z",
+        "balance": 1.0103010353386979e+26,
+        "earnings": 1.4211616563080383e+22,
+        "block_height": 54489064,
+        "epoch_id": "8VHUmADMCwP6QG9EQtYFEmtoNTgooynx61U4yAPgEWCp",
+        "next_epoch_id": "Buuxfjpi7V6cwQq1CiJuJhfqjQSseoaGop3sg1hgrh1B",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-06T07:56:45.268Z",
+        "balance": 1.0101589191730671e+26,
+        "earnings": 1.4406615919932633e+22,
+        "block_height": 54445864,
+        "epoch_id": "4jHu7r8jcZkSrwuQ91obXZEBFZYhcQSMkrupvXniJzdo",
+        "next_epoch_id": "8VHUmADMCwP6QG9EQtYFEmtoNTgooynx61U4yAPgEWCp",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-05T19:50:05.161Z",
+        "balance": 1.0100148530138678e+26,
+        "earnings": 1.452474465013916e+22,
+        "block_height": 54402664,
+        "epoch_id": "DoPGesnFvznxz3hcpLCXFqFM3AUjnPiYjoqoeMktXs1h",
+        "next_epoch_id": "4jHu7r8jcZkSrwuQ91obXZEBFZYhcQSMkrupvXniJzdo",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-05T07:31:38.519Z",
+        "balance": 1.0098696055673664e+26,
+        "earnings": 1.4334338041901176e+22,
+        "block_height": 54359464,
+        "epoch_id": "3Jfwm1D2yXmQkGSkhAonVjxtMVUts2A7u2dD7f6TbetB",
+        "next_epoch_id": "DoPGesnFvznxz3hcpLCXFqFM3AUjnPiYjoqoeMktXs1h",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-04T19:07:16.598Z",
+        "balance": 1.0097262621869474e+26,
+        "earnings": 1.4563155865774913e+22,
+        "block_height": 54316264,
+        "epoch_id": "A956e4eXonodK1qCi8HTZ447ERLJ5FEjmNz95GUfuqkH",
+        "next_epoch_id": "3Jfwm1D2yXmQkGSkhAonVjxtMVUts2A7u2dD7f6TbetB",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-04T06:52:43.254Z",
+        "balance": 1.0095806306282896e+26,
+        "earnings": 1.4449657914365711e+22,
+        "block_height": 54273064,
+        "epoch_id": "7tdBYrkAM9Y7bG3SePDZS6KrQuoGXLk48jfSFAVfExGL",
+        "next_epoch_id": "A956e4eXonodK1qCi8HTZ447ERLJ5FEjmNz95GUfuqkH",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-03T18:26:50.463Z",
+        "balance": 1.009436134049146e+26,
+        "earnings": 1.431332302260984e+22,
+        "block_height": 54229864,
+        "epoch_id": "BmnfjFFArp7xnKapPTvntP2szfgyUpd5w8ABJFN1FnBE",
+        "next_epoch_id": "7tdBYrkAM9Y7bG3SePDZS6KrQuoGXLk48jfSFAVfExGL",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-03T06:06:41.940Z",
+        "balance": 1.0092930008189199e+26,
+        "earnings": 1.4105305664396456e+22,
+        "block_height": 54186664,
+        "epoch_id": "B4qc7GpKhjnPCR6D3nh24oBsgrdaCdemGpDT1X6M726y",
+        "next_epoch_id": "BmnfjFFArp7xnKapPTvntP2szfgyUpd5w8ABJFN1FnBE",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-02T17:52:34.975Z",
+        "balance": 1.0091519477622759e+26,
+        "earnings": 1.4317816161586664e+22,
+        "block_height": 54143464,
+        "epoch_id": "A6bqb5MGYbLquecA543nizG8iUttn7VNGVubrbiySiUj",
+        "next_epoch_id": "B4qc7GpKhjnPCR6D3nh24oBsgrdaCdemGpDT1X6M726y",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-02T05:49:00.729Z",
+        "balance": 1.00900876960066e+26,
+        "earnings": 1.4574077276771741e+22,
+        "block_height": 54100264,
+        "epoch_id": "2MucAkKfEPFSvTZNZcGNUCrPCPnKJPY4ZAL1msr8uSXn",
+        "next_epoch_id": "A6bqb5MGYbLquecA543nizG8iUttn7VNGVubrbiySiUj",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-01T17:34:03.828Z",
+        "balance": 1.0088630288278923e+26,
+        "earnings": 1.4383279543488656e+22,
+        "block_height": 54057064,
+        "epoch_id": "GKonbezXDXCkUMTtNU1zowNscd2fuTqLK3GS1oLLwAgZ",
+        "next_epoch_id": "2MucAkKfEPFSvTZNZcGNUCrPCPnKJPY4ZAL1msr8uSXn",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-12-01T05:05:52.866Z",
+        "balance": 1.0087191960324574e+26,
+        "earnings": 1.4590080887179396e+22,
+        "block_height": 54013864,
+        "epoch_id": "5GGSV2ucHgiyTGJeDJ9BwvvgZ43KK8h8HLedwMehwiaa",
+        "next_epoch_id": "GKonbezXDXCkUMTtNU1zowNscd2fuTqLK3GS1oLLwAgZ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-30T16:47:11.335Z",
+        "balance": 1.0085732952235856e+26,
+        "earnings": 1.4416919667318937e+22,
+        "block_height": 53970664,
+        "epoch_id": "9gSRgY6vmfdQkyDKFmTCS7XjKPhdHQiJNUoy3j8BV4LB",
+        "next_epoch_id": "5GGSV2ucHgiyTGJeDJ9BwvvgZ43KK8h8HLedwMehwiaa",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-30T04:17:44.384Z",
+        "balance": 1.0084291260269125e+26,
+        "earnings": 1.4406797365430257e+22,
+        "block_height": 53927464,
+        "epoch_id": "AjaeNCy8W3TrfY1enmX9gH4jB3KF67X2Bn7ugWBeigxe",
+        "next_epoch_id": "9gSRgY6vmfdQkyDKFmTCS7XjKPhdHQiJNUoy3j8BV4LB",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-29T15:57:02.174Z",
+        "balance": 1.0082850580532581e+26,
+        "earnings": 1.4226984918928419e+22,
+        "block_height": 53884264,
+        "epoch_id": "6efFMW9iPoKa823agiYZYj9qZbSMMk6Qpx7KuN71yMwa",
+        "next_epoch_id": "AjaeNCy8W3TrfY1enmX9gH4jB3KF67X2Bn7ugWBeigxe",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-29T03:37:06.130Z",
+        "balance": 1.0081427882040689e+26,
+        "earnings": 1.450912842654015e+22,
+        "block_height": 53841064,
+        "epoch_id": "GzKzcuvzLy1a81cFAtFsRoYPs2iWUvorA5NBe4PYtBi2",
+        "next_epoch_id": "6efFMW9iPoKa823agiYZYj9qZbSMMk6Qpx7KuN71yMwa",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-28T15:26:57.102Z",
+        "balance": 1.0079976969198035e+26,
+        "earnings": 1.4237951770043584e+22,
+        "block_height": 53797864,
+        "epoch_id": "3Y7pdcnoBhUXv1DGNXgwusjCU2hu3CRW7hrWYsLBNKMg",
+        "next_epoch_id": "GzKzcuvzLy1a81cFAtFsRoYPs2iWUvorA5NBe4PYtBi2",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-28T03:02:26.037Z",
+        "balance": 1.007855317402103e+26,
+        "earnings": 1.4621929092757626e+22,
+        "block_height": 53754664,
+        "epoch_id": "9ccLvDRydAiiNNkwXL4jhFErtwLisWKDTrfVpofnH7io",
+        "next_epoch_id": "3Y7pdcnoBhUXv1DGNXgwusjCU2hu3CRW7hrWYsLBNKMg",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-27T14:51:21.233Z",
+        "balance": 1.0077090981111755e+26,
+        "earnings": 1.4262189594049214e+22,
+        "block_height": 53711464,
+        "epoch_id": "7aFxLj9Qd7vCKuz2SFZfi1sVjPTqcDEdDqtKdhRfoZX5",
+        "next_epoch_id": "9ccLvDRydAiiNNkwXL4jhFErtwLisWKDTrfVpofnH7io",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-27T02:27:22.042Z",
+        "balance": 1.007566476215235e+26,
+        "earnings": 1.4488875296960652e+22,
+        "block_height": 53668264,
+        "epoch_id": "8vmsV6Z9EfjMqkxqtL6LFsdC5MRruzQKRoNgqdwCu36k",
+        "next_epoch_id": "7aFxLj9Qd7vCKuz2SFZfi1sVjPTqcDEdDqtKdhRfoZX5",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-26T14:14:59.231Z",
+        "balance": 1.0074215874622654e+26,
+        "earnings": 1.4259310936182355e+22,
+        "block_height": 53625064,
+        "epoch_id": "4sJgKkbCa4UA3tQUq2GS8WMELpysaUTJpnHMEpbnpgT6",
+        "next_epoch_id": "8vmsV6Z9EfjMqkxqtL6LFsdC5MRruzQKRoNgqdwCu36k",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-26T01:50:59.536Z",
+        "balance": 1.0072789943529035e+26,
+        "earnings": 1.4759361010901396e+22,
+        "block_height": 53581864,
+        "epoch_id": "5WdBoCxZ6xsBGYG6t6zkU6B7kFsfQohKJxtNYRpWTt9H",
+        "next_epoch_id": "4sJgKkbCa4UA3tQUq2GS8WMELpysaUTJpnHMEpbnpgT6",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-25T13:38:41.654Z",
+        "balance": 1.0071314007427945e+26,
+        "earnings": 1.4350208513407896e+22,
+        "block_height": 53538664,
+        "epoch_id": "6HQ1TruBxQrsCQHU1PXy6jyeAeKWZLJ2FAEaHPgr9ibE",
+        "next_epoch_id": "5WdBoCxZ6xsBGYG6t6zkU6B7kFsfQohKJxtNYRpWTt9H",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-25T01:07:32.987Z",
+        "balance": 1.0069878986576604e+26,
+        "earnings": 1.4846090937680364e+22,
+        "block_height": 53495464,
+        "epoch_id": "5pjjZoBVfkcXGrFHtygrP1LkxszZHPs9yL7bTkoQpKVF",
+        "next_epoch_id": "6HQ1TruBxQrsCQHU1PXy6jyeAeKWZLJ2FAEaHPgr9ibE",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-24T12:57:10.256Z",
+        "balance": 1.0068394377482836e+26,
+        "earnings": 1.5016689558895574e+22,
+        "block_height": 53452264,
+        "epoch_id": "G3zMNYRGxJJii3CGt2bqsV9yZYDhtG3XcCnsAUwbuyt7",
+        "next_epoch_id": "5pjjZoBVfkcXGrFHtygrP1LkxszZHPs9yL7bTkoQpKVF",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-24T00:02:18.252Z",
+        "balance": 1.0066892708526947e+26,
+        "earnings": 1.425935565019352e+22,
+        "block_height": 53409064,
+        "epoch_id": "5GjmSKT6mGDCPzYgcRgARxpKqt67AD4pnWPYPpKAvwhz",
+        "next_epoch_id": "G3zMNYRGxJJii3CGt2bqsV9yZYDhtG3XcCnsAUwbuyt7",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-23T10:58:30.042Z",
+        "balance": 1.0065466772961927e+26,
+        "earnings": 1.4512777788456889e+22,
+        "block_height": 53365864,
+        "epoch_id": "EWeamTTxnuNqAy9mZedZTJZGFAEUTbhLgjZEoxBQndQ8",
+        "next_epoch_id": "5GjmSKT6mGDCPzYgcRgARxpKqt67AD4pnWPYPpKAvwhz",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-22T22:52:08.580Z",
+        "balance": 1.0064015495183082e+26,
+        "earnings": 1.4521101037877961e+22,
+        "block_height": 53322664,
+        "epoch_id": "z2k22Swyy6vR8GHBXE98B2cVpNznAHpEhh2rguuse7t",
+        "next_epoch_id": "EWeamTTxnuNqAy9mZedZTJZGFAEUTbhLgjZEoxBQndQ8",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-22T10:32:41.200Z",
+        "balance": 1.0062563385079294e+26,
+        "earnings": 1.4897309138054917e+22,
+        "block_height": 53279464,
+        "epoch_id": "66uJyfyVk6wySUqGdkSze6ezUv8EyrW8Y6gwVBCRRVp3",
+        "next_epoch_id": "z2k22Swyy6vR8GHBXE98B2cVpNznAHpEhh2rguuse7t",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-21T22:12:47.217Z",
+        "balance": 1.0061073654165488e+26,
+        "earnings": 1.4652316510912592e+22,
+        "block_height": 53236264,
+        "epoch_id": "GhErzKtbLFqPxYMLJuM2aVvNVe5h2UiMUuDeyUQ5KfTL",
+        "next_epoch_id": "66uJyfyVk6wySUqGdkSze6ezUv8EyrW8Y6gwVBCRRVp3",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-21T09:33:33.688Z",
+        "balance": 1.0059608422514397e+26,
+        "earnings": 1.4868144456218213e+22,
+        "block_height": 53193064,
+        "epoch_id": "EBPxivpqncuffUSiCDkEbZ3YHzQQMA6XGaA7fMJyk1SX",
+        "next_epoch_id": "GhErzKtbLFqPxYMLJuM2aVvNVe5h2UiMUuDeyUQ5KfTL",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-20T21:06:41.995Z",
+        "balance": 1.0058121608068775e+26,
+        "earnings": 1.4626520664705472e+22,
+        "block_height": 53149864,
+        "epoch_id": "AdXHdQYCLeDooLDVnSnDXY8F56QH2MvP7QUPS14Za8nT",
+        "next_epoch_id": "EBPxivpqncuffUSiCDkEbZ3YHzQQMA6XGaA7fMJyk1SX",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-20T08:26:51.425Z",
+        "balance": 1.0056658956002305e+26,
+        "earnings": 1.4952955733471545e+22,
+        "block_height": 53106664,
+        "epoch_id": "6CV3qWeuJnKAZcKdwhSjjGPxA1Re5Z7vGZKdgvmMcEKu",
+        "next_epoch_id": "AdXHdQYCLeDooLDVnSnDXY8F56QH2MvP7QUPS14Za8nT",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-19T19:59:17.615Z",
+        "balance": 1.0055163660428958e+26,
+        "earnings": 1.5432370980005589e+22,
+        "block_height": 53063464,
+        "epoch_id": "ArCsf9cycxUL6jydLKK49boW8BYwuyK12N1DCYsaCNKQ",
+        "next_epoch_id": "6CV3qWeuJnKAZcKdwhSjjGPxA1Re5Z7vGZKdgvmMcEKu",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-19T07:21:04.143Z",
+        "balance": 1.0053620423330957e+26,
+        "earnings": 1.5655835886649698e+22,
+        "block_height": 53020264,
+        "epoch_id": "9NJwZcgJ66D21NvPdMAK4tnmP8r1U8Zi4tCpR6gRgKD1",
+        "next_epoch_id": "ArCsf9cycxUL6jydLKK49boW8BYwuyK12N1DCYsaCNKQ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-18T18:36:22.687Z",
+        "balance": 1.0052054839742292e+26,
+        "earnings": 1.5989932386402716e+22,
+        "block_height": 52977064,
+        "epoch_id": "GEVBLmzi8k9dorE1buWs79P3ZANaxDpDAf16w2P3eAud",
+        "next_epoch_id": "9NJwZcgJ66D21NvPdMAK4tnmP8r1U8Zi4tCpR6gRgKD1",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-18T05:24:40.667Z",
+        "balance": 1.0050455846503652e+26,
+        "earnings": 1.5887723946385785e+22,
+        "block_height": 52933864,
+        "epoch_id": "3nJELTbvN7QHT92v2drL34GN33kUHt6mNqEXY2soPbAW",
+        "next_epoch_id": "GEVBLmzi8k9dorE1buWs79P3ZANaxDpDAf16w2P3eAud",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-17T15:46:55.170Z",
+        "balance": 1.0048867074109013e+26,
+        "earnings": 1.5370504923175828e+22,
+        "block_height": 52890664,
+        "epoch_id": "7Cba4ikQnAG92snaU96SRXs4BD4FtDoj36jCNmj8U9BA",
+        "next_epoch_id": "3nJELTbvN7QHT92v2drL34GN33kUHt6mNqEXY2soPbAW",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-17T02:12:15.064Z",
+        "balance": 1.0047330023616696e+26,
+        "earnings": 1.5601403788738907e+22,
+        "block_height": 52847464,
+        "epoch_id": "Ae2TB4V4tLQGX36wz5R5DM8fn6vX93S5n1RwY8RjDWE5",
+        "next_epoch_id": "7Cba4ikQnAG92snaU96SRXs4BD4FtDoj36jCNmj8U9BA",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-16T13:04:17.368Z",
+        "balance": 1.0045769883237822e+26,
+        "earnings": 1.5393358814023248e+22,
+        "block_height": 52804264,
+        "epoch_id": "4UgG9UwzzCd92ABmwdAvUCbiYxAH12sD8yiBsbYe9Ug7",
+        "next_epoch_id": "Ae2TB4V4tLQGX36wz5R5DM8fn6vX93S5n1RwY8RjDWE5",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-15T23:45:12.154Z",
+        "balance": 1.004423054735642e+26,
+        "earnings": 1.53986288281105e+22,
+        "block_height": 52761064,
+        "epoch_id": "14trzzSiqDwH365EfFMK13U69iWLnFLNRDZJqoRK1SsP",
+        "next_epoch_id": "4UgG9UwzzCd92ABmwdAvUCbiYxAH12sD8yiBsbYe9Ug7",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-15T10:37:00.492Z",
+        "balance": 1.0042690684473608e+26,
+        "earnings": 1.5750748184228758e+22,
+        "block_height": 52717864,
+        "epoch_id": "9PaehMSJ26EHc6WGrNtLqq6PcczkKYjqEFTkTEeiFMq9",
+        "next_epoch_id": "14trzzSiqDwH365EfFMK13U69iWLnFLNRDZJqoRK1SsP",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-14T21:20:55.781Z",
+        "balance": 1.0041115609655186e+26,
+        "earnings": 1.5162680836910215e+22,
+        "block_height": 52674664,
+        "epoch_id": "5ysJQEfbivWhCSXS9YKngFNQ9opNvuUaWEt1ZC5F3VMz",
+        "next_epoch_id": "9PaehMSJ26EHc6WGrNtLqq6PcczkKYjqEFTkTEeiFMq9",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-14T07:46:49.924Z",
+        "balance": 1.0039599341571495e+26,
+        "earnings": 1.5266755220899048e+22,
+        "block_height": 52631464,
+        "epoch_id": "6bL4o2iEQvAyWAxsWdUpcqqYH9MwszYFF6reGK5JyR5a",
+        "next_epoch_id": "5ysJQEfbivWhCSXS9YKngFNQ9opNvuUaWEt1ZC5F3VMz",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-13T18:50:06.255Z",
+        "balance": 1.0038072666049405e+26,
+        "earnings": 1.5644049476283202e+22,
+        "block_height": 52588264,
+        "epoch_id": "Gj617W9KNkD2nMSH7k1szBWQ5E3hKn9fjZRgLPRbkWp4",
+        "next_epoch_id": "6bL4o2iEQvAyWAxsWdUpcqqYH9MwszYFF6reGK5JyR5a",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-13T05:47:52.810Z",
+        "balance": 1.0036508261101776e+26,
+        "earnings": 1.5840853241255478e+22,
+        "block_height": 52545064,
+        "epoch_id": "GJEgoTfUjfwkKuBAQtKP5fa4oLghH5EtT16kAXovRXas",
+        "next_epoch_id": "Gj617W9KNkD2nMSH7k1szBWQ5E3hKn9fjZRgLPRbkWp4",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-12T16:19:27.906Z",
+        "balance": 1.003492417577765e+26,
+        "earnings": 1.5372287016209152e+22,
+        "block_height": 52501864,
+        "epoch_id": "8wsZBsi6HiXzryw4yKc5QXaBKCUDpPkLMzMyNnsYChT8",
+        "next_epoch_id": "GJEgoTfUjfwkKuBAQtKP5fa4oLghH5EtT16kAXovRXas",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-12T02:41:13.871Z",
+        "balance": 1.003338694707603e+26,
+        "earnings": 1.534609099400055e+22,
+        "block_height": 52458664,
+        "epoch_id": "3j6mxMGjKnZgzj6XKycvDXr2g1BLSat9puRTo26BA632",
+        "next_epoch_id": "8wsZBsi6HiXzryw4yKc5QXaBKCUDpPkLMzMyNnsYChT8",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-11T13:33:35.734Z",
+        "balance": 1.003185233797663e+26,
+        "earnings": 1.5425030781184764e+22,
+        "block_height": 52415464,
+        "epoch_id": "DgfwbovUx7AxWBzaAKuyUoFcuiygNHeR8XWY9HcB2tzU",
+        "next_epoch_id": "3j6mxMGjKnZgzj6XKycvDXr2g1BLSat9puRTo26BA632",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-11T00:28:03.369Z",
+        "balance": 1.0030309834898511e+26,
+        "earnings": 1.5071380783367427e+22,
+        "block_height": 52372264,
+        "epoch_id": "HrmDKzZHqQJqNDxUPgor3FPuQDzHxSudaGaBrLpwCRrq",
+        "next_epoch_id": "DgfwbovUx7AxWBzaAKuyUoFcuiygNHeR8XWY9HcB2tzU",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-10T11:17:05.762Z",
+        "balance": 1.0028802696820175e+26,
+        "earnings": 1.5217481826882e+22,
+        "block_height": 52329064,
+        "epoch_id": "Ac9pSyYDsZqHMXMBo5FWo7LwaJBq5Wg4FwhWNm28m5xs",
+        "next_epoch_id": "HrmDKzZHqQJqNDxUPgor3FPuQDzHxSudaGaBrLpwCRrq",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-09T22:23:55.260Z",
+        "balance": 1.0027280948637486e+26,
+        "earnings": 1.5219697686306273e+22,
+        "block_height": 52285863,
+        "epoch_id": "BTYR7At6dNQdQmiEmtAiudCHCQdQ6PSkFtcdwvVVXSoR",
+        "next_epoch_id": "Ac9pSyYDsZqHMXMBo5FWo7LwaJBq5Wg4FwhWNm28m5xs",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-09T09:22:17.604Z",
+        "balance": 1.0025758978868856e+26,
+        "earnings": 1.5086746686256562e+22,
+        "block_height": 52242663,
+        "epoch_id": "2wpUZvQt6sCWE32U4gLfP6x6oqNJpHWUxLsCdUUEC6sQ",
+        "next_epoch_id": "BTYR7At6dNQdQmiEmtAiudCHCQdQ6PSkFtcdwvVVXSoR",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-08T20:20:00.439Z",
+        "balance": 1.002425030420023e+26,
+        "earnings": 1.4596981178785291e+22,
+        "block_height": 52199463,
+        "epoch_id": "CRCHTrgAmszvXcnLo66BnpbeaMQubiZJSwy3wUQGpkSL",
+        "next_epoch_id": "2wpUZvQt6sCWE32U4gLfP6x6oqNJpHWUxLsCdUUEC6sQ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-08T07:24:32.275Z",
+        "balance": 1.0022790606082352e+26,
+        "earnings": 1.509074434825411e+22,
+        "block_height": 52156263,
+        "epoch_id": "FANSy7mVtScv2URXFGCaWw44YnCVReHmrZYaN68Kq2dT",
+        "next_epoch_id": "CRCHTrgAmszvXcnLo66BnpbeaMQubiZJSwy3wUQGpkSL",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-07T18:52:48.520Z",
+        "balance": 1.0021281531647526e+26,
+        "earnings": 1.4596533014942412e+22,
+        "block_height": 52113063,
+        "epoch_id": "FVcgGVMgvd7zd9vMmhmJ9xFTGraRM29dttZBXWJKEzHP",
+        "next_epoch_id": "FANSy7mVtScv2URXFGCaWw44YnCVReHmrZYaN68Kq2dT",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-07T05:55:39.116Z",
+        "balance": 1.0019821878346032e+26,
+        "earnings": 1.568752502179193e+22,
+        "block_height": 52069863,
+        "epoch_id": "3GfnSknMdFHSS1pXs1ounWUtDbbkQm9fWMueRtE9x3k3",
+        "next_epoch_id": "FVcgGVMgvd7zd9vMmhmJ9xFTGraRM29dttZBXWJKEzHP",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-06T17:24:10.900Z",
+        "balance": 1.0018253125843853e+26,
+        "earnings": 1.5931137555665785e+22,
+        "block_height": 52026663,
+        "epoch_id": "GU1zrLGRUdDiwUzBf8mnqwhtW1QBAJ4Stt1QoVhFNbr9",
+        "next_epoch_id": "3GfnSknMdFHSS1pXs1ounWUtDbbkQm9fWMueRtE9x3k3",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-06T03:56:37.260Z",
+        "balance": 1.0016660012088286e+26,
+        "earnings": 1.4900114957141906e+22,
+        "block_height": 51983463,
+        "epoch_id": "3PyxhdcfcbiULKhruZbpkhLECLDfdHWhafkf4DUedmto",
+        "next_epoch_id": "GU1zrLGRUdDiwUzBf8mnqwhtW1QBAJ4Stt1QoVhFNbr9",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-05T14:27:13.222Z",
+        "balance": 1.0015170000592572e+26,
+        "earnings": 1.487410959813512e+22,
+        "block_height": 51940263,
+        "epoch_id": "82bAMed8c3ZwEvwPX7Y7twMrJz6bPj5DXQQNb7bhdgcT",
+        "next_epoch_id": "3PyxhdcfcbiULKhruZbpkhLECLDfdHWhafkf4DUedmto",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-05T01:39:47.895Z",
+        "balance": 1.0013682589632758e+26,
+        "earnings": 1.5312655027781373e+22,
+        "block_height": 51897063,
+        "epoch_id": "CFptUKG4La5HNK4iF86a2VPtBhjpkC5MaLHWmNkZ4Wnq",
+        "next_epoch_id": "82bAMed8c3ZwEvwPX7Y7twMrJz6bPj5DXQQNb7bhdgcT",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-04T12:54:30.589Z",
+        "balance": 1.001215132412998e+26,
+        "earnings": 1.4824496447603385e+22,
+        "block_height": 51853863,
+        "epoch_id": "7xFDjz5GooM1wAAMF8s6tMixQoPtAAEDQXNXbNzByM9x",
+        "next_epoch_id": "CFptUKG4La5HNK4iF86a2VPtBhjpkC5MaLHWmNkZ4Wnq",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-03T23:46:21.649Z",
+        "balance": 1.001066887448522e+26,
+        "earnings": 1.5122723489294794e+22,
+        "block_height": 51810663,
+        "epoch_id": "GiWtfMRDZZyi4yFfSZsDo81EfkJ84kecWRA5mx9jEsia",
+        "next_epoch_id": "7xFDjz5GooM1wAAMF8s6tMixQoPtAAEDQXNXbNzByM9x",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-03T11:04:45.355Z",
+        "balance": 1.000915660213629e+26,
+        "earnings": 1.5043079559952026e+22,
+        "block_height": 51767463,
+        "epoch_id": "FS6PYr9oesrqTM3GVae7JTeoAm3bvPD3h8izotPjenUk",
+        "next_epoch_id": "GiWtfMRDZZyi4yFfSZsDo81EfkJ84kecWRA5mx9jEsia",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-02T22:08:16.293Z",
+        "balance": 1.0007652294180295e+26,
+        "earnings": 1.5095814677543562e+22,
+        "block_height": 51724263,
+        "epoch_id": "CsbuSNaaeDRzqMvRtrXy9eVqFeeYk8E3WmL5ZMPNJ6kz",
+        "next_epoch_id": "FS6PYr9oesrqTM3GVae7JTeoAm3bvPD3h8izotPjenUk",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-02T09:14:03.529Z",
+        "balance": 1.0006142712712541e+26,
+        "earnings": 1.5426624789491298e+22,
+        "block_height": 51681063,
+        "epoch_id": "2qrFo8csHNu24Btmbs77iZYqh526dUmMYNR32eHQ1zTJ",
+        "next_epoch_id": "CsbuSNaaeDRzqMvRtrXy9eVqFeeYk8E3WmL5ZMPNJ6kz",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-01T20:16:34.362Z",
+        "balance": 1.0004600050233592e+26,
+        "earnings": 1.5078269283140612e+22,
+        "block_height": 51637863,
+        "epoch_id": "EjvXurHMzqAMnyTPK6e6ZzQeFN3bqwYhNuQCvwgEDNfi",
+        "next_epoch_id": "2qrFo8csHNu24Btmbs77iZYqh526dUmMYNR32eHQ1zTJ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-11-01T07:02:12.123Z",
+        "balance": 1.0003092223305278e+26,
+        "earnings": 1.5333997964664662e+22,
+        "block_height": 51594663,
+        "epoch_id": "DfzuHiFtqK6s3Booi2MocfjrE64v99MTCdCj2oqMB3rg",
+        "next_epoch_id": "EjvXurHMzqAMnyTPK6e6ZzQeFN3bqwYhNuQCvwgEDNfi",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-10-31T18:05:24.587Z",
+        "balance": 1.0001558823508811e+26,
+        "earnings": 1.558823508810791e+22,
+        "block_height": 51551463,
+        "epoch_id": "BUAiPgzZFuYQWM7fWFpCpqcJzhd2Z2uvLBHRc2bq9LjJ",
+        "next_epoch_id": "DfzuHiFtqK6s3Booi2MocfjrE64v99MTCdCj2oqMB3rg",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-10-31T04:54:35.227Z",
+        "balance": 1e+26,
+        "earnings": 0,
+        "block_height": 51508263,
+        "epoch_id": "6AivSWGheCvvkv2Z7PyHrCRJVagygMhv4J76c8hFuCE6",
+        "next_epoch_id": "BUAiPgzZFuYQWM7fWFpCpqcJzhd2Z2uvLBHRc2bq9LjJ",
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-10-30T16:53:39.158Z",
+        "balance": 1e+26,
+        "block_hash": "BLvLAPGrsdsfN9TfoJzTDqxXgrrnG2hE5RoGUBPCPzay",
+        "block_height": 51469780,
+        "epoch_id": "6AivSWGheCvvkv2Z7PyHrCRJVagygMhv4J76c8hFuCE6",
+        "next_epoch_id": "BUAiPgzZFuYQWM7fWFpCpqcJzhd2Z2uvLBHRc2bq9LjJ",
+        "earnings": 0,
+        "deposit": 0,
+        "withdrawal": 0
+    },
+    {
+        "timestamp": "2021-10-30T16:53:39.158Z",
+        "balance": 1e+26,
+        "hash": "FShAiHofxY2MA6KEvnPoeQyyP9stAs7n91m3LAGASKPY",
+        "block_height": 51469780,
+        "epoch_id": "6AivSWGheCvvkv2Z7PyHrCRJVagygMhv4J76c8hFuCE6",
+        "next_epoch_id": "BUAiPgzZFuYQWM7fWFpCpqcJzhd2Z2uvLBHRc2bq9LjJ",
+        "deposit": 1e+26,
+        "withdrawal": 0,
+        "earnings": 0
+    }
+];

--- a/testdata/stakingbalances.js
+++ b/testdata/stakingbalances.js
@@ -1,4 +1,4 @@
-export const stakingBalances = [
+export const dokiaCapitalStakingBalances = [
     {
         "timestamp": "2023-11-25T12:15:49.970Z",
         "balance": 0,
@@ -12815,5 +12815,127 @@ export const stakingBalances = [
         "deposit": 1e+26,
         "withdrawal": 0,
         "earnings": 0
+    }
+];
+
+export const dokiacapitaltransactions = [
+    {
+        block_hash: 'HRNCVGdq8RtbeTEAmyjbjrHSFqAg5sQrMRveaHkALvE5',
+        block_timestamp: '1700805291286078571',
+        hash: 'Gu7kjCsPaoYQUdQpvxHm6L2LvStZ6go7AGFypQWpNCJx',
+        action_index: 0,
+        signer_id: 'dokiacapital.poolv1.near',
+        receiver_id: 'petersalomonsen.near',
+        action_kind: 'TRANSFER',
+        args: { deposit: '107781876121379430562795333' },
+        balance: '140070757487458768247810272'
+    },
+    {
+        block_hash: 'ByGmv11KH9T8N1ULwLMXN31BJ1upMf8Ry5Rfi2v4ZMC4',
+        block_timestamp: '1700805289955243055',
+        hash: 'Gu7kjCsPaoYQUdQpvxHm6L2LvStZ6go7AGFypQWpNCJx',
+        action_index: 0,
+        signer_id: 'petersalomonsen.near',
+        receiver_id: 'dokiacapital.poolv1.near',
+        action_kind: 'FUNCTION_CALL',
+        args: {
+            gas: 175000000000000,
+            deposit: '0',
+            args_json: {},
+            method_name: 'withdraw_all'
+        },
+        balance: '140070757487458768247810272'
+    },
+    {
+        block_hash: '9pSfArFzMaVHGL98N4pQZNU5FqCxCgogkfTqiqxHLA5Z',
+        block_timestamp: '1700501307576148206',
+        hash: '8b3CKnA6y7PKHr4TFz6X4ntJ4PHWtQTHpkdtzqkbHL4e',
+        action_index: 0,
+        signer_id: 'petersalomonsen.near',
+        receiver_id: 'dokiacapital.poolv1.near',
+        action_kind: 'FUNCTION_CALL',
+        args: {
+            gas: 125000000000000,
+            deposit: '0',
+            args_json: {},
+            method_name: 'unstake_all'
+        },
+        balance: '28550460865852622885014943'
+    },
+    {
+        block_hash: '2BbALSrcbohGrUxujSrDbVYG6TsNKhUE3VBqnNHkAeJ6',
+        block_timestamp: '1670965041080322963',
+        hash: '4syZCwYR9MdRvfPPV1FCt6XPtdSQX2PGyfA58tcbBy4w',
+        action_index: 0,
+        signer_id: 'petersalomonsen.near',
+        receiver_id: 'dokiacapital.poolv1.near',
+        action_kind: 'FUNCTION_CALL',
+        args: {
+            gas: 125000000000000,
+            deposit: '100000000000000000000000000',
+            args_json: {},
+            method_name: 'deposit_and_stake'
+        },
+        balance: '35952228543679286747001536'
+    },
+    {
+        block_hash: '991n8RQDRHSMP54aKLorU2thwdU6U6CXzQzB3NQM4H2x',
+        block_timestamp: '1670965004801621827',
+        hash: 'GJof1hwvnEtw3TpV5K9XZwpQfxrYgM2af38EHmdUnZSW',
+        action_index: 0,
+        signer_id: 'dokiacapital.poolv1.near',
+        receiver_id: 'petersalomonsen.near',
+        action_kind: 'TRANSFER',
+        args: { deposit: '111780575950537918979824444' },
+        balance: '135953495946786343047001536'
+    },
+    {
+        block_hash: 'A2rbaqpKfiY3471AfGkxQEB5hLkBKMJYQEdSwBTQEADx',
+        block_timestamp: '1670965003692394709',
+        hash: 'GJof1hwvnEtw3TpV5K9XZwpQfxrYgM2af38EHmdUnZSW',
+        action_index: 0,
+        signer_id: 'petersalomonsen.near',
+        receiver_id: 'dokiacapital.poolv1.near',
+        action_kind: 'FUNCTION_CALL',
+        args: {
+            gas: 175000000000000,
+            deposit: '0',
+            args_json: {},
+            method_name: 'withdraw_all'
+        },
+        balance: '135953495946786343047001536'
+    },
+    {
+        block_hash: 'BD7d8dMnUHrUKbwJdmoMminzP89z6GifY3L7WtEVmtmf',
+        block_timestamp: '1670648821661501076',
+        hash: '8EDs6Rn1LPmG5hFopCErGTTYA5YTGxEbNeBNb37Jkrfg',
+        action_index: 0,
+        signer_id: 'petersalomonsen.near',
+        receiver_id: 'dokiacapital.poolv1.near',
+        action_kind: 'FUNCTION_CALL',
+        args: {
+            gas: 125000000000000,
+            deposit: '0',
+            args_json: {},
+            method_name: 'unstake_all'
+        },
+        balance: '24190526013605135667177092'
+    },
+    {
+        block_hash: 'BLvLAPGrsdsfN9TfoJzTDqxXgrrnG2hE5RoGUBPCPzay',
+        block_timestamp: '1635612819158468503',
+        hash: 'FShAiHofxY2MA6KEvnPoeQyyP9stAs7n91m3LAGASKPY',
+        action_index: 0,
+        signer_id: 'petersalomonsen.near',
+        receiver_id: 'dokiacapital.poolv1.near',
+        action_kind: 'FUNCTION_CALL',
+        args: {
+            gas: 125000000000000,
+            deposit: '100000000000000000000000000',
+            args_json: {},
+            args_base64: 'e30=',
+            method_name: 'deposit_and_stake'
+        },
+        balance: '57076767884778730300000000'
     }
 ];

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -108,15 +108,15 @@ export default {
 
           if (body === undefined) {
             try {
-              response = await route.fetch();
+              const response = await route.fetch();
               status = response.status();
               body = await response.text();
-              if (response.ok()) {
+              if (response.ok() && !url.endsWith('/v1/blocks/count')) {
                 nearblockscache[url] = body;
                 await writeFile(nearBlocksCacheURL, JSON.stringify(nearblockscache, null, 1));
               }
-            } catch(e) {
-              
+            } catch (e) {
+              await writeFile('routeerror.txt', `${url} ${status} ${JSON.stringify(headers)}: ${body}, ${e}`);
             }
           } else {
             headers = {
@@ -124,6 +124,7 @@ export default {
               'X-Cache-Hit': 'true'
             };
           }
+
           await route.fulfill({
             body, headers, status
           });

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -74,15 +74,11 @@ export default {
                 const body = await response.text();
                 try {
                   const resultObj = JSON.parse(body);
-                  if (!resultObj.error) {
-                    if (storeInArchiveRpcCache) {
-                      archiveRpcCache[postdata] = JSON.stringify(resultObj);
-                      await writeFile(archiveRpcCacheURL, JSON.stringify(archiveRpcCache, null, 1));
-                    }
-                    return await route.fulfill({ body });
-                  } else {
-
+                  if (!resultObj.error && storeInArchiveRpcCache) {
+                    archiveRpcCache[postdata] = JSON.stringify(resultObj);
+                    await writeFile(archiveRpcCacheURL, JSON.stringify(archiveRpcCache, null, 1));
                   }
+                  return await route.fulfill({ body });                  
                 } catch (e) {
                   console.log('failed parsing result', e);
                 }

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -31,7 +31,7 @@ export default {
   testFramework: {
     config: {
       ui: 'bdd',
-      timeout: '120000',
+      timeout: '180000',
     },
   },
   plugins: [importMapsPlugin({


### PR DESCRIPTION
This PR fixes the issue that existing staking balances are re-fetched every time when updating data. It applies to the staking pools where the balance is now zero, but there have been funds staked earlier.

It also adjusts to the nearblocks free tier rate limit which is a maximum of 6 API calls per minute

Also fix that staking deposits and withdrawals were wrongly showing up as rewards ( after the switch to nearblocks )
