### PR TITLE
Transactions page: token filter dropdown, drop block column & attribution row

### DIFF
--- a/public_html/app.html.js
+++ b/public_html/app.html.js
@@ -36,14 +36,6 @@ export default /*html*/ `
     </div>
     
 </nav>
-
-<nav class="navbar navbar-light bg-light small">
-    <div id="attributions" class="container">
-        <div class="navbar-text">
-            Powered by <a href="https://nearblocks.io">Nearblocks.io</a> APIs and <a href="https://fastnear.com">FastNEAR</a> RPC.
-        </div>
-    </div>
-</nav>
 <br />
 <div class="container" id="mainContainer">
     Get an overview of your NEAR accounts. See your transactions, staking rewards,

--- a/public_html/transactions/transactions-page.component.html.js
+++ b/public_html/transactions/transactions-page.component.html.js
@@ -59,18 +59,23 @@ export default /*html*/ `<style>
 </style>
 <h3>Transactions</h3>
 <p class="text-muted small mb-2">Every balance-changing event for the selected account: NEAR, fungible tokens, NEAR Intents, and staking pool balances. Source is the raw worker records from the Ariz gateway.</p>
-<div class="row">
+<div class="row g-2 mb-2">
     <div class="col-md-6">
         <label for="accountselect" class="form-label">Account</label>
         <select class="form-select" aria-label="Select account" id="accountselect">
             <option disabled selected value>Select account</option>
         </select>
     </div>
+    <div class="col-md-6">
+        <label for="tokenselect" class="form-label">Token</label>
+        <select class="form-select" aria-label="Filter by token" id="tokenselect" disabled>
+            <option selected value="">All tokens</option>
+        </select>
+    </div>
 </div>
 <template id="transactionrowtemplate">
     <tr>
         <td class="txrow_datetime"></td>
-        <td class="txrow_block numeric"></td>
         <td>
             <div class="txrow_token_symbol"></div>
             <div class="txrow_token_id"></div>
@@ -87,7 +92,6 @@ export default /*html*/ `<style>
         <thead class="table-dark">
             <tr>
                 <th scope="col">date</th>
-                <th scope="col">block</th>
                 <th scope="col">token</th>
                 <th scope="col">change</th>
                 <th scope="col">balance after</th>

--- a/public_html/transactions/transactions-page.component.js
+++ b/public_html/transactions/transactions-page.component.js
@@ -79,6 +79,11 @@ customElements.define('transactions-page',
 
             accountselect.addEventListener('change', () => this.updateView(accountselect.value));
 
+            this.tokenselect = this.shadowRoot.querySelector('#tokenselect');
+            // Re-render from the already-loaded records when the token filter
+            // changes — no refetch, just a different view of the same data.
+            this.tokenselect.addEventListener('change', () => this._renderTable());
+
             return this.shadowRoot;
         }
 
@@ -90,7 +95,9 @@ customElements.define('transactions-page',
 
             setProgressbarValue('indeterminate', `Loading transactions for ${account}…`);
             try {
-                await this._renderView(account, generation);
+                await this._loadAccount(account, generation);
+                if (this._renderGeneration !== generation) return;
+                await this._renderTable(generation);
             } finally {
                 // Only clear the spinner if this is still the latest render —
                 // a newer one will manage its own spinner state.
@@ -100,7 +107,7 @@ customElements.define('transactions-page',
             }
         }
 
-        async _renderView(account, generation) {
+        async _loadAccount(account, generation) {
             const isCurrent = () => this._renderGeneration === generation;
 
             const allRecords = await getRecordsForAccount(account);
@@ -123,18 +130,6 @@ customElements.define('transactions-page',
                 return true;
             });
 
-            // Clear table
-            while (this.transactionsTable.lastElementChild) {
-                this.transactionsTable.removeChild(this.transactionsTable.lastElementChild);
-            }
-
-            if (allRecords.length === 0) {
-                this.emptyState.style.display = '';
-                this.emptyState.textContent = `No records for ${account}. Visit the Accounts page and click "load from server" to fetch.`;
-                return;
-            }
-            this.emptyState.style.display = 'none';
-
             // Resolve display info once per unique token_id (records reuse the same id heavily)
             const uniqueTokenIds = [...new Set(records.map(r => r.token_id))];
             const displayByToken = new Map();
@@ -143,8 +138,64 @@ customElements.define('transactions-page',
             }));
             if (!isCurrent()) return;
 
+            // Stash for _renderTable (the token-filter change handler re-renders
+            // from this without refetching).
+            this._account = account;
+            this._records = records;
+            this._hasAnyRecords = allRecords.length > 0;
+            this._displayByToken = displayByToken;
+            this._populateTokenSelect(uniqueTokenIds, displayByToken);
+        }
+
+        /**
+         * Repopulate the token dropdown with the tokens present for the current
+         * account (plus the leading "All tokens" entry), sorted by symbol, and
+         * reset the filter to "All tokens".
+         */
+        _populateTokenSelect(uniqueTokenIds, displayByToken) {
+            const sel = this.tokenselect;
+            while (sel.options.length > 1) sel.remove(1); // keep the "All tokens" option
+            const sorted = [...uniqueTokenIds].sort((a, b) =>
+                (displayByToken.get(a)?.symbol ?? a).localeCompare(displayByToken.get(b)?.symbol ?? b));
+            for (const tid of sorted) {
+                const opt = document.createElement('option');
+                opt.value = tid;
+                opt.text = displayByToken.get(tid)?.symbol ?? tid;
+                sel.appendChild(opt);
+            }
+            sel.value = '';
+            sel.disabled = uniqueTokenIds.length === 0;
+        }
+
+        async _renderTable(generation) {
+            // When invoked from the token-filter change handler there's no
+            // generation, so start a fresh one (aborts any in-flight render).
+            if (generation === undefined) {
+                generation = (this._renderGeneration ?? 0) + 1;
+                this._renderGeneration = generation;
+            }
+            const isCurrent = () => this._renderGeneration === generation;
+
+            // Clear table
+            while (this.transactionsTable.lastElementChild) {
+                this.transactionsTable.removeChild(this.transactionsTable.lastElementChild);
+            }
+
+            if (!this._hasAnyRecords) {
+                this.emptyState.style.display = '';
+                this.emptyState.textContent = `No records for ${this._account}. Visit the Accounts page and click "load from server" to fetch.`;
+                return;
+            }
+            this.emptyState.style.display = 'none';
+
+            const displayByToken = this._displayByToken;
+            const tokenFilter = this.tokenselect.value;
+            const filtered = tokenFilter
+                ? this._records.filter(r => r.token_id === tokenFilter)
+                : this._records;
+
             // Sort reverse-chronologically
-            const sorted = [...records].sort((a, b) => b.block_height - a.block_height);
+            const sorted = [...filtered].sort((a, b) => b.block_height - a.block_height);
 
             const rowTemplate = this.shadowRoot.querySelector('#transactionrowtemplate');
 
@@ -186,7 +237,6 @@ customElements.define('transactions-page',
                 : '';
 
             row.querySelector('.txrow_datetime').textContent = dateString;
-            row.querySelector('.txrow_block').textContent = rec.block_height;
             row.querySelector('.txrow_token_symbol').textContent = display.symbol;
             row.querySelector('.txrow_token_id').textContent = rec.token_id;
             row.querySelector('.txrow_change').textContent = formatAmount(rec.amount, display.decimals);

--- a/public_html/transactions/transactions-page.component.spec.js
+++ b/public_html/transactions/transactions-page.component.spec.js
@@ -87,11 +87,11 @@ describe('transactions-page', () => {
     });
 
     it('orders rows reverse-chronologically (newest block first)', () => {
-        const blocks = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_block'))
-            .map(el => Number(el.textContent));
-        // After filters: BTC (block 102), ARIZ (101), NEAR (100). Block 103 is
-        // a zero-amount NEAR snapshot — filtered.
-        expect(blocks).to.deep.equal([102, 101, 100]);
+        const ids = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_token_id'))
+            .map(el => el.textContent);
+        // After filters, newest-first by block: BTC (102), ARIZ (101), NEAR (100).
+        // Block 103 is a zero-amount NEAR snapshot — filtered.
+        expect(ids).to.deep.equal(['nep141:btc.omft.near', 'arizcredits.near', 'near']);
     });
 
     it('does not render any staking-pool rows', () => {
@@ -105,11 +105,11 @@ describe('transactions-page', () => {
             .map(el => el.textContent);
         // None of the rendered changes should be exactly "0"
         expect(changes.some(c => c === '0')).to.equal(false);
-        // The latest block in the fixture (103) is a zero-amount snapshot —
-        // shouldn't appear among the rendered blocks
-        const blocks = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_block'))
-            .map(el => Number(el.textContent));
-        expect(blocks.includes(103)).to.equal(false);
+        // The fixture has two NEAR records (a +5 at block 100 and a zero-amount
+        // snapshot at block 103); only the +5 should be rendered.
+        const nearRows = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_token_id'))
+            .filter(el => el.textContent === 'near');
+        expect(nearRows.length).to.equal(1);
     });
 
     it('shows both the resolved symbol and the raw token_id', () => {
@@ -137,5 +137,31 @@ describe('transactions-page', () => {
         const link = nearRow.querySelector('.txrow_hash a');
         expect(link).to.not.equal(null);
         expect(link.href).to.equal('https://explorer.near.org/transactions/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1');
+    });
+
+    it('populates the token dropdown with the account tokens (staking excluded)', () => {
+        const values = Array.from(shadowRoot.querySelectorAll('#tokenselect option'))
+            .map(o => o.value);
+        expect(values[0]).to.equal(''); // leading "All tokens"
+        expect(values).to.include('near');
+        expect(values).to.include('arizcredits.near');
+        expect(values).to.include('nep141:btc.omft.near');
+        // staking-pool token is filtered out of the records, so not an option
+        expect(values).to.not.include('astro-stakers.poolv1.near');
+    });
+
+    it('filters the table to the selected token', async () => {
+        const sel = shadowRoot.querySelector('#tokenselect');
+        sel.value = 'near';
+        await component._renderTable();
+        const ids = Array.from(shadowRoot.querySelectorAll('#transactionstable .txrow_token_id'))
+            .map(el => el.textContent);
+        expect(ids).to.deep.equal(['near']);
+
+        // Reset back to "All tokens" so later assumptions hold.
+        sel.value = '';
+        await component._renderTable();
+        const allCount = shadowRoot.querySelectorAll('#transactionstable tr').length;
+        expect(allCount).to.equal(3);
     });
 });


### PR DESCRIPTION
## Summary

Three changes to the Transactions page (from review feedback):

- **Token select dropdown** — added beside the Account select. Populated per account with that account's tokens, sorted by symbol (staking-pool tokens excluded, matching the existing record filter). Changing it filters the table by re-rendering from the already-loaded records — no refetch. The render path is split into `_loadAccount` (fetch + filter + resolve symbols + populate dropdown) and `_renderTable` (filtered, chunked render), both keeping the existing generation-guard so switching account/token mid-render aborts cleanly.
- **Removed the block column** — dropped from the table header, the row template `<td>`, and the `_buildRow` assignment.
- **Removed the "Powered by" attribution row** — it lived in the app shell (`app.html.js`), not the transactions component.

## Tests

Updated `transactions-page.component.spec.js`: the two tests that keyed off the removed block column now assert on `token_id` order instead, plus two new tests covering the dropdown (lists the account's tokens with staking excluded; selecting a token filters the table).

Full unit suite passes: 87 tests, 16 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)