### PR TITLE
feat: Add expense classification for counterparties

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,0 +1,31 @@
+Build the Ariz Portfolio app and deploy it to the ariz-gateway NEAR contract.
+
+The ariz-gateway repo (https://github.com/ArizHQ/ariz-gateway) should be cloned as a sibling directory to this repo.
+
+## Steps
+
+1. **Build the app bundle** (in this repo):
+   ```
+   yarn dist
+   ```
+   This runs rollup to bundle `public_html/index.html` into a single `dist/index.html` file with all JS inlined.
+
+2. **Base64-encode and copy to contract** (ariz-gateway is in `../ariz-gateway`):
+   ```
+   base64 -i dist/index.html -o ../ariz-gateway/contract/src/web4/index.html.base64
+   ```
+
+3. **Build the NEAR contract**:
+   ```
+   cd ../ariz-gateway/contract && cargo near build non-reproducible-wasm
+   ```
+   This produces `target/near/ariz_gateway.wasm`.
+
+4. **Deploy the contract**:
+   ```
+   cd ../ariz-gateway/contract && near contract deploy arizportfolio.near use-file target/near/ariz_gateway.wasm without-init-call network-config mainnet sign-with-keychain send
+   ```
+
+5. **Verify** by checking https://arizportfolio.near.page in a browser.
+
+IMPORTANT: Always ask for confirmation before step 4 (deploy). Show the wasm file size and confirm the user wants to deploy to mainnet.

--- a/public_html/counterparties/counterparties-page.component.html.js
+++ b/public_html/counterparties/counterparties-page.component.html.js
@@ -39,15 +39,17 @@ export default /*html*/ `
         <p class="small text-muted">
             All incoming transfers from external accounts are classified as <strong>deposit</strong> by default.
             Mark accounts as <strong>received</strong> to classify their incoming transfers as external income.
-            Both deposit and received enter FIFO cost basis at the same price — the distinction is for income reporting only.
+            Mark accounts as <strong>expense</strong> to classify outgoing transfers as expenses (not withdrawals/realizations).
+            Both deposit and received enter FIFO cost basis at the same price — the distinction is for reporting only.
         </p>
         <div class="filter-group mb-3">
             <input type="text" class="form-control form-control-sm" id="searchInput" placeholder="Search counterparty..." style="max-width: 300px;">
             <select class="form-select form-select-sm" id="filterSelect" style="max-width: 200px;">
                 <option value="all">All</option>
                 <option value="received">Marked as received</option>
-                <option value="deposit">Deposit (default)</option>
-                <option value="suggested">Suggested as received</option>
+                <option value="expense">Marked as expense</option>
+                <option value="deposit">Deposit/withdrawal (default)</option>
+                <option value="suggested">Suggested (unclassified)</option>
             </select>
             <button class="btn btn-sm btn-outline-primary" id="autoClassifyBtn" title="Apply auto-classification suggestions">Auto-classify</button>
             <button class="btn btn-sm btn-outline-success" id="saveBtn">Save</button>
@@ -57,7 +59,7 @@ export default /*html*/ `
             <table class="table table-sm table-hover counterparty-table">
                 <thead>
                     <tr>
-                        <th data-sort="isReceived" style="width: 70px;">Received</th>
+                        <th data-sort="classification" style="width: 120px;">Classification</th>
                         <th data-sort="account">Counterparty</th>
                         <th data-sort="txCount" class="text-end">Txns</th>
                         <th class="text-end">Incoming</th>

--- a/public_html/counterparties/counterparties-page.component.js
+++ b/public_html/counterparties/counterparties-page.component.js
@@ -1,5 +1,5 @@
 import html from './counterparties-page.component.html.js';
-import { getAccounts, getTransactionsForAccount, getAllFungibleTokenTransactions, getReceivedAccounts, setReceivedAccounts } from '../storage/domainobjectstore.js';
+import { getAccounts, getTransactionsForAccount, getAllFungibleTokenTransactions, getReceivedAccounts, setReceivedAccounts, getExpenseAccounts, setExpenseAccounts } from '../storage/domainobjectstore.js';
 import { getStakingAccounts } from '../near/stakingpool.js';
 
 // Token prices cache, keyed by symbol (uppercase)
@@ -165,6 +165,11 @@ function classifyCounterparty(account, stats, ownAccounts, stakingAccounts) {
         return { suggestion: 'received', reason: 'Incoming-only transfers' };
     }
 
+    // If only outgoing, never incoming, and reasonably small number of txns → likely expense/payment
+    if (totalIncoming === 0n && totalOutgoing > 0n && stats.txCount <= 10) {
+        return { suggestion: 'expense', reason: 'Outgoing-only transfers' };
+    }
+
     return null;
 }
 
@@ -219,6 +224,7 @@ customElements.define('counterparties-page',
             }
 
             const receivedAccounts = await getReceivedAccounts();
+            const expenseAccounts = await getExpenseAccounts();
             this.tokenPrices = await fetchTokenPrices();
             const counterparties = {};
 
@@ -230,7 +236,8 @@ customElements.define('counterparties-page',
                         tokens: {}, // { symbol: { incoming: 0n, outgoing: 0n, decimals } }
                         hasAttachedDeposit: false,
                         isReceived: !!receivedAccounts[counterparty],
-                        description: receivedAccounts[counterparty]?.description || '',
+                        isExpense: !!expenseAccounts[counterparty],
+                        description: receivedAccounts[counterparty]?.description || expenseAccounts[counterparty]?.description || '',
                         suggestion: null,
                     };
                 }
@@ -306,6 +313,12 @@ customElements.define('counterparties-page',
             for (const [account, cp] of Object.entries(this.counterparties)) {
                 if (cp.suggestion && cp.suggestion.suggestion === 'received' && !cp.isReceived) {
                     cp.isReceived = true;
+                    cp.isExpense = false;
+                    cp.description = cp.description || cp.suggestion.reason;
+                }
+                if (cp.suggestion && cp.suggestion.suggestion === 'expense' && !cp.isExpense) {
+                    cp.isExpense = true;
+                    cp.isReceived = false;
                     cp.description = cp.description || cp.suggestion.reason;
                 }
             }
@@ -325,12 +338,19 @@ customElements.define('counterparties-page',
             }
 
             if (filter === 'received') entries = entries.filter(cp => cp.isReceived);
-            else if (filter === 'deposit') entries = entries.filter(cp => !cp.isReceived);
-            else if (filter === 'suggested') entries = entries.filter(cp => cp.suggestion?.suggestion === 'received');
+            else if (filter === 'expense') entries = entries.filter(cp => cp.isExpense);
+            else if (filter === 'deposit') entries = entries.filter(cp => !cp.isReceived && !cp.isExpense);
+            else if (filter === 'suggested') entries = entries.filter(cp => cp.suggestion && !cp.isReceived && !cp.isExpense);
 
             const col = this.sortColumn;
             entries.sort((a, b) => {
                 let va = a[col], vb = b[col];
+                if (col === 'classification') {
+                    const ca = a.isReceived ? 'received' : a.isExpense ? 'expense' : 'deposit';
+                    const cb = b.isReceived ? 'received' : b.isExpense ? 'expense' : 'deposit';
+                    const diff = ca.localeCompare(cb);
+                    return this.sortDesc ? -diff : diff;
+                }
                 if (typeof va === 'boolean') {
                     const diff = (va === vb) ? 0 : va ? -1 : 1;
                     return this.sortDesc ? -diff : diff;
@@ -367,9 +387,10 @@ customElements.define('counterparties-page',
             });
 
             const receivedCount = Object.values(this.counterparties).filter(cp => cp.isReceived).length;
+            const expenseCount = Object.values(this.counterparties).filter(cp => cp.isExpense).length;
             const totalCount = Object.keys(this.counterparties).length;
             this.shadowRoot.getElementById('statsSpan').textContent =
-                `${receivedCount} received / ${totalCount} total counterparties (showing ${entries.length})`;
+                `${receivedCount} received / ${expenseCount} expense / ${totalCount} total counterparties (showing ${entries.length})`;
 
             for (const cp of entries) {
                 const tr = document.createElement('tr');
@@ -387,12 +408,20 @@ customElements.define('counterparties-page',
                     return lines.join('<br>') || '0';
                 };
 
+                const suggestionBadgeClass = cp.suggestion
+                    ? (cp.suggestion.suggestion === 'received' ? 'bg-info' : cp.suggestion.suggestion === 'expense' ? 'bg-warning' : 'bg-secondary')
+                    : '';
                 const suggestionHtml = cp.suggestion
-                    ? `<span class="badge suggestion-badge ${cp.suggestion.suggestion === 'received' ? 'bg-info' : 'bg-secondary'}">${cp.suggestion.reason}</span>`
+                    ? `<span class="badge suggestion-badge ${suggestionBadgeClass}">${cp.suggestion.reason}</span>`
                     : '';
 
+                const classification = cp.isReceived ? 'received' : cp.isExpense ? 'expense' : 'deposit';
                 tr.innerHTML = `
-                    <td class="text-center"><input type="checkbox" class="form-check-input received-check" data-account="${cp.account}" ${cp.isReceived ? 'checked' : ''}></td>
+                    <td><select class="form-select form-select-sm classification-select" data-account="${cp.account}">
+                        <option value="deposit" ${classification === 'deposit' ? 'selected' : ''}>deposit/withdrawal</option>
+                        <option value="received" ${classification === 'received' ? 'selected' : ''}>received</option>
+                        <option value="expense" ${classification === 'expense' ? 'selected' : ''}>expense</option>
+                    </select></td>
                     <td class="text-break">${cp.account}</td>
                     <td class="text-end">${cp.txCount}</td>
                     <td class="text-end">${formatTokenList(d => d.incoming)}</td>
@@ -405,10 +434,12 @@ customElements.define('counterparties-page',
                 tbody.appendChild(tr);
             }
 
-            // Attach checkbox listeners
-            tbody.querySelectorAll('.received-check').forEach(cb => {
-                cb.addEventListener('change', () => {
-                    this.counterparties[cb.dataset.account].isReceived = cb.checked;
+            // Attach classification select listeners
+            tbody.querySelectorAll('.classification-select').forEach(sel => {
+                sel.addEventListener('change', () => {
+                    const cp = this.counterparties[sel.dataset.account];
+                    cp.isReceived = sel.value === 'received';
+                    cp.isExpense = sel.value === 'expense';
                     this.updateStats();
                 });
             });
@@ -423,20 +454,26 @@ customElements.define('counterparties-page',
 
         updateStats() {
             const receivedCount = Object.values(this.counterparties).filter(cp => cp.isReceived).length;
+            const expenseCount = Object.values(this.counterparties).filter(cp => cp.isExpense).length;
             const totalCount = Object.keys(this.counterparties).length;
             const shownCount = this.shadowRoot.getElementById('counterpartyTableBody').children.length;
             this.shadowRoot.getElementById('statsSpan').textContent =
-                `${receivedCount} received / ${totalCount} total counterparties (showing ${shownCount})`;
+                `${receivedCount} received / ${expenseCount} expense / ${totalCount} total counterparties (showing ${shownCount})`;
         }
 
         async save() {
             const receivedAccounts = {};
+            const expenseAccounts = {};
             for (const [account, cp] of Object.entries(this.counterparties)) {
                 if (cp.isReceived) {
                     receivedAccounts[account] = { description: cp.description || '' };
                 }
+                if (cp.isExpense) {
+                    expenseAccounts[account] = { description: cp.description || '' };
+                }
             }
             await setReceivedAccounts(receivedAccounts);
+            await setExpenseAccounts(expenseAccounts);
             const btn = this.shadowRoot.getElementById('saveBtn');
             btn.textContent = 'Saved!';
             btn.classList.replace('btn-outline-success', 'btn-success');

--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -10,6 +10,7 @@ export const accountdatadir = 'accountdata';
 export const accountsconfigfile = 'accounts.json';
 export const depositaccountsfile = 'depositaccounts.json';
 export const receivedaccountsfile = 'receivedaccounts.json';
+export const expenseaccountsfile = 'expenseaccounts.json';
 export const ignorefungibletokensfile = 'ignorefungibletokens.json';
 export const customexchangeratesfile = 'customexchangerates.json';
 export const currencylistfile = 'currencylist.json';
@@ -78,6 +79,18 @@ export async function getReceivedAccounts() {
 
 export async function setReceivedAccounts(receivedaccounts) {
     await writeFile(receivedaccountsfile, JSON.stringify(receivedaccounts));
+}
+
+export async function getExpenseAccounts() {
+    if (await exists(expenseaccountsfile)) {
+        return JSON.parse(await readTextFile(expenseaccountsfile));
+    } else {
+        return {};
+    }
+}
+
+export async function setExpenseAccounts(expenseaccounts) {
+    await writeFile(expenseaccountsfile, JSON.stringify(expenseaccounts));
 }
 
 export async function getIgnoredFungibleTokens() {

--- a/public_html/yearreport/yearreport-page.component.html.js
+++ b/public_html/yearreport/yearreport-page.component.html.js
@@ -93,12 +93,13 @@ export default /*html*/ `<style>
         <td class="dailybalancerow_received numeric"></td>
         <td class="dailybalancerow_deposit numeric"></td>
         <td class="dailybalancerow_withdrawal numeric"></td>
+        <td class="dailybalancerow_expense numeric"></td>
         <td class="dailybalancerow_profit numeric"></td>
         <td class="dailybalancerow_loss numeric"></td>
         <td><button class="btn btn-light show_transactions_button">&#128194;</button></td>
     </tr>
     <tr class="inforow bg-info">
-        <td colspan="14" >
+        <td colspan="15" >
             <table class="table table-sm table-borderless">
                 <thead>
                     <tr>
@@ -151,6 +152,9 @@ export default /*html*/ `<style>
                 withdrawals
             </th>
             <th scope="col">
+                expenses
+            </th>
+            <th scope="col">
                 profit
             </th>
             <th scope="col">
@@ -195,6 +199,9 @@ export default /*html*/ `<style>
 
             </th>
             <th scope="col" class="numeric" id="totalwithdrawal">
+
+            </th>
+            <th scope="col" class="numeric" id="totalexpense">
 
             </th>
             <th scope="col" class="numeric" id="totalprofit">

--- a/public_html/yearreport/yearreport-print.component.html.js
+++ b/public_html/yearreport/yearreport-print.component.html.js
@@ -58,6 +58,10 @@ export default /*html*/ `<style>
     <td>Withdrawal</td>
     <td class="numeric" id="totalwithdrawal"></td>
 </tr>
+<tr>
+    <td>Expenses</td>
+    <td class="numeric" id="totalexpense"></td>
+</tr>
 <tr class="profit">
     <td>Profit on realizations</td>
     <td class="numeric" id="totalprofit"></td>
@@ -81,11 +85,12 @@ export default /*html*/ `<style>
         <td class="dailybalancerow_received numeric"></td>
         <td class="dailybalancerow_deposit numeric"></td>
         <td class="dailybalancerow_withdrawal numeric"></td>
+        <td class="dailybalancerow_expense numeric"></td>
         <td class="dailybalancerow_profit numeric"></td>
         <td class="dailybalancerow_loss numeric"></td>
     </tr>
     <tr class="inforow bg-info">
-        <td colspan="13" >
+        <td colspan="14" >
             <table class="table table-sm table-borderless">
                 <thead>
                     <tr>
@@ -146,6 +151,9 @@ is obtained by calling the staking contract for the balance for that specific da
         </th>
         <th scope="col" class="numeric">
             withdrawals
+        </th>
+        <th scope="col" class="numeric">
+            expenses
         </th>
         <th scope="col" class="numeric profit">
             profit

--- a/public_html/yearreport/yearreport-print.component.js
+++ b/public_html/yearreport/yearreport-print.component.js
@@ -80,6 +80,7 @@ customElements.define('year-report-print',
                 }
             });
             this.shadowRoot.getElementById('totalearnings').innerText = formatNumber(result.totalReceived + result.totalStakingReward);
+            this.shadowRoot.getElementById('totalexpense').innerText = formatNumber(result.totalExpense);
             return result;
         }
     }

--- a/public_html/yearreport/yearreport-table-renderer.js
+++ b/public_html/yearreport/yearreport-table-renderer.js
@@ -68,6 +68,7 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
     let totalReceived = 0;
     let totalDeposit = 0;
     let totalWithdrawal = 0;
+    let totalExpense = 0;
     let totalProfit = 0;
     let totalLoss = 0;
 
@@ -75,6 +76,7 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
     let token_totalReceived = 0n;
     let token_totalDeposit = 0;
     let token_totalWithdrawal = 0;
+    let token_totalExpense = 0n;
 
     const decimalConversionValue = token ? getDecimalConversionValue(token) : Math.pow(10, -24);
     const tokenNumberFormatter = getNumberFormatter();
@@ -89,7 +91,7 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
         const row = rowTemplate.cloneNode(true).content;
         const rowdata = yearReportData[datestring];
 
-        const { stakingReward, received, deposit, withdrawal, conversionRate } = token ?
+        const { stakingReward, received, deposit, withdrawal, expense, conversionRate } = token ?
             await getFungibleTokenConvertedValuesForDay(rowdata, token, convertToCurrency, datestring) :
             await getConvertedValuesForDay(rowdata, convertToCurrency, datestring);
 
@@ -97,6 +99,7 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
         totalDeposit += deposit;
         totalReceived += received;
         totalWithdrawal += withdrawal;
+        totalExpense += expense;
         totalProfit += rowdata.profit ?? 0;
         totalLoss += rowdata.loss ?? 0;
 
@@ -104,6 +107,7 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
         token_totalReceived += rowdata.received;
         token_totalDeposit += rowdata.deposit;
         token_totalWithdrawal += rowdata.withdrawal;
+        token_totalExpense += rowdata.expense;
 
         rowdata.convertedTotalBalance = conversionRate * (rowdata.totalBalance * decimalConversionValue);
         rowdata.convertedAccountBalance = conversionRate * (Number(rowdata.accountBalance) * decimalConversionValue);
@@ -123,6 +127,7 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
         row.querySelector('.dailybalancerow_received').innerHTML = `${formatNumber(received)} ${convertToCurrency ? `<br />${formatTokenAmount(Number(rowdata.received))}` : ''}`;
         row.querySelector('.dailybalancerow_deposit').innerHTML = `${formatNumber(deposit)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.deposit)}` : ''}`;
         row.querySelector('.dailybalancerow_withdrawal').innerHTML = `${formatNumber(withdrawal)} ${convertToCurrency ? `<br />${formatTokenAmount(rowdata.withdrawal)}` : ''}`;
+        row.querySelector('.dailybalancerow_expense').innerHTML = `${formatNumber(expense)} ${convertToCurrency ? `<br />${formatTokenAmount(Number(rowdata.expense))}` : ''}`;
         if (convertToCurrency) {
             row.querySelector('.dailybalancerow_profit').innerText = formatNumber(rowdata.profit) ?? '';
             row.querySelector('.dailybalancerow_loss').innerText = formatNumber(rowdata.loss) ?? '';
@@ -154,7 +159,8 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
             rowdata.totalChange !== 0 ||
             received !== 0 ||
             deposit !== 0 ||
-            withdrawal !== 0
+            withdrawal !== 0 ||
+            expense !== 0
         ) {
             yearReportTable.appendChild(row);
         }
@@ -164,6 +170,7 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
         shadowRoot.querySelector('#totalreceived').innerHTML = `${formatNumber(totalReceived)} ${convertToCurrency ? `<br />${formatTokenAmount(Number(token_totalReceived))}` : ''}`;
         shadowRoot.querySelector('#totaldeposit').innerHTML = `${formatNumber(totalDeposit)} ${convertToCurrency ? `<br />${formatTokenAmount(token_totalDeposit)}` : ''}`;
         shadowRoot.querySelector('#totalwithdrawal').innerHTML = `${formatNumber(totalWithdrawal)} ${convertToCurrency ? `<br />${formatTokenAmount(token_totalWithdrawal)}` : ''}`;
+        shadowRoot.querySelector('#totalexpense').innerHTML = `${formatNumber(totalExpense)} ${convertToCurrency ? `<br />${formatTokenAmount(Number(token_totalExpense))}` : ''}`;
         if (convertToCurrency) {
             shadowRoot.querySelector('#totalprofit').innerText = formatNumber(totalProfit);
             shadowRoot.querySelector('#totalloss').innerText = formatNumber(totalLoss);
@@ -178,6 +185,7 @@ export async function renderPeriodReportTable({ shadowRoot, token, periodStartDa
         totalReceived,
         totalDeposit,
         totalWithdrawal,
+        totalExpense,
         totalProfit,
         totalLoss,
         outboundBalance: dailyBalances[outboundBalanceDate],

--- a/public_html/yearreport/yearreportdata.js
+++ b/public_html/yearreport/yearreportdata.js
@@ -1,4 +1,4 @@
-import { getAccounts, getTransactionsForAccount, getStakingRewardsForAccountAndPool, getAllFungibleTokenTransactionsByTxHash, getReceivedAccounts, getCustomRealizationRates } from "../storage/domainobjectstore.js";
+import { getAccounts, getTransactionsForAccount, getStakingRewardsForAccountAndPool, getAllFungibleTokenTransactionsByTxHash, getReceivedAccounts, getExpenseAccounts, getCustomRealizationRates } from "../storage/domainobjectstore.js";
 import { getStakingAccounts } from "../near/stakingpool.js";
 import { getEODPrice, getCustomSellPrice, getCustomBuyPrice } from '../pricedata/pricedata.js';
 import { resolveDecimals } from '../near/intents-tokens.js';
@@ -27,6 +27,7 @@ export async function calculateYearReportData(fungibleTokenSymbol) {
     const transactionsByDate = {};
     const allStakingAccounts = {};
     const receivedaccounts = await getReceivedAccounts();
+    const expenseaccounts = await getExpenseAccounts();
     const customRealizationRates = await getCustomRealizationRates();
 
     let decimalConversionValue = Math.pow(10, -24);
@@ -68,6 +69,19 @@ export async function calculateYearReportData(fungibleTokenSymbol) {
                 && (fungibleTokenSymbol || !fungbleTokenTxMap[tx.hash])
             ) {
                 tx.receivedBalance = tx.changedBalance;
+                tx.changedBalance = 0n;
+            }
+
+            // Classify outgoing transfers to expense accounts:
+            // If receiver is in expenseaccounts and balance decreased, treat as expense (not withdrawal)
+            // Expenses do not trigger FIFO realization — they are costs, not sales.
+            if (!accountsMap[tx.receiver_id]
+                && !allStakingAccounts[tx.receiver_id]
+                && tx.changedBalance < 0n
+                && (expenseaccounts[tx.receiver_id] || expenseaccounts[tx.involved_account_id])
+                && (fungibleTokenSymbol || !fungbleTokenTxMap[tx.hash])
+            ) {
+                tx.expenseBalance = -tx.changedBalance;
                 tx.changedBalance = 0n;
             }
 
@@ -151,7 +165,8 @@ export async function calculateYearReportData(fungibleTokenSymbol) {
             stakingEarnings: 0,
             deposit: 0,
             withdrawal: 0,
-            received: 0n
+            received: 0n,
+            expense: 0n
         };
         currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate() + 1);
         accounts.forEach(account => {
@@ -173,6 +188,10 @@ export async function calculateYearReportData(fungibleTokenSymbol) {
                     if (tx.receivedBalance) {
                         dailyBalances[datestring].received += tx.receivedBalance;
                         tx.receivedBalance = 0n;
+                    }
+                    if (tx.expenseBalance) {
+                        dailyBalances[datestring].expense += tx.expenseBalance;
+                        tx.expenseBalance = 0n;
                     }
                 });
 
@@ -356,8 +375,9 @@ export async function getConvertedValuesForDay(rowdata, convertToCurrency, dates
     const depositConversionRate = convertToCurrencyIsNEAR ? 1 : await getCustomBuyPrice(convertToCurrency, datestring);
     const deposit = (depositConversionRate * (rowdata.deposit / 1e+24));
     const withdrawal = convertToCurrencyIsNEAR ? (rowdata.withdrawal / 1e+24)  : rowdata.convertToCurrencyWithdrawalAmount;
+    const expense = (conversionRate * (Number(rowdata.expense) / 1e+24));
 
-    return { stakingReward, received, deposit, withdrawal, conversionRate };
+    return { stakingReward, received, deposit, withdrawal, expense, conversionRate };
 }
 
 export async function getFungibleTokenConvertedValuesForDay(rowdata, symbol, convertToCurrency, datestring) {
@@ -369,6 +389,7 @@ export async function getFungibleTokenConvertedValuesForDay(rowdata, symbol, con
     const stakingReward = (conversionRate * (rowdata.stakingRewards * decimalConversionValue));
     const deposit = (conversionRate * (rowdata.deposit * decimalConversionValue));
     const withdrawal = (conversionRate * (rowdata.withdrawal * decimalConversionValue));
+    const expense = (conversionRate * (Number(rowdata.expense) * decimalConversionValue));
 
-    return { stakingReward, received, deposit, withdrawal, conversionRate };
+    return { stakingReward, received, deposit, withdrawal, expense, conversionRate };
 }

--- a/public_html/yearreport/yearreportdata.spec.js
+++ b/public_html/yearreport/yearreportdata.spec.js
@@ -1,5 +1,5 @@
 import { calculateProfitLoss, calculateYearReportData, getConvertedValuesForDay } from './yearreportdata.js';
-import { setAccounts, fetchTransactionsFromAccountingExport, getTransactionsForAccount, writeStakingData, writeTransactions, fetchFungibleTokenTransactionsForAccount, setCustomRealizationRates, setDepositAccounts, setReceivedAccounts } from '../storage/domainobjectstore.js';
+import { setAccounts, fetchTransactionsFromAccountingExport, getTransactionsForAccount, writeStakingData, writeTransactions, fetchFungibleTokenTransactionsForAccount, setCustomRealizationRates, setDepositAccounts, setReceivedAccounts, setExpenseAccounts } from '../storage/domainobjectstore.js';
 import { transactionsWithDeposits } from './yearreporttestdata.js'
 import { fetchHistoricalPricesFromArizGateway, setCustomExchangeRateSell, setSkipFetchingPrices } from '../pricedata/pricedata.js';
 import { mockWalletAuthenticationData, mockArizGatewayAccess } from '../arizgateway/arizgatewayaccess.spec.js';
@@ -80,6 +80,7 @@ describe('year-report-data', () => {
         const verifyDate = '2021-02-14';
         await setAccounts(accounts);
         await setReceivedAccounts({});
+        await setExpenseAccounts({});
 
         for (var account of accounts) {
             await fetchTransactionsFromAccountingExport(account);
@@ -99,6 +100,7 @@ describe('year-report-data', () => {
         await setAccounts(accounts);
         // Mark "near" root account as external received (e.g. account creation grant)
         await setReceivedAccounts({'near': { description: 'NEAR root account - account creation' }});
+        await setExpenseAccounts({});
 
         for (var account of accounts) {
             await fetchTransactionsFromAccountingExport(account);
@@ -109,6 +111,46 @@ describe('year-report-data', () => {
         expect(Number(dailydata[verifyDate].received) / 1e+24).to.be.closeTo(0.1, 0.005);
         expect(Number(dailydata[verifyDate].deposit) / 1e+24).to.be.closeTo(11.89, 0.005);
         expect(Number(dailydata[verifyDate].withdrawal) / 1e+24).to.be.closeTo(0.03, 0.005);
+    });
+    it('should classify outgoing to expenseaccounts as expense (not withdrawal)', async function () {
+        this.timeout(20 * 60000);
+        const accounts = ['psalomo.near', 'wasmgit.near'];
+        const verifyDate = '2021-02-14';
+        await setAccounts(accounts);
+        await setReceivedAccounts({});
+
+        for (var account of accounts) {
+            await fetchTransactionsFromAccountingExport(account);
+        }
+
+        // First run without expense accounts to find the withdrawal counterparty
+        const baseData = (await calculateYearReportData()).dailyBalances;
+        const baseWithdrawal = Number(baseData[verifyDate].withdrawal) / 1e+24;
+        expect(baseWithdrawal).to.be.closeTo(0.03, 0.005);
+
+        // Find the receiver of outgoing transfers on verifyDate
+        const allTransactions = [];
+        for (const acc of accounts) {
+            const txs = await getTransactionsForAccount(acc);
+            txs.forEach(tx => tx._account = acc);
+            allTransactions.push(...txs);
+        }
+        const dateTxs = allTransactions.filter(tx => {
+            const txdate = new Date(tx.block_timestamp / 1_000_000).toJSON().substring(0, 'yyyy-MM-dd'.length);
+            return txdate === verifyDate && tx.signer_id === tx._account;
+        });
+        // Find an external receiver (not own account, not staking)
+        const receiver = dateTxs.find(tx => !accounts.includes(tx.receiver_id))?.receiver_id;
+        expect(receiver, 'Should find an external receiver for withdrawal').to.exist;
+
+        // Mark that receiver as expense
+        await setExpenseAccounts({ [receiver]: { description: 'Test expense' } });
+        const dailydata = (await calculateYearReportData()).dailyBalances;
+
+        // Expense should now capture what was previously withdrawal
+        expect(Number(dailydata[verifyDate].expense) / 1e+24).to.be.greaterThan(0);
+        // Withdrawal should be reduced
+        expect(Number(dailydata[verifyDate].withdrawal) / 1e+24).to.be.lessThan(baseWithdrawal);
     });
     it('should use previous epoch staking balance for days with no epoch', async function () {
         this.timeout(10 * 60000);


### PR DESCRIPTION
## Summary
- Adds **expense** as a new counterparty classification type (alongside deposit and received)
- Outgoing transfers to expense-classified accounts are deducted from withdrawals, mirroring how received deducts from deposit
- Expenses do **not** trigger FIFO profit/loss realizations — they are costs, not sales
- Replaces the received checkbox with a classification dropdown (deposit/withdrawal, received, expense)
- Adds auto-classification heuristic for outgoing-only transfers
- Adds "expenses" column to year report (interactive + print)

## Future considerations
The expense column is designed to also accommodate implicit costs (gas fees, swap fees, LP fees) once detection for those is implemented. Currently it tracks explicit payments to counterparties only.

## Test plan
- [x] All 7 existing + new yearreportdata tests pass
- [ ] Verify counterparty classification dropdown works in UI
- [ ] Verify expense column appears in year report
- [ ] Verify expense deducts from withdrawal correctly with real data
- [ ] Verify print report includes expenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)