### PR TITLE
Back to nearblocks

### DIFF
--- a/public_html/near/account.js
+++ b/public_html/near/account.js
@@ -1,7 +1,6 @@
 import { setProgressbarValue } from '../ui/progress-bar.js';
 import { getAccountTransactionsMetaData, getAndCacheTransactions } from './fastnear.js';
 import { getFromNearBlocks } from './nearblocks.js';
-import { getArchiveNodeUrl } from './network.js';
 import { retry } from './retry.js';
 import { queryMultipleRPC } from './rpc.js';
 import { getBlockInfo } from './stakingpool.js';
@@ -210,7 +209,7 @@ export async function fixTransactionsWithoutBalance({ account, transactions }) {
 }
 
 export async function getTransactionStatus(txhash, account_id) {
-    return (await fetch(getArchiveNodeUrl(), {
+    const createTransactionStatusQuery = async (rpcUrl) => fetch(rpcUrl, {
         method: 'POST',
         headers: {
             'content-type': 'application/json'
@@ -222,11 +221,12 @@ export async function getTransactionStatus(txhash, account_id) {
             "params": [txhash, account_id]
         }
         )
-    }).then(r => r.json())).result;
+    });
+    return (await queryMultipleRPC(createTransactionStatusQuery)).result;
 }
 
 export async function getTransactionStatusWithReceipts(tx_hash, sender_account_id) {
-    return (await fetch(getArchiveNodeUrl(), {
+    const createTransactionStatusWithReceiptsQuery = async (rpcUrl) => fetch(rpcUrl, {
         method: 'POST',
         headers: {
             'content-type': 'application/json'
@@ -238,11 +238,12 @@ export async function getTransactionStatusWithReceipts(tx_hash, sender_account_i
             "params": {
                 tx_hash,
                 sender_account_id,
-                "wait_until": "EXECUTED"
+                "wait_until": "NONE"
             }
         }
         )
-    }).then(r => r.json())).result;
+    });
+    return (await queryMultipleRPC(createTransactionStatusWithReceiptsQuery)).result;
 }
 
 

--- a/public_html/near/account.js
+++ b/public_html/near/account.js
@@ -15,7 +15,7 @@ export const TRANSACTION_DATA_API_FASTNEAR = 'fastnear';
 export function getTransactionDataApi() {
     const transactionDataApi = localStorage.getItem(TRANSACTION_DATA_API_LOCALSTORAGE_KEY);
     if (transactionDataApi == null) {
-        return TRANSACTION_DATA_API_FASTNEAR;
+        return TRANSACTION_DATA_API_NEARBLOCKS;
     } else {
         return transactionDataApi;
     }
@@ -225,13 +225,34 @@ export async function getTransactionStatus(txhash, account_id) {
     }).then(r => r.json())).result;
 }
 
+export async function getTransactionStatusWithReceipts(tx_hash, sender_account_id) {
+    return (await fetch(getArchiveNodeUrl(), {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+            "jsonrpc": "2.0",
+            "id": "dontcare",
+            "method": "tx",
+            "params": {
+                tx_hash,
+                sender_account_id,
+                "wait_until": "EXECUTED"
+            }
+        }
+        )
+    }).then(r => r.json())).result;
+}
+
+
 function findDeepestReceipt(transactionData) {
-    const receipts = transactionData.receipts;
+    const receipts = transactionData.receipts_outcome;
 
     // Create a map of receipts by their IDs for quick lookup
     const receiptMap = new Map();
     receipts.forEach((receipt) => {
-        receiptMap.set(receipt.execution_outcome.id, receipt);
+        receiptMap.set(receipt.id, receipt);
     });
 
     // Helper function to traverse receipts and calculate depth
@@ -240,7 +261,7 @@ function findDeepestReceipt(transactionData) {
         if (!receipt) return [];
 
         // Traverse child receipts
-        const childReceiptIds = receipt.execution_outcome.outcome.receipt_ids || [];
+        const childReceiptIds = receipt.outcome.receipt_ids || [];
         const childTraversals = childReceiptIds.flatMap((childId) =>
             traverseReceipt(childId, depth + 1)
         );
@@ -250,7 +271,7 @@ function findDeepestReceipt(transactionData) {
     }
 
     // Start traversal from the root receipt(s)
-    const rootReceiptIds = transactionData.execution_outcome.outcome.receipt_ids || [];
+    const rootReceiptIds = transactionData.transaction_outcome.outcome.receipt_ids || [];
     const allReceipts = rootReceiptIds.flatMap((id) => traverseReceipt(id));
 
     // Find the receipt with the maximum depth and latest position in the array
@@ -267,10 +288,10 @@ function findDeepestReceipt(transactionData) {
 }
 
 
-export async function getAccountBalanceAfterTransaction(account_id, tx_hash, block_height) {
-    const transaction = await getAndCacheTransactions(account_id, tx_hash, block_height);
+export async function getAccountBalanceAfterTransaction(account_id, tx_hash) {
+    const transaction = await getTransactionStatusWithReceipts(tx_hash, account_id);
     const finalReceipt = findDeepestReceipt(transaction);
-    const balance = (await viewAccount(finalReceipt.receipt.execution_outcome.block_hash, account_id)).amount;
+    const balance = (await viewAccount(finalReceipt.receipt.block_hash, account_id)).amount;
     return { transaction, balance };
 }
 

--- a/public_html/near/account.spec.js
+++ b/public_html/near/account.spec.js
@@ -5,9 +5,7 @@ import { getFromNearBlocks } from './nearblocks.js';
 describe('nearaccount transactions petersalomonsen.near', function () {
     const account = 'petersalomonsen.near';
     const getBalanceForTxHash = async (txHash, accountId) => {
-        const transaction = await getFromNearBlocks(`/v1/txns/${txHash}`);
-        const block_height = transaction.txns[0].block.block_height;
-        const { balance } = await getAccountBalanceAfterTransaction(accountId, txHash, block_height);
+        const { balance } = await getAccountBalanceAfterTransaction(accountId, txHash);
         return balance;
     };
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -19,7 +19,7 @@ const importMapStart = indexHtml.indexOf('<script type="importmap">') + '<script
 const importMapEnd = indexHtml.indexOf('</script>', importMapStart);
 const importMap = JSON.parse(indexHtml.substring(importMapStart, importMapEnd));
 
-const storeInArchiveRpcCache = false;
+const storeInArchiveRpcCache = true;
 
 export default {
   files: [
@@ -89,6 +89,7 @@ export default {
             }
           } catch (e) {
             console.error('failed to handle route', e);
+            return await route.abort("connectionfailed");
           }
         };
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -19,7 +19,7 @@ const importMapStart = indexHtml.indexOf('<script type="importmap">') + '<script
 const importMapEnd = indexHtml.indexOf('</script>', importMapStart);
 const importMap = JSON.parse(indexHtml.substring(importMapStart, importMapEnd));
 
-const storeInArchiveRpcCache = true;
+const storeInArchiveRpcCache = process.env.STORE_IN_ARCHIVE_RPC_CACHE;
 
 export default {
   files: [


### PR DESCRIPTION
FASTNEAR explorer API does only have up to November 2024. Reverting to nearblocks API, but there also some improvements in terms of alternating RPCs used to fetch transaction data.

Discussed in the conversation here: https://t.me/fast_near/82

Also we'll keep an eye on FASTNEAR if there will be a service to get historic transaction hashes, as mentioned in the discussion. What is needed for this application is to get a list of historic transaction hashes, and then the actual can transactions can be retrieved from archive RPCs.