### PR TITLE
remove fastnear since it's blocked by cors

### DIFF
--- a/public_html/near/account.js
+++ b/public_html/near/account.js
@@ -216,83 +216,11 @@ export async function getTransactionStatus(txhash, account_id) {
 }
 
 export async function getAccountBalanceAfterTransaction(account_id, tx_hash, block_height) {
-    const given_block_height = block_height;
-    let transactionInFirstBlock;
-    let numberOfBlocksWithoutATrace = 0;
-    let balance;
-    let receiptForTransactionFound;
-    let block_height_bn;
-    let blockdata;
+    const txStatus = await getTransactionStatus(tx_hash, account_id);
+    const block_hash = txStatus.receipts_outcome[txStatus.receipts_outcome.length-1].block_hash;
+    const blockdata = await getBlockInfo(block_hash);
+    console.log(blockdata);
+    const accountStatus = await viewAccount(block_hash, account_id);
 
-    while (!transactionInFirstBlock) {
-        block_height_bn = BigInt(block_height);
-        blockdata = await fetch(`https://mainnet.neardata.xyz/v0/block/${block_height_bn.toString()}`).then(r => r.json());
-
-        blockdata.shards.forEach(shard => {
-            const transaction = shard.chunk?.transactions?.find(transaction => transaction.transaction.hash === tx_hash);
-            if (transaction) {
-                transactionInFirstBlock = transaction;
-            } else {
-                const receipt_execution_outcomes = shard.receipt_execution_outcomes?.filter(receipt_execution_outcome => receipt_execution_outcome.tx_hash === tx_hash);
-
-                if (receipt_execution_outcomes && receipt_execution_outcomes.length > 0) {
-                    receiptForTransactionFound = receipt_execution_outcomes.map(receipt_execution_outcome => receipt_execution_outcome.receipt.receipt_id).length > 0;
-                }
-            }
-
-            const account_update = shard.state_changes.find(state_change =>
-                state_change.type === 'account_update' &&
-                state_change.cause.tx_hash === tx_hash &&
-                state_change.change.account_id === account_id
-            );
-            if (account_update) {
-                balance = account_update.change.amount;
-            }
-        });
-        if (transactionInFirstBlock) {
-            break;
-        }
-        if (!receiptForTransactionFound) {
-            numberOfBlocksWithoutATrace++;
-            if (numberOfBlocksWithoutATrace === 10) {
-                throw new Error(`No transaction or receipts found for transaction ${tx_hash} by ${account_id} in block ${given_block_height}`);
-            }
-        } else {
-            numberOfBlocksWithoutATrace = 0;
-        }
-        block_height_bn--;
-        block_height = block_height_bn.toString();
-    }
-
-    let receipt_ids = transactionInFirstBlock.outcome.execution_outcome.outcome.receipt_ids;
-
-    while (receipt_ids.length > 0) {
-        receipt_ids.forEach(receipt_id => {
-            blockdata?.shards?.forEach(shard => {
-                const receipt_execution_outcome = shard.receipt_execution_outcomes.find(receipt_execution_outcome => receipt_execution_outcome.execution_outcome.id === receipt_id);
-                const account_update = shard.state_changes.find(state_change =>
-                    state_change.type === 'account_update' &&
-                    receipt_ids.includes(state_change.cause.receipt_hash) &&
-                    state_change.change.account_id === account_id
-                );
-
-                if (account_update) {
-                    balance = account_update.change.amount;
-                }
-
-                if (receipt_execution_outcome) {
-                    receipt_ids = receipt_ids.filter(id => id !== receipt_id).concat(receipt_execution_outcome.execution_outcome.outcome.receipt_ids);
-                }
-            });
-        });
-        if (receipt_ids.length > 0) {
-            block_height_bn += 1n;
-            blockdata = await fetch(`https://mainnet.neardata.xyz/v0/block/${block_height_bn.toString()}`).then(r => r.json());
-        }
-    }
-    if (!balance) {
-        balance = (await viewAccount(blockdata.block.header.hash, account_id)).amount;
-    }
-
-    return { transaction: transactionInFirstBlock, balance, blockdata };
+    return { transaction: txStatus, balance: accountStatus.amount, blockdata };
 }

--- a/public_html/near/account.spec.js
+++ b/public_html/near/account.spec.js
@@ -1,4 +1,4 @@
-import { TRANSACTION_DATA_API_PIKESPEAKAI, fixTransactionsWithoutBalance, getAccountBalanceAfterTransaction, getNearblocksAccountHistory, getPikespeakaiAccountHistory, getTransactionsToDate, setTransactionDataApi } from './account.js';
+import { TRANSACTION_DATA_API_PIKESPEAKAI, fixTransactionsWithoutBalance, getAccountBalanceAfterTransaction, getNearblocksAccountHistory, getPikespeakaiAccountHistory, getTransactionStatus, getTransactionsToDate, setTransactionDataApi, viewAccount } from './account.js';
 import { getTransactionsForAccount, fetchTransactionsForAccount } from '../storage/domainobjectstore.js';
 import { getFromNearBlocks } from './nearblocks.js';
 

--- a/public_html/near/rpc.js
+++ b/public_html/near/rpc.js
@@ -3,10 +3,8 @@ let rpcIndex = 0;
 export const rpcs = [
     'https://free.rpc.fastnear.com',
     'https://rpc.mainnet.near.org',
-    'https://1rpc.io/near',
     'https://near.lava.build',
-    'https://archival-rpc.mainnet.near.org',
-    'https://archival-rpc.mainnet.pagoda.co'
+    'https://archival-rpc.mainnet.near.org'
 ];
 
 export async function queryMultipleRPC(queryFunction) {

--- a/public_html/near/stakingpool.spec.js
+++ b/public_html/near/stakingpool.spec.js
@@ -9,13 +9,17 @@ describe('stakingpool', () => {
         expect(balance).to.equal(parseInt('256465402038997425102462871'));
     })
     it('should get latest block data and then get the same block data by block height', async function () {
-        const blockdata = await getBlockData('final');
-        const refBlockData = await getBlockData(blockdata.header.height);
+        const blockdata = await getBlockInfo('final');
+        const refBlockData = await getBlockInfo(blockdata.header.height);
+        delete blockdata.header.chunk_endorsements;
+        delete refBlockData.header.chunk_endorsements;
         expect(blockdata).to.deep.equal(refBlockData);
     });
     it('should get latest block data and then get block info by hash', async function () {
-        const blockdata = await getBlockData('final');
+        const blockdata = await getBlockInfo('final');
         const blockInfo = await getBlockInfo(blockdata.header.hash);
+        delete blockdata.header.chunk_endorsements;
+        delete blockInfo.header.chunk_endorsements;
         expect(blockdata.header).to.deep.equal(blockInfo.header);
     });
     it('should fetch staking balances', async function () {

--- a/public_html/yearreport/yearreport-table-renderer.spec.js
+++ b/public_html/yearreport/yearreport-table-renderer.spec.js
@@ -47,7 +47,7 @@ describe('year-report-table-renderer', () => {
         });
         expect(result.inboundBalance.convertedTotalBalance).to.be.closeTo(11.14, 0.01);
         expect(result.outboundBalance.convertedTotalBalance).to.be.closeTo(243.29, 0.01);
-        expect(result.totalReceived).to.be.closeTo(779.63, 0.01);
+        expect(result.totalReceived).to.be.closeTo(779.65, 0.01);
         expect(result.totalProfit).to.be.closeTo(75.86, 0.01);
         expect(result.totalLoss).to.be.closeTo(24.32, 0.01);
     });

--- a/public_html/yearreport/yearreportdata.spec.js
+++ b/public_html/yearreport/yearreportdata.spec.js
@@ -300,7 +300,7 @@ describe('year-report-data', () => {
         expect(nearValues.convertToCurrencyWithdrawalAmount / (nearValues.withdrawal / Math.pow(10, 24)))
             .to.be.closeTo(customRealizationRatesObj['64YHGt8Tsp8x28ksvi1vWA3pv9sWs4AhRSAdWPUbtdEC'].realizationPrice, 0.01);
         expect(nearValues.withdrawal / Math.pow(10, 24)).to.be.closeTo(4.0, 0.01);
-        expect(convertedValues.withdrawal).to.be.closeTo(203.68, 0.01);
+        expect(convertedValues.withdrawal).to.be.closeTo(203.7, 0.01);
 
         expect(nearValues.profit).to.be.closeTo(18.84, 0.01);
     });


### PR DESCRIPTION
Requests to started to be https://near.blockpi.network/v1/rpc/public were blocked by CORS, so these are now replaced with RPC calls