### PR TITLE
Transactions page: render every balance change from raw V2 records

### DIFF
--- a/playwright_tests/tests/transactions-page.spec.js
+++ b/playwright_tests/tests/transactions-page.spec.js
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { setupApiMocks } from '../util/api-mocks.js';
+
+/**
+ * Full-flow test for the records-driven Transactions page.
+ *
+ * Loads the cached accounting fixture for webassemblymusic-treasury.sputnik-dao.near,
+ * navigates to /transactions, and verifies that:
+ * - rows render at all (regression check: the storage layer must persist the
+ *   raw V2 records, not the converted V1-like shape — that bug shipped once)
+ * - the table contains records for tokens beyond NEAR (FT + NEAR Intents)
+ * - the resolved-symbol column shows human names (not just contract IDs)
+ * - the raw token_id is also visible alongside the symbol
+ */
+test('Transactions page renders FT + Intents records, not just NEAR', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  await setupApiMocks(page);
+
+  page.on('pageerror', err => console.log('BROWSER ERROR:', err.message));
+  page.on('console', msg => {
+    if (msg.type() === 'error') console.log('BROWSER CONSOLE ERROR:', msg.text());
+  });
+
+  // Start fresh
+  await page.goto('/');
+
+  // Add the test account via the Accounts page. Uses a synthetic V2 fixture
+  // (testdata/accountingexport/accounts_tx-page-test.near_download_json.json)
+  // with a known mix of NEAR + FT + Intents + staking-pool records.
+  const testAccount = 'tx-page-test.near';
+  await page.getByRole('link', { name: 'Accounts' }).click();
+  await page.getByRole('button', { name: 'Add account' }).click();
+  await page.getByRole('textbox').fill(testAccount);
+
+  // Click "load from server" — this should now also persist records.json
+  await page.getByRole('button', { name: 'load from server' }).click();
+
+  // Wait for the load to finish
+  const progressbar = page.locator('progress-bar');
+  try {
+    await progressbar.waitFor({ state: 'visible', timeout: 10_000 });
+    await progressbar.waitFor({ state: 'hidden', timeout: 90_000 });
+  } catch {
+    await page.waitForTimeout(5000);
+  }
+  await page.waitForTimeout(2000);
+
+  // Navigate to Transactions
+  await page.getByRole('link', { name: 'Transactions' }).click();
+
+  // Pick the loaded account
+  const accountSelect = page.locator('transactions-page').locator('#accountselect');
+  await expect(accountSelect).toBeVisible();
+  await accountSelect.selectOption(testAccount);
+
+  // Wait briefly for symbol/decimal resolution (intents metadata + RPC for unknown FTs)
+  await page.waitForTimeout(3000);
+  await page.screenshot({ path: 'test-results/transactions-page.png', fullPage: true });
+
+  // === Assertions ===
+
+  // The empty-state must NOT be visible. If it is, the storage-layer write
+  // didn't persist the raw V2 records (regression check for the bug where
+  // fetchAccountingExportJSON converted before persisting).
+  const emptyState = page.locator('transactions-page').locator('#emptystate');
+  await expect(emptyState).toBeHidden();
+
+  // 4 records in the fixture → 4 rows
+  const rows = page.locator('transactions-page').locator('#transactionstable tr');
+  expect(await rows.count()).toBe(4);
+
+  // Distinct token_ids cover NEAR + FT + Intents + staking pool
+  const rawTokenIds = await page.locator('transactions-page').locator('.txrow_token_id').allTextContents();
+  const uniqueTokenIds = new Set(rawTokenIds);
+  expect(uniqueTokenIds.has('near')).toBeTruthy();
+  expect(uniqueTokenIds.has('arizcredits.near')).toBeTruthy();
+  expect(uniqueTokenIds.has('nep141:btc.omft.near')).toBeTruthy();
+  expect(uniqueTokenIds.has('astro-stakers.poolv1.near')).toBeTruthy();
+
+  // Resolved symbols
+  const symbols = await page.locator('transactions-page').locator('.txrow_token_symbol').allTextContents();
+  expect(symbols).toContain('NEAR');                             // native NEAR
+  expect(symbols.some(s => s.includes('NEAR Intents'))).toBe(true);  // BTC via Intents
+  expect(symbols.some(s => s.includes('staked NEAR'))).toBe(true);   // staking pool
+});

--- a/playwright_tests/tests/transactions-page.spec.js
+++ b/playwright_tests/tests/transactions-page.spec.js
@@ -66,21 +66,21 @@ test('Transactions page renders FT + Intents records, not just NEAR', async ({ p
   const emptyState = page.locator('transactions-page').locator('#emptystate');
   await expect(emptyState).toBeHidden();
 
-  // 4 records in the fixture → 4 rows
+  // 4 records in the fixture, 1 of which is a staking-pool record → 3 rendered rows
   const rows = page.locator('transactions-page').locator('#transactionstable tr');
-  expect(await rows.count()).toBe(4);
+  expect(await rows.count()).toBe(3);
 
-  // Distinct token_ids cover NEAR + FT + Intents + staking pool
+  // Distinct token_ids cover NEAR + FT + Intents (staking pool is filtered out)
   const rawTokenIds = await page.locator('transactions-page').locator('.txrow_token_id').allTextContents();
   const uniqueTokenIds = new Set(rawTokenIds);
   expect(uniqueTokenIds.has('near')).toBeTruthy();
   expect(uniqueTokenIds.has('arizcredits.near')).toBeTruthy();
   expect(uniqueTokenIds.has('nep141:btc.omft.near')).toBeTruthy();
-  expect(uniqueTokenIds.has('astro-stakers.poolv1.near')).toBeTruthy();
+  // Staking-pool record from the fixture must NOT appear
+  expect([...uniqueTokenIds].some(id => id.includes('.poolv1.near'))).toBe(false);
 
   // Resolved symbols
   const symbols = await page.locator('transactions-page').locator('.txrow_token_symbol').allTextContents();
   expect(symbols).toContain('NEAR');                             // native NEAR
   expect(symbols.some(s => s.includes('NEAR Intents'))).toBe(true);  // BTC via Intents
-  expect(symbols.some(s => s.includes('staked NEAR'))).toBe(true);   // staking pool
 });

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -84,13 +84,12 @@
       }
     }
     </script>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 </head>
 <body>
     <app-near-account-report></app-near-account-report>
 </body>
 <script type="module" src="app.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
 </html>

--- a/public_html/near/accounting-export.js
+++ b/public_html/near/accounting-export.js
@@ -177,7 +177,14 @@ export function convertV2ToInternalFormat(v2Data) {
  * @param {string} accountId - NEAR account ID
  * @returns {Promise<Object>} Parsed JSON response
  */
-export async function fetchAccountingExportJSON(accountId) {
+/**
+ * Fetch the raw response from the accounting-export gateway. For V2 data this
+ * is the flat BalanceChangeRecord shape: { version, accountId, metadata,
+ * records: [...] }. For pre-V2 data it's the legacy entries-grouped-by-block
+ * shape. Used directly by the storage layer to persist records.json — callers
+ * that want the V1-like internal format should use fetchAccountingExportJSON.
+ */
+export async function fetchRawAccountingExport(accountId) {
     // Always make the fetch (so test mocks intercept regardless of auth state).
     // Add the bearer token if signed in; the gateway will 401 anonymous requests
     // in production, while test mocks bypass auth entirely.
@@ -198,6 +205,12 @@ export async function fetchAccountingExportJSON(accountId) {
     if (data.accountId && data.accountId !== accountId) {
         throw new Error(`Gateway returned data for ${data.accountId} but ${accountId} was requested`);
     }
+
+    return data;
+}
+
+export async function fetchAccountingExportJSON(accountId) {
+    const data = await fetchRawAccountingExport(accountId);
 
     // Convert V2 format to V1-like internal format
     if (isV2Format(data)) {

--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -4,7 +4,7 @@ import { writeFile } from './gitstorage.js';
 import { fetchAllStakingEarnings } from '../near/stakingpool.js';
 import { getFungibleTokenTransactionsToDate } from '../near/fungibletoken.js';
 import { setProgressbarValue } from '../ui/progress-bar.js';
-import { fetchAccountingExportJSON, convertAccountingExportToTransactions, mergeTransactions, mergeFungibleTokenTransactions, mergeStakingEntries } from '../near/accounting-export.js';
+import { fetchRawAccountingExport, convertAccountingExportToTransactions, isV2Format, convertV2ToInternalFormat, mergeTransactions, mergeFungibleTokenTransactions, mergeStakingEntries } from '../near/accounting-export.js';
 
 export const accountdatadir = 'accountdata';
 export const accountsconfigfile = 'accounts.json';
@@ -390,15 +390,16 @@ export async function fetchTransactionsFromAccountingExport(account, options = {
     setProgressbarValue('indeterminate', `Fetching accounting data for ${account}...`);
 
     try {
-        // Fetch raw V2 records from the gateway, persist as-is for the
-        // Transactions page (it renders directly from records, not the
-        // NEAR-transaction conversion), then run the conversion for the
-        // existing year-report / counterparties / staking consumers.
-        const jsonData = await fetchAccountingExportJSON(account);
-        await writeAccountingRecords(account, jsonData);
+        // Fetch raw V2 response from the gateway. Persist it as-is for the
+        // Transactions page (which reads records directly), then convert to
+        // the V1-like internal format for the existing year-report /
+        // counterparties / staking consumers.
+        const rawData = await fetchRawAccountingExport(account);
+        await writeAccountingRecords(account, rawData);
 
+        const internalFormat = isV2Format(rawData) ? convertV2ToInternalFormat(rawData) : rawData;
         const { transactions: newTransactions, ftTransactions: newFtTransactions, stakingData: newStakingData } =
-            await convertAccountingExportToTransactions(account, jsonData);
+            await convertAccountingExportToTransactions(account, internalFormat);
 
         let finalTransactions;
         let finalFtTransactions;

--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -4,7 +4,7 @@ import { writeFile } from './gitstorage.js';
 import { fetchAllStakingEarnings } from '../near/stakingpool.js';
 import { getFungibleTokenTransactionsToDate } from '../near/fungibletoken.js';
 import { setProgressbarValue } from '../ui/progress-bar.js';
-import { fetchAndConvertAccountingExport, mergeTransactions, mergeFungibleTokenTransactions, mergeStakingEntries } from '../near/accounting-export.js';
+import { fetchAccountingExportJSON, convertAccountingExportToTransactions, mergeTransactions, mergeFungibleTokenTransactions, mergeStakingEntries } from '../near/accounting-export.js';
 
 export const accountdatadir = 'accountdata';
 export const accountsconfigfile = 'accounts.json';
@@ -197,6 +197,33 @@ export async function writeTransactions(account, transactions) {
     await writeFile(`${accountdatadir}/${account}/transactions.json`, JSON.stringify(transactions, null, 1));
 }
 
+/**
+ * Persist the raw V2 records returned by the accounting-export gateway,
+ * alongside the existing derived transactions.json / fungible_token_transactions.json /
+ * stakingpools/* files. The Transactions page reads this to show every
+ * balance-changing event (NEAR, FTs, NEAR Intents, staking) without
+ * going through the NEAR-transaction conversion.
+ */
+export async function writeAccountingRecords(account, jsonData) {
+    await makeAccountDataDirs(account);
+    await writeFile(`${accountdatadir}/${account}/records.json`, JSON.stringify(jsonData, null, 1));
+}
+
+/**
+ * Read the raw V2 records file. Returns an array of BalanceChangeRecord
+ * (one per token balance change at a block), or an empty array if the
+ * file doesn't exist yet (i.e. the user hasn't re-fetched from the gateway
+ * since this feature shipped).
+ */
+export async function getRecordsForAccount(account) {
+    const path = `${accountdatadir}/${account}/records.json`;
+    if (await exists(path)) {
+        const data = JSON.parse(await readTextFile(path));
+        return Array.isArray(data?.records) ? data.records : [];
+    }
+    return [];
+}
+
 function getStakingDataDir(account) {
     return `${accountdatadir}/${account}/stakingpools`;
 }
@@ -363,9 +390,15 @@ export async function fetchTransactionsFromAccountingExport(account, options = {
     setProgressbarValue('indeterminate', `Fetching accounting data for ${account}...`);
 
     try {
-        // Fetch and convert from accounting export API
+        // Fetch raw V2 records from the gateway, persist as-is for the
+        // Transactions page (it renders directly from records, not the
+        // NEAR-transaction conversion), then run the conversion for the
+        // existing year-report / counterparties / staking consumers.
+        const jsonData = await fetchAccountingExportJSON(account);
+        await writeAccountingRecords(account, jsonData);
+
         const { transactions: newTransactions, ftTransactions: newFtTransactions, stakingData: newStakingData } =
-            await fetchAndConvertAccountingExport(account);
+            await convertAccountingExportToTransactions(account, jsonData);
 
         let finalTransactions;
         let finalFtTransactions;

--- a/public_html/transactions/transactions-page.component.html.js
+++ b/public_html/transactions/transactions-page.component.html.js
@@ -1,89 +1,86 @@
 export default /*html*/ `<style>
     .numeric {
         text-align: right;
+        font-variant-numeric: tabular-nums;
     }
 
-    .transactionrow_datetime {
+    .txrow_datetime {
         white-space: nowrap;
+    }
+
+    .txrow_token_symbol {
+        white-space: nowrap;
+        font-weight: 500;
+    }
+
+    .txrow_token_id {
+        font-size: 0.75rem;
+        color: var(--bs-secondary-color, #6c757d);
+        word-break: break-all;
+    }
+
+    .txrow_counterparty {
+        word-break: break-all;
+    }
+
+    .txrow_hash a {
+        font-family: monospace;
     }
 
     .table-responsive {
         max-height: 100%;
     }
 
-    table thead,
-    table tfoot {
-        position: sticky;
-    }
-
     table thead {
+        position: sticky;
         inset-block-start: 0;
         top: 0;
     }
 
-    table tfoot {
-        inset-block-end: 0;
-        bottom: 0;
-    }
-    .transactionrow_signer {
-        text-overflow: clip;
-    }
-    .transactionrow_receiver {
-        text-overflow: clip;
+    #emptystate {
+        margin: 1rem 0;
+        color: var(--bs-secondary-color, #6c757d);
     }
 </style>
 <h3>Transactions</h3>
+<p class="text-muted small mb-2">Every balance-changing event for the selected account: NEAR, fungible tokens, NEAR Intents, and staking pool balances. Source is the raw worker records from the Ariz gateway.</p>
 <div class="row">
-<div class="col-md-6">
-    <label for="accountselect" class="form-label">Account</label>
-    <select class="form-select" aria-label="Select account" id="accountselect">
-        <option disabled selected value>Select account</option>
-    </select>
-</div>
-<div class="col-md-6">
-    <label for="currencyselect" class="form-label">Currency</label>
-    <select class="form-select" aria-label="Select currency" id="currencyselect">
-        <option value="near">NEAR</option>
-    </select>
+    <div class="col-md-6">
+        <label for="accountselect" class="form-label">Account</label>
+        <select class="form-select" aria-label="Select account" id="accountselect">
+            <option disabled selected value>Select account</option>
+        </select>
+    </div>
 </div>
 <template id="transactionrowtemplate">
     <tr>
-        <td class="transactionrow_datetime"></td>
-        <td class="transactionrow_kind"></td>
-        <td class="transactionrow_balance numeric"></td>
-        <td class="transactionrow_change numeric"></td>
-        <td class="transactionrow_signer"></td>
-        <td class="transactionrow_receiver"></td>
-        <td class="transactionrow_hash"></td>
+        <td class="txrow_datetime"></td>
+        <td class="txrow_block numeric"></td>
+        <td>
+            <div class="txrow_token_symbol"></div>
+            <div class="txrow_token_id"></div>
+        </td>
+        <td class="txrow_change numeric"></td>
+        <td class="txrow_balance numeric"></td>
+        <td class="txrow_counterparty"></td>
+        <td class="txrow_hash"></td>
     </tr>
 </template>
+<div id="emptystate" style="display:none;"></div>
 <div class="table-responsive">
     <table class="table table-sm">
         <thead class="table-dark">
-            <th scope="col">
-                date
-            </th>
-            <th scope="col">
-                kind
-            </th>
-            <th scope="col">
-                balance
-            </th>
-            <th scope="col">
-                change
-            </th>
-            <th scope="col">
-                signer
-            </th>
-            <th scope="col">
-                receiver
-            </th>
-            <th scope="col">
-                hash
-            </th>
+            <tr>
+                <th scope="col">date</th>
+                <th scope="col">block</th>
+                <th scope="col">token</th>
+                <th scope="col">change</th>
+                <th scope="col">balance after</th>
+                <th scope="col">counterparty</th>
+                <th scope="col">tx</th>
+            </tr>
         </thead>
         <tbody id="transactionstable">
-
         </tbody>
     </table>
 </div>

--- a/public_html/transactions/transactions-page.component.html.js
+++ b/public_html/transactions/transactions-page.component.html.js
@@ -1,30 +1,44 @@
 export default /*html*/ `<style>
+    /* Dense table: shrink padding + font on top of Bootstrap's table-sm. */
+    table.table {
+        --bs-table-cell-padding-x: 0.4rem;
+        --bs-table-cell-padding-y: 0.15rem;
+        font-size: 0.8125rem;
+        margin-bottom: 0;
+    }
+
     .numeric {
         text-align: right;
         font-variant-numeric: tabular-nums;
+        white-space: nowrap;
     }
 
     .txrow_datetime {
         white-space: nowrap;
+        font-variant-numeric: tabular-nums;
     }
 
     .txrow_token_symbol {
         white-space: nowrap;
         font-weight: 500;
+        line-height: 1.1;
     }
 
     .txrow_token_id {
-        font-size: 0.75rem;
+        font-size: 0.6875rem;
         color: var(--bs-secondary-color, #6c757d);
         word-break: break-all;
+        line-height: 1.1;
     }
 
     .txrow_counterparty {
         word-break: break-all;
+        font-size: 0.75rem;
     }
 
     .txrow_hash a {
-        font-family: monospace;
+        font-family: var(--bs-font-monospace, monospace);
+        font-size: 0.75rem;
     }
 
     .table-responsive {
@@ -35,6 +49,7 @@ export default /*html*/ `<style>
         position: sticky;
         inset-block-start: 0;
         top: 0;
+        z-index: 1;
     }
 
     #emptystate {

--- a/public_html/transactions/transactions-page.component.js
+++ b/public_html/transactions/transactions-page.component.js
@@ -83,9 +83,22 @@ customElements.define('transactions-page',
 
         async updateView(account) {
             const allRecords = await getRecordsForAccount(account);
-            // Filter staking-pool records: high-frequency periodic snapshots
-            // belong on the Staking rewards page, not in the transaction list.
-            const records = allRecords.filter(r => !isStakingPoolToken(r.token_id));
+            // Filter out:
+            //  - Staking-pool records: high-frequency periodic snapshots belong
+            //    on the Staking rewards page, not the transaction list.
+            //  - Zero-amount records: balance snapshots where nothing changed,
+            //    used by the worker to confirm the current balance. Pure noise
+            //    for a "what happened" view.
+            const records = allRecords.filter(r => {
+                if (isStakingPoolToken(r.token_id)) return false;
+                if (r.amount === undefined || r.amount === null) return false;
+                try {
+                    if (BigInt(r.amount) === 0n) return false;
+                } catch {
+                    return false;
+                }
+                return true;
+            });
 
             // Clear table
             while (this.transactionsTable.lastElementChild) {

--- a/public_html/transactions/transactions-page.component.js
+++ b/public_html/transactions/transactions-page.component.js
@@ -83,16 +83,29 @@ customElements.define('transactions-page',
         }
 
         async updateView(account) {
+            // Bump the generation counter so any in-flight render for a prior
+            // account aborts cleanly instead of fighting this one for the table.
+            const generation = (this._renderGeneration ?? 0) + 1;
+            this._renderGeneration = generation;
+
             setProgressbarValue('indeterminate', `Loading transactions for ${account}…`);
             try {
-                await this._renderView(account);
+                await this._renderView(account, generation);
             } finally {
-                setProgressbarValue(null);
+                // Only clear the spinner if this is still the latest render —
+                // a newer one will manage its own spinner state.
+                if (this._renderGeneration === generation) {
+                    setProgressbarValue(null);
+                }
             }
         }
 
-        async _renderView(account) {
+        async _renderView(account, generation) {
+            const isCurrent = () => this._renderGeneration === generation;
+
             const allRecords = await getRecordsForAccount(account);
+            if (!isCurrent()) return;
+
             // Filter out:
             //  - Staking-pool records: high-frequency periodic snapshots belong
             //    on the Staking rewards page, not the transaction list.
@@ -128,43 +141,67 @@ customElements.define('transactions-page',
             await Promise.all(uniqueTokenIds.map(async tid => {
                 displayByToken.set(tid, await resolveTokenDisplay(tid));
             }));
+            if (!isCurrent()) return;
 
             // Sort reverse-chronologically
             const sorted = [...records].sort((a, b) => b.block_height - a.block_height);
 
             const rowTemplate = this.shadowRoot.querySelector('#transactionrowtemplate');
 
-            for (const rec of sorted) {
-                this.transactionsTable.appendChild(rowTemplate.content.cloneNode(true));
-                const row = this.transactionsTable.lastElementChild;
-                const display = displayByToken.get(rec.token_id);
-
-                const dateString = rec.block_timestamp
-                    ? new Date(rec.block_timestamp).toJSON().substring(0, 'yyyy-MM-dd HH:mm'.length).replace('T', ' ')
-                    : '';
-
-                row.querySelector('.txrow_datetime').textContent = dateString;
-                row.querySelector('.txrow_block').textContent = rec.block_height;
-                row.querySelector('.txrow_token_symbol').textContent = display.symbol;
-                row.querySelector('.txrow_token_id').textContent = rec.token_id;
-                row.querySelector('.txrow_change').textContent = formatAmount(rec.amount, display.decimals);
-                row.querySelector('.txrow_balance').textContent = formatAmount(rec.balance_after, display.decimals);
-                row.querySelector('.txrow_counterparty').textContent = rec.counterparty ?? '';
-
-                const hashCell = row.querySelector('.txrow_hash');
-                if (rec.tx_hash) {
-                    const a = document.createElement('a');
-                    a.href = explorerTxUrl(rec.tx_hash);
-                    a.target = '_blank';
-                    a.rel = 'noopener';
-                    a.textContent = rec.tx_hash.slice(0, 10) + '…';
-                    hashCell.appendChild(a);
-                } else {
-                    hashCell.textContent = '';
-                }
-            }
-
+            // Pre-size the scroll container before any rows append so the
+            // sticky header doesn't jump as chunks arrive.
             const tableElement = this.shadowRoot.querySelector('.table-responsive');
             tableElement.style.height = (window.innerHeight - tableElement.getBoundingClientRect().top) + 'px';
+
+            // Chunked render: large accounts (20k+ records) would block the
+            // main thread for seconds if rendered in one pass. Build chunks
+            // off-DOM via DocumentFragment, append, yield to the event loop,
+            // repeat. The user sees rows appear progressively and can scroll
+            // / switch accounts without waiting for completion.
+            const CHUNK_SIZE = 200;
+            for (let i = 0; i < sorted.length; i += CHUNK_SIZE) {
+                if (!isCurrent()) return;
+                const fragment = document.createDocumentFragment();
+                const end = Math.min(i + CHUNK_SIZE, sorted.length);
+                for (let j = i; j < end; j++) {
+                    fragment.appendChild(this._buildRow(sorted[j], displayByToken, rowTemplate));
+                }
+                this.transactionsTable.appendChild(fragment);
+
+                if (end < sorted.length) {
+                    // Yield to the event loop so the browser can paint this
+                    // chunk, handle user input (scroll, account-switch click),
+                    // and stay responsive.
+                    await new Promise(r => setTimeout(r, 0));
+                }
+            }
+        }
+
+        _buildRow(rec, displayByToken, rowTemplate) {
+            const row = rowTemplate.content.cloneNode(true).firstElementChild;
+            const display = displayByToken.get(rec.token_id);
+
+            const dateString = rec.block_timestamp
+                ? new Date(rec.block_timestamp).toJSON().substring(0, 'yyyy-MM-dd HH:mm'.length).replace('T', ' ')
+                : '';
+
+            row.querySelector('.txrow_datetime').textContent = dateString;
+            row.querySelector('.txrow_block').textContent = rec.block_height;
+            row.querySelector('.txrow_token_symbol').textContent = display.symbol;
+            row.querySelector('.txrow_token_id').textContent = rec.token_id;
+            row.querySelector('.txrow_change').textContent = formatAmount(rec.amount, display.decimals);
+            row.querySelector('.txrow_balance').textContent = formatAmount(rec.balance_after, display.decimals);
+            row.querySelector('.txrow_counterparty').textContent = rec.counterparty ?? '';
+
+            const hashCell = row.querySelector('.txrow_hash');
+            if (rec.tx_hash) {
+                const a = document.createElement('a');
+                a.href = explorerTxUrl(rec.tx_hash);
+                a.target = '_blank';
+                a.rel = 'noopener';
+                a.textContent = rec.tx_hash.slice(0, 10) + '…';
+                hashCell.appendChild(a);
+            }
+            return row;
         }
     });

--- a/public_html/transactions/transactions-page.component.js
+++ b/public_html/transactions/transactions-page.component.js
@@ -4,6 +4,12 @@ import html from './transactions-page.component.html.js';
 
 const NEAR_DECIMALS = 24;
 
+/**
+ * Staking-pool records are excluded from the Transactions page — they are
+ * high-frequency periodic-snapshot noise that's better viewed on the dedicated
+ * Staking rewards page. Detection is the standard NEAR staking-pool naming
+ * convention.
+ */
 function isStakingPoolToken(tokenId) {
     return tokenId.includes('.poolv1.near') ||
            tokenId.includes('.pool.near') ||
@@ -11,16 +17,13 @@ function isStakingPoolToken(tokenId) {
 }
 
 /**
- * Resolve display info for a token_id once per unique value (records reuse the same
- * token_id heavily). Returns { symbol, decimals } where symbol is e.g. "NEAR",
- * "USDC", "BTC ( NEAR Intents / Bitcoin )", or "<pool>.poolv1.near (staked NEAR)".
+ * Resolve display info for a token_id once per unique value (records reuse the
+ * same token_id heavily). Returns { symbol, decimals } where symbol is e.g.
+ * "NEAR", "USDC", or "BTC ( NEAR Intents / Bitcoin )".
  */
 async function resolveTokenDisplay(tokenId) {
     if (tokenId === 'near') {
         return { symbol: 'NEAR', decimals: NEAR_DECIMALS };
-    }
-    if (isStakingPoolToken(tokenId)) {
-        return { symbol: `${tokenId} (staked NEAR)`, decimals: NEAR_DECIMALS };
     }
     const symbol = await resolveDisplaySymbol(tokenId, tokenId);
     const decimals = await resolveDecimals(tokenId, NEAR_DECIMALS);
@@ -79,14 +82,17 @@ customElements.define('transactions-page',
         }
 
         async updateView(account) {
-            const records = await getRecordsForAccount(account);
+            const allRecords = await getRecordsForAccount(account);
+            // Filter staking-pool records: high-frequency periodic snapshots
+            // belong on the Staking rewards page, not in the transaction list.
+            const records = allRecords.filter(r => !isStakingPoolToken(r.token_id));
 
             // Clear table
             while (this.transactionsTable.lastElementChild) {
                 this.transactionsTable.removeChild(this.transactionsTable.lastElementChild);
             }
 
-            if (records.length === 0) {
+            if (allRecords.length === 0) {
                 this.emptyState.style.display = '';
                 this.emptyState.textContent = `No records for ${account}. Visit the Accounts page and click "load from server" to fetch.`;
                 return;

--- a/public_html/transactions/transactions-page.component.js
+++ b/public_html/transactions/transactions-page.component.js
@@ -1,7 +1,54 @@
-import 'https://cdn.jsdelivr.net/npm/near-api-js@0.44.2/dist/near-api-js.min.js';
-import { getCurrencyList, getEODPrice } from '../pricedata/pricedata.js';
-import { getAccounts, getTransactionsForAccount } from '../storage/domainobjectstore.js';
+import { getAccounts, getRecordsForAccount } from '../storage/domainobjectstore.js';
+import { resolveDisplaySymbol, resolveDecimals } from '../near/intents-tokens.js';
 import html from './transactions-page.component.html.js';
+
+const NEAR_DECIMALS = 24;
+
+function isStakingPoolToken(tokenId) {
+    return tokenId.includes('.poolv1.near') ||
+           tokenId.includes('.pool.near') ||
+           tokenId.endsWith('.pool.f863973.m0');
+}
+
+/**
+ * Resolve display info for a token_id once per unique value (records reuse the same
+ * token_id heavily). Returns { symbol, decimals } where symbol is e.g. "NEAR",
+ * "USDC", "BTC ( NEAR Intents / Bitcoin )", or "<pool>.poolv1.near (staked NEAR)".
+ */
+async function resolveTokenDisplay(tokenId) {
+    if (tokenId === 'near') {
+        return { symbol: 'NEAR', decimals: NEAR_DECIMALS };
+    }
+    if (isStakingPoolToken(tokenId)) {
+        return { symbol: `${tokenId} (staked NEAR)`, decimals: NEAR_DECIMALS };
+    }
+    const symbol = await resolveDisplaySymbol(tokenId, tokenId);
+    const decimals = await resolveDecimals(tokenId, NEAR_DECIMALS);
+    return { symbol, decimals };
+}
+
+/**
+ * Format a yoctoUnits amount with the given decimals as a fixed-point string.
+ * Trailing fractional zeros are dropped for readability.
+ */
+function formatAmount(amountStr, decimals) {
+    if (amountStr === undefined || amountStr === null || amountStr === '') return '';
+    const negative = amountStr.startsWith('-');
+    const abs = negative ? amountStr.slice(1) : amountStr;
+    if (decimals === 0) {
+        return negative ? `-${abs}` : abs;
+    }
+    const padded = abs.padStart(decimals + 1, '0');
+    const intPart = padded.slice(0, padded.length - decimals);
+    const fracPart = padded.slice(padded.length - decimals);
+    const trimmedFrac = fracPart.replace(/0+$/, '');
+    const body = trimmedFrac ? `${intPart}.${trimmedFrac}` : intPart;
+    return negative ? `-${body}` : body;
+}
+
+function explorerTxUrl(txHash) {
+    return `https://explorer.near.org/transactions/${txHash}`;
+}
 
 customElements.define('transactions-page',
     class extends HTMLElement {
@@ -14,69 +61,78 @@ customElements.define('transactions-page',
         async loadHTML() {
             this.shadowRoot.innerHTML = html;
             this.transactionsTable = this.shadowRoot.getElementById('transactionstable');
+            this.emptyState = this.shadowRoot.getElementById('emptystate');
             document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
 
             const accountselect = this.shadowRoot.querySelector('#accountselect');
-            await Promise.all((await getAccounts()).map(async account => {
-                const accountoption = document.createElement('option');
-                accountoption.value = account;
-                accountoption.text = account;
-                accountselect.appendChild(accountoption);
-            }));
+            const accounts = await getAccounts();
+            for (const account of accounts) {
+                const option = document.createElement('option');
+                option.value = account;
+                option.text = account;
+                accountselect.appendChild(option);
+            }
 
-            const numDecimals = 2;
-            const currencyselect = this.shadowRoot.querySelector('#currencyselect');
-            (await getCurrencyList()).forEach(currency => {
-                const currencyoption = document.createElement('option');
-                currencyoption.value = currency;
-                currencyoption.text = currency.toUpperCase();
-                currencyselect.appendChild(currencyoption);
-            });
-
-            const viewSettingsChange = () => {
-                const account = accountselect.value;
-                const currency = currencyselect.value;
-                this.updateView(account, currency, numDecimals);
-            };
-            accountselect.addEventListener('change', viewSettingsChange);
-            currencyselect.addEventListener('change', viewSettingsChange);
+            accountselect.addEventListener('change', () => this.updateView(accountselect.value));
 
             return this.shadowRoot;
         }
 
-        async updateView(account, convertToCurrency, numDecimals) {
-            const accountHistory = await getTransactionsForAccount(account);
-            const transactionRowTemplate = this.shadowRoot.querySelector('#transactionrowtemplate');
-            let totalDeposits = 0;
-            let totalWithdrawals = 0;
-            while( this.transactionsTable.lastElementChild) {
+        async updateView(account) {
+            const records = await getRecordsForAccount(account);
+
+            // Clear table
+            while (this.transactionsTable.lastElementChild) {
                 this.transactionsTable.removeChild(this.transactionsTable.lastElementChild);
             }
 
-            for (let n = 0; n < accountHistory.length; n++) {
-                this.transactionsTable.appendChild(transactionRowTemplate.content.cloneNode(true));
-                const transactionRow = this.transactionsTable.lastElementChild;
-                const transaction = accountHistory[n];
-                const previousbalance = n < (accountHistory.length - 1) ? accountHistory[n + 1].balance : 0;
-                const changedBalance = ((transaction.balance - previousbalance) / 1e+24);
+            if (records.length === 0) {
+                this.emptyState.style.display = '';
+                this.emptyState.textContent = `No records for ${account}. Visit the Accounts page and click "load from server" to fetch.`;
+                return;
+            }
+            this.emptyState.style.display = 'none';
 
-                const transactionDateString = new Date(transaction.block_timestamp / 1_000_000).toJSON().substring(0, 'yyyy-MM-dd'.length);
-                const conversionRate = convertToCurrency == 'near' ? 1 : await getEODPrice(convertToCurrency, transactionDateString);
+            // Resolve display info once per unique token_id (records reuse the same id heavily)
+            const uniqueTokenIds = [...new Set(records.map(r => r.token_id))];
+            const displayByToken = new Map();
+            await Promise.all(uniqueTokenIds.map(async tid => {
+                displayByToken.set(tid, await resolveTokenDisplay(tid));
+            }));
 
-                transactionRow.querySelector('.transactionrow_datetime').innerHTML = transactionDateString;
-                transactionRow.querySelector('.transactionrow_kind').innerHTML = `${transaction.action_kind}${(transaction.action_kind == 'FUNCTION_CALL' ? `(${transaction.args.method_name})`: '')}`;
+            // Sort reverse-chronologically
+            const sorted = [...records].sort((a, b) => b.block_height - a.block_height);
 
-                transactionRow.querySelector('.transactionrow_balance').innerHTML = (conversionRate *
-                        (parseInt(transaction.balance) / 1e+24)
-                    ).toFixed(numDecimals);
+            const rowTemplate = this.shadowRoot.querySelector('#transactionrowtemplate');
 
+            for (const rec of sorted) {
+                this.transactionsTable.appendChild(rowTemplate.content.cloneNode(true));
+                const row = this.transactionsTable.lastElementChild;
+                const display = displayByToken.get(rec.token_id);
 
-                const fiatChangedBalance = (conversionRate * changedBalance);
-                transactionRow.querySelector('.transactionrow_change').innerHTML = fiatChangedBalance.toFixed(numDecimals);
+                const dateString = rec.block_timestamp
+                    ? new Date(rec.block_timestamp).toJSON().substring(0, 'yyyy-MM-dd HH:mm'.length).replace('T', ' ')
+                    : '';
 
-                transactionRow.querySelector('.transactionrow_signer').innerHTML = transaction.signer_id;
-                transactionRow.querySelector('.transactionrow_receiver').innerHTML = transaction.receiver_id;
-                transactionRow.querySelector('.transactionrow_hash').innerHTML = transaction.hash;
+                row.querySelector('.txrow_datetime').textContent = dateString;
+                row.querySelector('.txrow_block').textContent = rec.block_height;
+                row.querySelector('.txrow_token_symbol').textContent = display.symbol;
+                row.querySelector('.txrow_token_id').textContent = rec.token_id;
+                row.querySelector('.txrow_change').textContent = formatAmount(rec.amount, display.decimals);
+                row.querySelector('.txrow_balance').textContent = formatAmount(rec.balance_after, display.decimals);
+                row.querySelector('.txrow_counterparty').textContent = rec.counterparty ?? '';
+
+                const hashCell = row.querySelector('.txrow_hash');
+                if (rec.tx_hash) {
+                    const a = document.createElement('a');
+                    a.href = explorerTxUrl(rec.tx_hash);
+                    a.target = '_blank';
+                    a.rel = 'noopener';
+                    a.textContent = rec.tx_hash.slice(0, 10) + '…';
+                    hashCell.appendChild(a);
+                } else {
+                    hashCell.textContent = '';
+                }
             }
 
             const tableElement = this.shadowRoot.querySelector('.table-responsive');

--- a/public_html/transactions/transactions-page.component.js
+++ b/public_html/transactions/transactions-page.component.js
@@ -1,5 +1,6 @@
 import { getAccounts, getRecordsForAccount } from '../storage/domainobjectstore.js';
 import { resolveDisplaySymbol, resolveDecimals } from '../near/intents-tokens.js';
+import { setProgressbarValue } from '../ui/progress-bar.js';
 import html from './transactions-page.component.html.js';
 
 const NEAR_DECIMALS = 24;
@@ -82,6 +83,15 @@ customElements.define('transactions-page',
         }
 
         async updateView(account) {
+            setProgressbarValue('indeterminate', `Loading transactions for ${account}…`);
+            try {
+                await this._renderView(account);
+            } finally {
+                setProgressbarValue(null);
+            }
+        }
+
+        async _renderView(account) {
             const allRecords = await getRecordsForAccount(account);
             // Filter out:
             //  - Staking-pool records: high-frequency periodic snapshots belong

--- a/public_html/transactions/transactions-page.component.spec.js
+++ b/public_html/transactions/transactions-page.component.spec.js
@@ -11,7 +11,7 @@ describe('transactions-page', () => {
         await writeAccountingRecords(account, {
             version: 2,
             accountId: account,
-            metadata: { firstBlock: 100, lastBlock: 102, totalRecords: 4, historyComplete: true },
+            metadata: { firstBlock: 100, lastBlock: 103, totalRecords: 5, historyComplete: true },
             records: [
                 {
                     block_height: 100,
@@ -52,6 +52,17 @@ describe('transactions-page', () => {
                     balance_after: '10000000000000000000000000',
                     counterparty: 'astro-stakers.poolv1.near',
                     tx_hash: null
+                },
+                {
+                    // Zero-amount balance snapshot — should be filtered out.
+                    block_height: 103,
+                    block_timestamp: '2026-01-04T10:00:00.000Z',
+                    token_id: 'near',
+                    amount: '0',
+                    balance_before: '5000000000000000000000000',
+                    balance_after: '5000000000000000000000000',
+                    counterparty: null,
+                    tx_hash: null
                 }
             ]
         });
@@ -69,16 +80,17 @@ describe('transactions-page', () => {
         component.remove();
     });
 
-    it('renders one row per non-staking record (NEAR + FT + Intents), excluding staking-pool records', () => {
+    it('renders one row per balance-changing non-staking record', () => {
         const rows = shadowRoot.querySelectorAll('#transactionstable tr');
-        // 4 fixture records, 1 of which is a staking-pool record → 3 rendered rows
+        // 5 fixture records → minus 1 staking-pool → minus 1 zero-amount snapshot → 3 rendered
         expect(rows.length).to.equal(3);
     });
 
     it('orders rows reverse-chronologically (newest block first)', () => {
         const blocks = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_block'))
             .map(el => Number(el.textContent));
-        // After staking-pool filter: BTC (block 102), ARIZ (101), NEAR (100)
+        // After filters: BTC (block 102), ARIZ (101), NEAR (100). Block 103 is
+        // a zero-amount NEAR snapshot — filtered.
         expect(blocks).to.deep.equal([102, 101, 100]);
     });
 
@@ -86,6 +98,18 @@ describe('transactions-page', () => {
         const rawIds = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_token_id'))
             .map(el => el.textContent);
         expect(rawIds.some(id => id.includes('.poolv1.near') || id.includes('.pool.near'))).to.equal(false);
+    });
+
+    it('does not render zero-amount balance-snapshot rows', () => {
+        const changes = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_change'))
+            .map(el => el.textContent);
+        // None of the rendered changes should be exactly "0"
+        expect(changes.some(c => c === '0')).to.equal(false);
+        // The latest block in the fixture (103) is a zero-amount snapshot —
+        // shouldn't appear among the rendered blocks
+        const blocks = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_block'))
+            .map(el => Number(el.textContent));
+        expect(blocks.includes(103)).to.equal(false);
     });
 
     it('shows both the resolved symbol and the raw token_id', () => {

--- a/public_html/transactions/transactions-page.component.spec.js
+++ b/public_html/transactions/transactions-page.component.spec.js
@@ -69,19 +69,23 @@ describe('transactions-page', () => {
         component.remove();
     });
 
-    it('renders one row per record, including NEAR, FT, Intents, and staking pool', () => {
+    it('renders one row per non-staking record (NEAR + FT + Intents), excluding staking-pool records', () => {
         const rows = shadowRoot.querySelectorAll('#transactionstable tr');
-        expect(rows.length).to.equal(4);
+        // 4 fixture records, 1 of which is a staking-pool record → 3 rendered rows
+        expect(rows.length).to.equal(3);
     });
 
     it('orders rows reverse-chronologically (newest block first)', () => {
         const blocks = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_block'))
             .map(el => Number(el.textContent));
-        // Two records share block 102, then 101, then 100
-        expect(blocks[0]).to.equal(102);
-        expect(blocks[1]).to.equal(102);
-        expect(blocks[2]).to.equal(101);
-        expect(blocks[3]).to.equal(100);
+        // After staking-pool filter: BTC (block 102), ARIZ (101), NEAR (100)
+        expect(blocks).to.deep.equal([102, 101, 100]);
+    });
+
+    it('does not render any staking-pool rows', () => {
+        const rawIds = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_token_id'))
+            .map(el => el.textContent);
+        expect(rawIds.some(id => id.includes('.poolv1.near') || id.includes('.pool.near'))).to.equal(false);
     });
 
     it('shows both the resolved symbol and the raw token_id', () => {
@@ -90,34 +94,24 @@ describe('transactions-page', () => {
         const rawIds = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_token_id'))
             .map(el => el.textContent);
 
-        // NEAR row should show 'NEAR' as symbol
         expect(symbols).to.include('NEAR');
-        // staking pool row shows the pool id with a (staked NEAR) suffix
-        expect(symbols.some(s => s.includes('astro-stakers.poolv1.near') && s.includes('staked NEAR'))).to.equal(true);
-        // raw token_ids appear under each row's symbol
         expect(rawIds).to.include('near');
         expect(rawIds).to.include('arizcredits.near');
         expect(rawIds).to.include('nep141:btc.omft.near');
-        expect(rawIds).to.include('astro-stakers.poolv1.near');
     });
 
     it('formats NEAR amount with 24 decimals (5 NEAR row shows "5")', () => {
-        // Find the NEAR row (block 100)
         const rows = Array.from(shadowRoot.querySelectorAll('#transactionstable tr'));
         const nearRow = rows.find(r => r.querySelector('.txrow_token_id').textContent === 'near');
         expect(nearRow.querySelector('.txrow_change').textContent).to.equal('5');
         expect(nearRow.querySelector('.txrow_balance').textContent).to.equal('5');
     });
 
-    it('renders tx hash as an explorer link, omits link when tx_hash is null', () => {
+    it('renders tx hash as an explorer link', () => {
         const rows = Array.from(shadowRoot.querySelectorAll('#transactionstable tr'));
         const nearRow = rows.find(r => r.querySelector('.txrow_token_id').textContent === 'near');
         const link = nearRow.querySelector('.txrow_hash a');
         expect(link).to.not.equal(null);
         expect(link.href).to.equal('https://explorer.near.org/transactions/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1');
-
-        // staking row has null tx_hash → no link
-        const stakingRow = rows.find(r => r.querySelector('.txrow_token_id').textContent === 'astro-stakers.poolv1.near');
-        expect(stakingRow.querySelector('.txrow_hash a')).to.equal(null);
     });
 });

--- a/public_html/transactions/transactions-page.component.spec.js
+++ b/public_html/transactions/transactions-page.component.spec.js
@@ -1,0 +1,123 @@
+import './transactions-page.component.js';
+import { setAccounts, writeAccountingRecords } from '../storage/domainobjectstore.js';
+
+describe('transactions-page', () => {
+    const account = 'test.near';
+    let component;
+    let shadowRoot;
+
+    before(async () => {
+        await setAccounts([account]);
+        await writeAccountingRecords(account, {
+            version: 2,
+            accountId: account,
+            metadata: { firstBlock: 100, lastBlock: 102, totalRecords: 4, historyComplete: true },
+            records: [
+                {
+                    block_height: 100,
+                    block_timestamp: '2026-01-01T10:00:00.000Z',
+                    token_id: 'near',
+                    amount: '5000000000000000000000000', // +5 NEAR
+                    balance_before: '0',
+                    balance_after: '5000000000000000000000000',
+                    counterparty: 'sender.near',
+                    tx_hash: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1'
+                },
+                {
+                    block_height: 101,
+                    block_timestamp: '2026-01-02T10:00:00.000Z',
+                    token_id: 'arizcredits.near',
+                    amount: '1000000', // +1 ARIZ (6 decimals)
+                    balance_before: '0',
+                    balance_after: '1000000',
+                    counterparty: 'arizcredits.near',
+                    tx_hash: 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB2'
+                },
+                {
+                    block_height: 102,
+                    block_timestamp: '2026-01-03T10:00:00.000Z',
+                    token_id: 'nep141:btc.omft.near',
+                    amount: '50000', // +0.0005 BTC (8 decimals)
+                    balance_before: '0',
+                    balance_after: '50000',
+                    counterparty: 'solver-ref.near',
+                    tx_hash: 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC3'
+                },
+                {
+                    block_height: 102,
+                    block_timestamp: '2026-01-03T10:00:00.000Z',
+                    token_id: 'astro-stakers.poolv1.near',
+                    amount: '10000000000000000000000000', // +10 NEAR staked
+                    balance_before: '0',
+                    balance_after: '10000000000000000000000000',
+                    counterparty: 'astro-stakers.poolv1.near',
+                    tx_hash: null
+                }
+            ]
+        });
+
+        component = document.createElement('transactions-page');
+        document.body.appendChild(component);
+        shadowRoot = await component.readyPromise;
+
+        const select = shadowRoot.querySelector('#accountselect');
+        select.value = account;
+        await component.updateView(account);
+    });
+
+    after(() => {
+        component.remove();
+    });
+
+    it('renders one row per record, including NEAR, FT, Intents, and staking pool', () => {
+        const rows = shadowRoot.querySelectorAll('#transactionstable tr');
+        expect(rows.length).to.equal(4);
+    });
+
+    it('orders rows reverse-chronologically (newest block first)', () => {
+        const blocks = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_block'))
+            .map(el => Number(el.textContent));
+        // Two records share block 102, then 101, then 100
+        expect(blocks[0]).to.equal(102);
+        expect(blocks[1]).to.equal(102);
+        expect(blocks[2]).to.equal(101);
+        expect(blocks[3]).to.equal(100);
+    });
+
+    it('shows both the resolved symbol and the raw token_id', () => {
+        const symbols = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_token_symbol'))
+            .map(el => el.textContent);
+        const rawIds = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_token_id'))
+            .map(el => el.textContent);
+
+        // NEAR row should show 'NEAR' as symbol
+        expect(symbols).to.include('NEAR');
+        // staking pool row shows the pool id with a (staked NEAR) suffix
+        expect(symbols.some(s => s.includes('astro-stakers.poolv1.near') && s.includes('staked NEAR'))).to.equal(true);
+        // raw token_ids appear under each row's symbol
+        expect(rawIds).to.include('near');
+        expect(rawIds).to.include('arizcredits.near');
+        expect(rawIds).to.include('nep141:btc.omft.near');
+        expect(rawIds).to.include('astro-stakers.poolv1.near');
+    });
+
+    it('formats NEAR amount with 24 decimals (5 NEAR row shows "5")', () => {
+        // Find the NEAR row (block 100)
+        const rows = Array.from(shadowRoot.querySelectorAll('#transactionstable tr'));
+        const nearRow = rows.find(r => r.querySelector('.txrow_token_id').textContent === 'near');
+        expect(nearRow.querySelector('.txrow_change').textContent).to.equal('5');
+        expect(nearRow.querySelector('.txrow_balance').textContent).to.equal('5');
+    });
+
+    it('renders tx hash as an explorer link, omits link when tx_hash is null', () => {
+        const rows = Array.from(shadowRoot.querySelectorAll('#transactionstable tr'));
+        const nearRow = rows.find(r => r.querySelector('.txrow_token_id').textContent === 'near');
+        const link = nearRow.querySelector('.txrow_hash a');
+        expect(link).to.not.equal(null);
+        expect(link.href).to.equal('https://explorer.near.org/transactions/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1');
+
+        // staking row has null tx_hash → no link
+        const stakingRow = rows.find(r => r.querySelector('.txrow_token_id').textContent === 'astro-stakers.poolv1.near');
+        expect(stakingRow.querySelector('.txrow_hash a')).to.equal(null);
+    });
+});

--- a/testdata/accountingexport/accounts_tx-page-test.near_download_json.json
+++ b/testdata/accountingexport/accounts_tx-page-test.near_download_json.json
@@ -5,8 +5,8 @@
   "updatedAt": "2026-01-03T10:00:00.000Z",
   "metadata": {
     "firstBlock": 100,
-    "lastBlock": 102,
-    "totalRecords": 4,
+    "lastBlock": 103,
+    "totalRecords": 5,
     "historyComplete": true
   },
   "records": [
@@ -69,6 +69,21 @@
       "amount": "10000000000000000000000000",
       "balance_before": "0",
       "balance_after": "10000000000000000000000000"
+    },
+    {
+      "block_height": 103,
+      "block_timestamp": "2026-01-04T10:00:00.000Z",
+      "tx_hash": null,
+      "tx_block": null,
+      "signer_id": null,
+      "receiver_id": null,
+      "predecessor_id": null,
+      "token_id": "near",
+      "receipt_id": null,
+      "counterparty": null,
+      "amount": "0",
+      "balance_before": "5000000000000000000000000",
+      "balance_after": "5000000000000000000000000"
     }
   ]
 }

--- a/testdata/accountingexport/accounts_tx-page-test.near_download_json.json
+++ b/testdata/accountingexport/accounts_tx-page-test.near_download_json.json
@@ -1,0 +1,74 @@
+{
+  "version": 2,
+  "accountId": "tx-page-test.near",
+  "createdAt": "2025-12-01T00:00:00.000Z",
+  "updatedAt": "2026-01-03T10:00:00.000Z",
+  "metadata": {
+    "firstBlock": 100,
+    "lastBlock": 102,
+    "totalRecords": 4,
+    "historyComplete": true
+  },
+  "records": [
+    {
+      "block_height": 100,
+      "block_timestamp": "2026-01-01T10:00:00.000Z",
+      "tx_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+      "tx_block": null,
+      "signer_id": "sender.near",
+      "receiver_id": "tx-page-test.near",
+      "predecessor_id": "sender.near",
+      "token_id": "near",
+      "receipt_id": "RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR1",
+      "counterparty": "sender.near",
+      "amount": "5000000000000000000000000",
+      "balance_before": "0",
+      "balance_after": "5000000000000000000000000"
+    },
+    {
+      "block_height": 101,
+      "block_timestamp": "2026-01-02T10:00:00.000Z",
+      "tx_hash": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB2",
+      "tx_block": null,
+      "signer_id": "arizcredits.near",
+      "receiver_id": "tx-page-test.near",
+      "predecessor_id": "arizcredits.near",
+      "token_id": "arizcredits.near",
+      "receipt_id": "RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR2",
+      "counterparty": "arizcredits.near",
+      "amount": "1000000",
+      "balance_before": "0",
+      "balance_after": "1000000"
+    },
+    {
+      "block_height": 102,
+      "block_timestamp": "2026-01-03T10:00:00.000Z",
+      "tx_hash": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC3",
+      "tx_block": null,
+      "signer_id": "solver-ref.near",
+      "receiver_id": "tx-page-test.near",
+      "predecessor_id": "solver-ref.near",
+      "token_id": "nep141:btc.omft.near",
+      "receipt_id": "RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR3",
+      "counterparty": "solver-ref.near",
+      "amount": "50000",
+      "balance_before": "0",
+      "balance_after": "50000"
+    },
+    {
+      "block_height": 102,
+      "block_timestamp": "2026-01-03T10:00:00.000Z",
+      "tx_hash": null,
+      "tx_block": null,
+      "signer_id": null,
+      "receiver_id": null,
+      "predecessor_id": null,
+      "token_id": "astro-stakers.poolv1.near",
+      "receipt_id": null,
+      "counterparty": "astro-stakers.poolv1.near",
+      "amount": "10000000000000000000000000",
+      "balance_before": "0",
+      "balance_after": "10000000000000000000000000"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The Transactions page used to show only NEAR balance changes (derived via \`convertAccountingExportToTransactions\`). Anything that wasn't a NEAR transfer — fungible tokens, NEAR Intents balance changes, staking-pool balance shifts — was invisible.

The accounting-export worker already records every balance change as a flat V2 \`BalanceChangeRecord\`. This PR makes the page render those directly: one row per balance-changing event, NEAR + FTs + Intents, reverse-chronological. Staking pools and zero-amount snapshots are filtered as noise.

**Narrow scope**: year report, counterparties, profit/loss, staking-rewards calculations all keep using the existing converted shape. We only add a new parallel data path for the Transactions page — no regression risk for the rest of the app.

## What's in the PR

### Storage layer
- New \`fetchRawAccountingExport(accountId)\` in \`accounting-export.js\` that does the network fetch without running the V2→V1-internal conversion. \`fetchAccountingExportJSON\` is now a thin wrapper that runs the conversion on top, preserving the contract for existing callers.
- New \`writeAccountingRecords\` / \`getRecordsForAccount\` in \`domainobjectstore.js\`. \`fetchTransactionsFromAccountingExport\` now persists the raw V2 as \`accountdata/<account>/records.json\` alongside the existing derived files, then runs the conversion separately for the legacy consumers.

### Page component
- Reads records directly via \`getRecordsForAccount\`. No conversion in between.
- Filters applied: staking-pool records (high-frequency snapshots belong on the Staking rewards page) and zero-amount snapshots (worker liveness pings — pure noise here).
- Symbol/decimal resolution via \`intents-tokens.resolveDisplaySymbol\` / \`resolveDecimals\` (handles NEAR, FTs via cached \`ft_metadata\`, NEAR Intents via 1Click). Resolved once per unique \`token_id\` so 20k-row accounts render fast.
- **Chunked rendering** (200 rows per chunk, yielding to the event loop between chunks). 22k-record accounts no longer freeze the main thread; rows stream in progressively.
- **Generation-based abort**: switching accounts mid-render cancels the previous render so the table doesn't get rows from two different accounts mixed.
- **Indeterminate progress spinner** from click-account → first render, owned by the latest render only.

### HTML template + density
- New columns: date · block · token (resolved symbol + raw \`token_id\`) · change · balance after · counterparty · tx (explorer link)
- **Bootstrap 5.2.3 → 5.3.8** (CSS + integrity hash). Replaced the separate Popper + bootstrap.min.js pair with \`bootstrap.bundle.min.js\` (Popper bundled in — one fewer asset).
- Denser table using BS 5.3's table CSS custom properties: padding 0.4rem × 0.15rem on top of \`table-sm\`, 13px base font (11px for raw \`token_id\`, hash, counterparty), tabular-nums on all numeric cells, sticky-header z-index fix.

## Tests

- **wtr suite**: 85 tests pass (was 78 before this PR). The 7 new tests live in \`transactions-page.component.spec.js\`:
  - One row per non-staking, non-zero-amount record
  - Reverse-chronological ordering
  - No staking-pool rows
  - No zero-amount snapshot rows
  - Both resolved symbol and raw token_id rendered
  - NEAR amount formatting (yocto string → human-readable)
  - Tx-hash explorer link
- **Playwright**: new \`transactions-page.spec.js\` covers the full pipeline (load-from-server → \`records.json\` write → page render) with a 4-record V2 fixture. Catches the persist-raw vs persist-converted regression I shipped once during development.

## Migration

Existing users see an empty-state hint on first visit until they go to Accounts and click "load from server" — that's when \`records.json\` gets written. The legacy derived files (\`transactions.json\`, \`fungible_token_transactions.json\`, \`stakingpools/*.json\`) stay where they are; year report and friends continue to read them.

## Behaviour notes

- The new endpoint shape (\`/api/accounting/:accountId/download/json\`, gated by NEAR-token auth) was shipped already in arizas/ariz-gateway#10. This PR is purely the frontend half of the cutover for the Transactions page.
- Currency conversion (the old page had a fiat selector that converted NEAR amounts) is dropped in v1 — with multi-token rows it gets fiddly. Native amounts only for now.
- Year-report / counterparties / profit/loss are intentionally unchanged. A wider refactor to make those consume records directly stays an option but has no urgency right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)