### PR TITLE
Frontend: NEP-413 login + Ariz credits UI (operator deduction)

### DIFF
--- a/public_html/app.html.js
+++ b/public_html/app.html.js
@@ -30,6 +30,7 @@ export default /*html*/ `
                 <a class="nav-item nav-link" href="/counterparties" data-page="counterparties">Counterparties</a>
                 <a class="nav-item nav-link" href="/accounts" data-page="accounts">Accounts</a>
                 <a class="nav-item nav-link" href="/storage" data-page="storage">Storage</a>
+                <a class="nav-item nav-link" href="/arizcredits" data-page="arizcredits">Ariz credits</a>
                 <button id="loginbutton" class="nav-item nav-button">Login</button>
             </div>
         </div>

--- a/public_html/app.js
+++ b/public_html/app.js
@@ -7,6 +7,7 @@ import './customexchangerates/customexchangerates-page.component.js';
 import './storage/storage-page.component.js';
 import './counterparties/counterparties-page.component.js';
 import './yearreport/yearreport-page.component.js';
+import './arizcredits/arizcredits-page.component.js';
 import './yearreport/yearreport-print.component.js';
 import './yearreport/yearsummary-alltokens-print.component.js';
 

--- a/public_html/app.js
+++ b/public_html/app.js
@@ -71,19 +71,20 @@ class AppNearNumbersComponent extends HTMLElement {
         });
 
         const loginButton = this.shadowRoot.querySelector('#loginbutton');
+        const refreshLoginButton = async () => {
+            loginButton.innerHTML = (await isSignedIn()) ? 'Logout' : 'Login';
+        };
         loginButton.addEventListener('click', async () => {
+            // near-connect resolves in-page (no redirect), so refresh the label
+            // once the login/logout settles.
             if (await isSignedIn()) {
-                logout();
-                loginButton.innerHTML = 'Login';
+                await logout();
             } else {
-                loginToArizGateway();
+                await loginToArizGateway();
             }
+            await refreshLoginButton();
         });
-        setTimeout(async () => {
-            if (await isSignedIn()) {
-                loginButton.innerHTML = 'Logout';
-            }
-        }, 0);
+        refreshLoginButton();
 
         const init = (async () => {
             if (await exists(accountsconfigfile)) {

--- a/public_html/arizcredits/arizcredits-page.component.html.js
+++ b/public_html/arizcredits/arizcredits-page.component.html.js
@@ -1,0 +1,43 @@
+export default /*html*/ `<style>
+    .ariz-stat { margin-bottom: 0.5rem; }
+    .ariz-stat .label { color: var(--bs-secondary-color, #6c757d); margin-right: 0.5rem; }
+    .ariz-value { font-variant-numeric: tabular-nums; font-weight: 500; }
+    #authrow { max-width: 28rem; }
+    .ariz-section { margin: 1rem 0; }
+</style>
+<h3>Ariz credits</h3>
+<p class="text-muted small mb-3">
+    Buy <strong>ARIZ</strong> and authorise the Ariz gateway to deduct ARIZ for the FastNear API
+    usage of syncing your account. Deductions happen at most once per day, up to the daily cap you set,
+    and the tokens go to the arizcredits.near treasury.
+</p>
+
+<div id="signedout" style="display:none;" class="alert alert-info">
+    Please log in (button at the top right) to manage your Ariz credits.
+</div>
+
+<div id="panel" style="display:none;">
+    <div class="ariz-stat"><span class="label">Account</span><span class="ariz-value" id="acct"></span></div>
+    <div class="ariz-stat"><span class="label">ARIZ balance</span><span class="ariz-value" id="balance">…</span></div>
+    <div class="ariz-stat"><span class="label">Gateway authorisation</span><span class="ariz-value" id="authstatus">…</span></div>
+    <div class="ariz-stat"><span class="label">Spent today</span><span class="ariz-value" id="spent">…</span></div>
+
+    <div class="ariz-section">
+        <button id="buybtn" class="btn btn-primary">Buy 3 ARIZ for 0.5 NEAR</button>
+    </div>
+
+    <div class="ariz-section">
+        <label for="maxperday" class="form-label">Daily deduction cap (ARIZ)</label>
+        <div class="input-group" id="authrow">
+            <input type="number" min="0" step="any" class="form-control" id="maxperday" placeholder="e.g. 1" />
+            <button id="authbtn" class="btn btn-success">Authorise gateway</button>
+        </div>
+    </div>
+
+    <div class="ariz-section">
+        <button id="revokebtn" class="btn btn-outline-danger">Revoke authorisation</button>
+    </div>
+
+    <div id="ariz-error" class="text-danger small" style="display:none;"></div>
+</div>
+`;

--- a/public_html/arizcredits/arizcredits-page.component.js
+++ b/public_html/arizcredits/arizcredits-page.component.js
@@ -1,0 +1,132 @@
+import { getAccountId, signAndSendTransaction } from '../arizgateway/arizgatewayaccess.js';
+import { callViewFunction } from '../near/rpc.js';
+import html from './arizcredits-page.component.html.js';
+
+export const ARIZCREDITS_CONTRACT_ID = 'arizcredits.near';
+// The operator the user authorises is the contract account itself (see the
+// contract's deduct: operator === current_account_id).
+export const OPERATOR_ACCOUNT = ARIZCREDITS_CONTRACT_ID;
+export const ARIZ_DECIMALS = 6;
+const GAS = '300000000000000'; // 300 Tgas
+const HALF_NEAR = '500000000000000000000000'; // 0.5 NEAR — buy_tokens_for_near price
+
+/** Format a raw 6-decimal ARIZ amount (string) as a human-readable number. */
+export function formatAriz(raw) {
+    const n = BigInt(raw ?? '0');
+    const base = 10n ** BigInt(ARIZ_DECIMALS);
+    const whole = n / base;
+    const frac = (n % base).toString().padStart(ARIZ_DECIMALS, '0').replace(/0+$/, '');
+    return frac ? `${whole}.${frac}` : `${whole}`;
+}
+
+/** Parse a human ARIZ amount ("1.5") to a raw 6-decimal integer string. */
+export function parseAriz(value) {
+    const [w, f = ''] = String(value).trim().split('.');
+    const frac = (f + '0'.repeat(ARIZ_DECIMALS)).slice(0, ARIZ_DECIMALS);
+    return (BigInt(w || '0') * 10n ** BigInt(ARIZ_DECIMALS) + BigInt(frac || '0')).toString();
+}
+
+/** Build a wallet-selector FunctionCall action that dispatches an on-chain JS method. */
+export function jsFunctionCall(functionName, extraArgs = {}, deposit = '0') {
+    return {
+        type: 'FunctionCall',
+        params: {
+            methodName: 'call_js_func',
+            args: { function_name: functionName, ...extraArgs },
+            gas: GAS,
+            deposit,
+        },
+    };
+}
+
+customElements.define('arizcredits-page',
+    class extends HTMLElement {
+        constructor() {
+            super();
+            this.attachShadow({ mode: 'open' });
+            this.readyPromise = this.loadHTML();
+        }
+
+        async loadHTML() {
+            this.shadowRoot.innerHTML = html;
+            document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
+
+            this.shadowRoot.getElementById('buybtn').addEventListener('click', () => this._run(() => this.buy()));
+            this.shadowRoot.getElementById('authbtn').addEventListener('click', () => this._run(() => this.authorize()));
+            this.shadowRoot.getElementById('revokebtn').addEventListener('click', () => this._run(() => this.revoke()));
+
+            await this.refresh();
+            return this.shadowRoot;
+        }
+
+        _setError(message) {
+            const el = this.shadowRoot.getElementById('ariz-error');
+            if (!el) return;
+            el.textContent = message || '';
+            el.style.display = message ? '' : 'none';
+        }
+
+        // Run an action, then refresh; surface errors instead of throwing.
+        async _run(action) {
+            this._setError('');
+            try {
+                await action();
+                await this.refresh();
+            } catch (e) {
+                this._setError(e?.message || String(e));
+            }
+        }
+
+        async refresh() {
+            const accountId = await getAccountId();
+            const signedout = this.shadowRoot.getElementById('signedout');
+            const panel = this.shadowRoot.getElementById('panel');
+            if (!accountId) {
+                signedout.style.display = '';
+                panel.style.display = 'none';
+                return;
+            }
+            signedout.style.display = 'none';
+            panel.style.display = '';
+            this._accountId = accountId;
+            this.shadowRoot.getElementById('acct').textContent = accountId;
+
+            const [balance, auth, spent] = await Promise.all([
+                callViewFunction(ARIZCREDITS_CONTRACT_ID, 'ft_balance_of', { account_id: accountId }).catch(() => '0'),
+                callViewFunction(ARIZCREDITS_CONTRACT_ID, 'view_js_func', {
+                    function_name: 'view_authorisation', user: accountId, operator_account: OPERATOR_ACCOUNT,
+                }).catch(() => null),
+                callViewFunction(ARIZCREDITS_CONTRACT_ID, 'view_js_func', {
+                    function_name: 'view_spent_since_reset', user: accountId, operator_account: OPERATOR_ACCOUNT,
+                }).catch(() => '0'),
+            ]);
+
+            this.shadowRoot.getElementById('balance').textContent = `${formatAriz(balance)} ARIZ`;
+            this.shadowRoot.getElementById('authstatus').textContent = auth
+                ? `up to ${formatAriz(auth.max_per_day)} ARIZ/day`
+                : 'not authorised';
+            this.shadowRoot.getElementById('spent').textContent = `${formatAriz(spent)} ARIZ`;
+            this.shadowRoot.getElementById('revokebtn').disabled = !auth;
+        }
+
+        async buy() {
+            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [jsFunctionCall('buy_tokens_for_near', {}, HALF_NEAR)]);
+        }
+
+        async authorize() {
+            const value = this.shadowRoot.getElementById('maxperday').value;
+            if (!value || Number(value) <= 0) {
+                throw new Error('Enter a daily cap greater than 0');
+            }
+            const max_amount_per_day = parseAriz(value);
+            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [
+                jsFunctionCall('authorize_deduction', { operator_account: OPERATOR_ACCOUNT, max_amount_per_day }),
+            ]);
+        }
+
+        async revoke() {
+            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [
+                jsFunctionCall('revoke_deduction', { operator_account: OPERATOR_ACCOUNT }),
+            ]);
+        }
+    });

--- a/public_html/arizcredits/arizcredits-page.component.spec.js
+++ b/public_html/arizcredits/arizcredits-page.component.spec.js
@@ -1,0 +1,112 @@
+import { __setTestWallet } from '../arizgateway/arizgatewayaccess.js';
+import { formatAriz, parseAriz, jsFunctionCall } from './arizcredits-page.component.js';
+import './arizcredits-page.component.js';
+
+describe('arizcredits helpers', () => {
+    it('formatAriz renders raw 6-decimal amounts', () => {
+        expect(formatAriz('3000000')).to.equal('3');
+        expect(formatAriz('1500000')).to.equal('1.5');
+        expect(formatAriz('0')).to.equal('0');
+        expect(formatAriz('1')).to.equal('0.000001');
+    });
+
+    it('parseAriz converts human ARIZ to raw 6-decimal', () => {
+        expect(parseAriz('3')).to.equal('3000000');
+        expect(parseAriz('1.5')).to.equal('1500000');
+        expect(parseAriz('0.000001')).to.equal('1');
+    });
+
+    it('jsFunctionCall builds a call_js_func dispatch action', () => {
+        const a = jsFunctionCall('revoke_deduction', { operator_account: 'arizcredits.near' });
+        expect(a.type).to.equal('FunctionCall');
+        expect(a.params.methodName).to.equal('call_js_func');
+        expect(a.params.args).to.deep.equal({ function_name: 'revoke_deduction', operator_account: 'arizcredits.near' });
+        expect(a.params.deposit).to.equal('0');
+    });
+});
+
+describe('arizcredits-page', () => {
+    let origFetch, sent;
+
+    function rpcReturn(jsonString) {
+        return { json: async () => ({ result: { result: Array.from(new TextEncoder().encode(jsonString)) } }) };
+    }
+
+    beforeEach(() => {
+        sent = [];
+        __setTestWallet({
+            accountId: 'alice.near',
+            async getAccounts() { return [{ accountId: 'alice.near' }]; },
+            async signAndSendTransaction(params) { sent.push(params); return { status: 'ok' }; },
+            async signMessage() { return { accountId: 'alice.near', publicKey: 'ed25519:x', signature: '' }; },
+            async signOut() {},
+        });
+        origFetch = globalThis.fetch;
+        globalThis.fetch = async (_url, opts) => {
+            const body = JSON.parse(opts.body);
+            const method = body.params.method_name;
+            const args = JSON.parse(atob(body.params.args_base64));
+            if (method === 'ft_balance_of') return rpcReturn('"3000000"');
+            if (method === 'view_js_func' && args.function_name === 'view_authorisation') {
+                return rpcReturn(JSON.stringify({ max_per_day: '1000000', last_deduct_day: '', spent_today: '0' }));
+            }
+            if (method === 'view_js_func' && args.function_name === 'view_spent_since_reset') return rpcReturn('"0"');
+            return rpcReturn('null');
+        };
+    });
+
+    afterEach(() => {
+        globalThis.fetch = origFetch;
+        __setTestWallet(null);
+    });
+
+    it('renders balance + authorisation for the signed-in account', async () => {
+        const el = document.createElement('arizcredits-page');
+        document.body.appendChild(el);
+        const root = await el.readyPromise;
+        expect(root.getElementById('acct').textContent).to.equal('alice.near');
+        expect(root.getElementById('balance').textContent).to.equal('3 ARIZ');
+        expect(root.getElementById('authstatus').textContent).to.equal('up to 1 ARIZ/day');
+        expect(root.getElementById('spent').textContent).to.equal('0 ARIZ');
+        el.remove();
+    });
+
+    it('authorize sends call_js_func authorize_deduction with the raw cap', async () => {
+        const el = document.createElement('arizcredits-page');
+        document.body.appendChild(el);
+        await el.readyPromise;
+        el.shadowRoot.getElementById('maxperday').value = '2.5';
+        await el._run(() => el.authorize());
+
+        expect(sent.length).to.equal(1);
+        expect(sent[0].receiverId).to.equal('arizcredits.near');
+        expect(sent[0].actions[0].params.args).to.deep.equal({
+            function_name: 'authorize_deduction',
+            operator_account: 'arizcredits.near',
+            max_amount_per_day: '2500000',
+        });
+        el.remove();
+    });
+
+    it('buy sends buy_tokens_for_near with 0.5 NEAR attached', async () => {
+        const el = document.createElement('arizcredits-page');
+        document.body.appendChild(el);
+        await el.readyPromise;
+        await el._run(() => el.buy());
+
+        const action = sent[0].actions[0];
+        expect(action.params.args.function_name).to.equal('buy_tokens_for_near');
+        expect(action.params.deposit).to.equal('500000000000000000000000');
+        el.remove();
+    });
+
+    it('shows the signed-out notice when no account', async () => {
+        __setTestWallet({ async getAccounts() { return []; } });
+        const el = document.createElement('arizcredits-page');
+        document.body.appendChild(el);
+        const root = await el.readyPromise;
+        expect(root.getElementById('signedout').style.display).to.equal('');
+        expect(root.getElementById('panel').style.display).to.equal('none');
+        el.remove();
+    });
+});

--- a/public_html/arizgateway/arizgatewayaccess.js
+++ b/public_html/arizgateway/arizgatewayaccess.js
@@ -1,215 +1,177 @@
-import nearApi from 'near-api-js';
-import { modalAlert, modalYesNo } from '../ui/modal.js';
 import { setProgressbarValue } from '../ui/progress-bar.js';
 
-const keyStore = new nearApi.keyStores.BrowserLocalStorageKeyStore();
-const contractId = 'arizportfolio.near';
-export const ACCESS_TOKEN_SESSION_STORAGE_KEY = 'ariz_gateway_access_token';
-export const TOKEN_EXPIRY_MILLIS = 5 * 60 * 1000;
+// Login + gateway auth via NEP-413 signed messages (@hot-labs/near-connect).
+//
+// Instead of registering an on-chain access token (the old register_token / 0.2
+// NEAR flow), the user signs a NEP-413 message with their wallet. The signed
+// message is sent to the gateway as a Bearer token; the gateway verifies the
+// signature, recipient, a timestamp window, and that the signing key is a Full
+// Access key on the account. See ariz-gateway/server/accesscontrol/nep413.js.
+
+const CONTRACT_ID = 'arizportfolio.near';
+// The NEP-413 recipient the gateway expects (it defaults recipient to its
+// contract id).
+const RECIPIENT = CONTRACT_ID;
 export const arizgatewayhost = 'https://arizgateway.fly.dev';
 //export const arizgatewayhost = 'http://localhost:15000';
+export const ACCESS_TOKEN_SESSION_STORAGE_KEY = 'ariz_gateway_access_token';
+// Re-sign before the gateway's NEP-413 validity window (1h) elapses, so a cached
+// token is always accepted.
+const TOKEN_TTL_MS = 50 * 60 * 1000;
 
+let _connectorPromise = null;
+let _testWallet = null; // injected by specs so they don't need a real wallet
 
-const nearConfig = {
-    nodeUrl: 'https://rpc.mainnet.fastnear.com',
-    walletUrl: 'https://app.mynearwallet.com',
-    networkId: 'mainnet',
-    keyStore
-};
+/**
+ * Test hook: inject a fake wallet (with getAccounts/signMessage/signOut) so
+ * specs can exercise the signed-in code paths without a real near-connect
+ * session. Pass null to clear.
+ */
+export function __setTestWallet(wallet) {
+    _testWallet = wallet;
+}
 
-export async function getWalletConnection() {
-    const near = await nearApi.connect(nearConfig);
-    const walletConnection = new nearApi.WalletConnection(near, 'Ariz portfolio');
-    return walletConnection;
+async function getConnector() {
+    if (!_connectorPromise) {
+        // Lazy dynamic import so specs that only use the injected test wallet
+        // never load the wallet UI library.
+        _connectorPromise = import('@hot-labs/near-connect').then(
+            ({ NearConnector }) => new NearConnector({ network: 'mainnet' })
+        );
+    }
+    return _connectorPromise;
+}
+
+async function currentWallet() {
+    if (_testWallet) return _testWallet;
+    try {
+        const connector = await getConnector();
+        return await connector.wallet();
+    } catch {
+        return null; // not connected
+    }
+}
+
+async function accountIdFromWallet(wallet) {
+    if (!wallet) return null;
+    try {
+        const accounts = await wallet.getAccounts();
+        return accounts?.[0]?.accountId ?? wallet.accountId ?? null;
+    } catch {
+        return wallet.accountId ?? null;
+    }
+}
+
+export async function getAccountId() {
+    return accountIdFromWallet(await currentWallet());
 }
 
 export async function loginToArizGateway() {
-    if (await modalYesNo('Login to Ariz gateway', `
-        By logging in to the Ariz gateway, you will get access to conversion rates for many currencies.
-        If you click "yes", you will be redirected to <b>MyNearWallet</b> for signing into the Ariz Portfolio contract. After signing in
-        you will be prompted to pay 0.2 NEAR for registering an access token to the Ariz gateway on this device. The access token
-        will be valid in 5 minutes, and will have to be renewed if requesting more data from the Ariz gateway. The renewal cost is only the gas
-        for the smart contract call.
-    `)) {
-        const walletConnection = await getWalletConnection();
-        await walletConnection.requestSignIn({ contractId, successUrl: location.origin, failureUrl: location.origin });
-    }
-}
-
-export async function isSignedIn() {
-    const walletConnection = await getWalletConnection();
-    return walletConnection.isSignedIn();
+    const connector = await getConnector();
+    await connector.connect(); // opens the wallet-selection modal
 }
 
 export async function logout() {
-    const walletConnection = await getWalletConnection();
-    return walletConnection.signOut();
-}
-
-export function isTokenValidForAccount(accountId, tokenPayload) {
-    return accountId == tokenPayload.accountId && tokenPayload.iat <= new Date().getTime() &&
-        tokenPayload.iat > (new Date().getTime() - TOKEN_EXPIRY_MILLIS)
-}
-
-// Cache the contract view result so a batch of fetchFromArizGateway calls
-// (e.g. "load from server" iterating over many accounts) doesn't fire a
-// get_account_id_for_token RPC for every single one.
-const TOKEN_VERIFICATION_TTL_MS = 60 * 1000;
-const tokenVerificationCache = new Map(); // token → { accountId, tokenHashBytes, verifiedAt }
-
-export async function getAccessToken() {
-    const storedAccessToken = localStorage.getItem(ACCESS_TOKEN_SESSION_STORAGE_KEY);
-
-    if (storedAccessToken) {
-        const walletConnection = await getWalletConnection();
-        const account = walletConnection.account();
-        const token_parts = storedAccessToken.split('.');
-        const token_payload = atob(token_parts[0], 'base64');
-        const token_payload_obj = JSON.parse(token_payload);
-
-        let registeredAccountIdForToken;
-        let token_hash_bytes;
-        const cached = tokenVerificationCache.get(storedAccessToken);
-        if (cached && (Date.now() - cached.verifiedAt) < TOKEN_VERIFICATION_TTL_MS) {
-            registeredAccountIdForToken = cached.accountId;
-            token_hash_bytes = cached.tokenHashBytes;
-        } else {
-            const token_payload_bytes = new TextEncoder().encode(token_payload);
-            token_hash_bytes = new Uint8Array(await crypto.subtle.digest("SHA-256", token_payload_bytes));
-            registeredAccountIdForToken = await account.viewFunction({
-                contractId,
-                methodName: 'get_account_id_for_token',
-                args: { token_hash: Array.from(token_hash_bytes) }
-            });
-            tokenVerificationCache.set(storedAccessToken, {
-                accountId: registeredAccountIdForToken,
-                tokenHashBytes: token_hash_bytes,
-                verifiedAt: Date.now()
-            });
-        }
-
-        if (isTokenValidForAccount(registeredAccountIdForToken, token_payload_obj)) {
-            return storedAccessToken;
-        } else if (registeredAccountIdForToken === account.accountId) {
-            setProgressbarValue('indeterminate', 'Renewing Ariz gateway access token');
-            const renewedAccessToken = await createAccessToken(token_hash_bytes);
-            setProgressbarValue(null);
-            return renewedAccessToken;
-        }
+    localStorage.removeItem(ACCESS_TOKEN_SESSION_STORAGE_KEY);
+    if (_testWallet) {
+        _testWallet = null;
+        return;
     }
-
-    setProgressbarValue('indeterminate', 'Create Ariz gateway access token');
-    await createAccessToken();
-    setProgressbarValue(null);
+    try {
+        const connector = await getConnector();
+        const wallet = await connector.wallet();
+        await connector.disconnect(wallet);
+    } catch {
+        // not connected — nothing to do
+    }
 }
 
-export async function uint8ArrayToBase64(uint8Array) {
-    // Create a Blob from the Uint8Array
-    const blob = new Blob([uint8Array], { type: 'application/octet-stream' });
-
-    // Create a FileReader to read the Blob as a Data URL
-    const reader = new FileReader();
-
-    // Return a promise that resolves when the FileReader finishes reading
-    return new Promise((resolve, reject) => {
-        // Define the onload event handler
-        reader.onload = function (event) {
-            // The result is a Data URL, which includes the Base64 encoded string
-            const base64String = event.target.result.split(',')[1];
-            resolve(base64String);
-        };
-
-        // Define the onerror event handler
-        reader.onerror = function (error) {
-            reject(error);
-        };
-
-        // Read the Blob as a Data URL
-        reader.readAsDataURL(blob);
-    });
+function readCachedToken() {
+    const raw = localStorage.getItem(ACCESS_TOKEN_SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return null;
+    }
 }
 
-export async function createAccessTokenPayload() {
-    const walletConnection = await getWalletConnection();
-    const accountId = walletConnection.getAccountId();
-
-    const keyPair = await keyStore.getKey(nearConfig.networkId, accountId);
-
-    const tokenPayload = JSON.stringify({ iat: new Date().getTime(), accountId, publicKey: keyPair.getPublicKey().toString() });
-    const tokenBytes = new TextEncoder().encode(tokenPayload);
-    const tokenHash = new Uint8Array(await crypto.subtle.digest("SHA-256", tokenBytes));
-
-    const signatureObj = await keyPair.sign(tokenHash);
-
-    const signatureBytes = signatureObj.signature;
-    const token = `${await uint8ArrayToBase64(tokenBytes)}.${await uint8ArrayToBase64(signatureBytes)}`;
-    return { token, tokenHash, signatureBytes, publicKeyBytes: keyPair.getPublicKey().data, walletConnection };
+function cachedTokenIsFresh(cached) {
+    return !!(cached && cached.token && cached.issuedAt && (Date.now() - cached.issuedAt) < TOKEN_TTL_MS);
 }
 
-export async function createAccessToken(oldTokenHash) {
-    const { token, tokenHash, signatureBytes, publicKeyBytes, walletConnection } = await createAccessTokenPayload();
+export async function isSignedIn() {
+    // A fresh cached token implies an active session without touching the wallet.
+    if (cachedTokenIsFresh(readCachedToken())) return true;
+    return !!(await accountIdFromWallet(await currentWallet()));
+}
 
-    const args = {
-        token_hash: Array.from(tokenHash),
-        signature: Array.from(signatureBytes),
-        public_key: Array.from(publicKeyBytes)
+function bytesToBase64(bytes) {
+    let s = '';
+    for (const b of bytes) s += String.fromCharCode(b);
+    return btoa(s);
+}
+
+function stringToBase64(str) {
+    return bytesToBase64(new TextEncoder().encode(str));
+}
+
+// Sign a fresh NEP-413 message and cache the resulting bearer token.
+async function createAccessToken() {
+    const wallet = await currentWallet();
+    if (!wallet) throw new Error('Not signed in to the Ariz gateway');
+
+    const issuedAt = Date.now();
+    const message = JSON.stringify({ issuedAt });
+    const nonce = crypto.getRandomValues(new Uint8Array(32));
+    const signed = await wallet.signMessage({ message, recipient: RECIPIENT, nonce });
+
+    const payload = {
+        accountId: signed.accountId,
+        publicKey: signed.publicKey,
+        signature: signed.signature, // base64 per NEP-413
+        message,
+        nonce: bytesToBase64(nonce),
+        recipient: RECIPIENT,
     };
-
-    const account = walletConnection.account();
-
-    if (oldTokenHash) {
-        args.old_token_hash = Array.from(oldTokenHash);
-        args.new_token_hash = args.token_hash;
-        try {
-            await account.functionCall({
-                contractId: contractId,
-                methodName: 'replace_token',
-                args
-            });
-            localStorage.setItem(ACCESS_TOKEN_SESSION_STORAGE_KEY, token);
-        } catch (e) {
-            if (await modalYesNo('Error renewing token', `<p>There was a problem renewing your access token:</p>
-                ${e.message}
-                <p>
-                Do you want to delete the existing access token, so that a new will be registered on the next attempt (costs 0.2 NEAR) ?
-                </p>`)
-            ) {
-                localStorage.removeItem(ACCESS_TOKEN_SESSION_STORAGE_KEY);
-            }
-        }
-    } else {
-        localStorage.setItem(ACCESS_TOKEN_SESSION_STORAGE_KEY, token);
-        await account.functionCall({
-            contractId: contractId,
-            methodName: 'register_token',
-            args,
-            attachedDeposit: nearApi.utils.format.parseNearAmount('0.2')
-        });
-    }
+    const token = stringToBase64(JSON.stringify(payload));
+    localStorage.setItem(
+        ACCESS_TOKEN_SESSION_STORAGE_KEY,
+        JSON.stringify({ token, accountId: signed.accountId, issuedAt })
+    );
     return token;
 }
 
+export async function getAccessToken() {
+    const cached = readCachedToken();
+    if (cachedTokenIsFresh(cached)) return cached.token;
+
+    setProgressbarValue('indeterminate', 'Signing in to the Ariz gateway');
+    try {
+        return await createAccessToken();
+    } finally {
+        setProgressbarValue(null);
+    }
+}
+
 export async function fetchFromArizGateway(path) {
-    if (await isSignedIn()) {
-        try {
-            const arizGatewayAccessToken = await getAccessToken();
-            setProgressbarValue('indeterminate', 'Loading data from Ariz gateway');
-            const response = await fetch(`${arizgatewayhost}${path}`, {
-                headers: {
-                    "authorization": `Bearer ${arizGatewayAccessToken}`
-                }
-            });
-            setProgressbarValue(null);
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`${response.status} ${response.statusText}: ${errorText}`);
-            }
-            return await response.json();
-        } catch (e) {
-            setProgressbarValue(null);
-            throw (e);
-        }
-    } else {
+    if (!(await isSignedIn())) {
         return {};
+    }
+    try {
+        const arizGatewayAccessToken = await getAccessToken();
+        setProgressbarValue('indeterminate', 'Loading data from Ariz gateway');
+        const response = await fetch(`${arizgatewayhost}${path}`, {
+            headers: { 'authorization': `Bearer ${arizGatewayAccessToken}` }
+        });
+        setProgressbarValue(null);
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`${response.status} ${response.statusText}: ${errorText}`);
+        }
+        return await response.json();
+    } catch (e) {
+        setProgressbarValue(null);
+        throw e;
     }
 }

--- a/public_html/arizgateway/arizgatewayaccess.js
+++ b/public_html/arizgateway/arizgatewayaccess.js
@@ -66,6 +66,21 @@ export async function getAccountId() {
     return accountIdFromWallet(await currentWallet());
 }
 
+/**
+ * Sign and send a transaction through the connected wallet (NEAR Connect).
+ * Prompts a login first if not connected. `actions` use the wallet-selector
+ * shape, e.g. [{ type: 'FunctionCall', params: { methodName, args, gas, deposit } }].
+ */
+export async function signAndSendTransaction(receiverId, actions) {
+    let wallet = await currentWallet();
+    if (!wallet) {
+        await loginToArizGateway();
+        wallet = await currentWallet();
+    }
+    if (!wallet) throw new Error('Not signed in to the Ariz gateway');
+    return wallet.signAndSendTransaction({ receiverId, actions });
+}
+
 export async function loginToArizGateway() {
     const connector = await getConnector();
     await connector.connect(); // opens the wallet-selection modal

--- a/public_html/arizgateway/arizgatewayaccess.spec.js
+++ b/public_html/arizgateway/arizgatewayaccess.spec.js
@@ -1,17 +1,75 @@
-import { ACCESS_TOKEN_SESSION_STORAGE_KEY, createAccessTokenPayload, isTokenValidForAccount } from './arizgatewayaccess.js';
+import {
+    ACCESS_TOKEN_SESSION_STORAGE_KEY,
+    __setTestWallet,
+    getAccessToken,
+    isSignedIn,
+} from './arizgatewayaccess.js';
 
+// Inject a fake @hot-labs/near-connect wallet so specs can exercise the
+// signed-in code paths without a real wallet session. It produces a
+// NEP-413-shaped signed message (accountId / publicKey / signature).
 export function mockWalletAuthenticationData(accountId = 'test.near') {
-    localStorage.setItem(
-        "Ariz portfolio_wallet_auth_key",
-        JSON.stringify({ accountId, allKeys: ["ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi"] })
-    );
-    localStorage.setItem(
-        `near-api-js:keystore:${accountId}:mainnet`,
-        "ed25519:eUVkG7dVfg5Z776MPy7d4L23cmEtAxrYoP1HgWSQrBy1GHdaZystRkYyz4ANN5uyKceuUrjyoLWaPgpzvo3BNDZ"
-    );
+    __setTestWallet({
+        accountId,
+        async getAccounts() {
+            return [{ accountId }];
+        },
+        async signMessage({ message, recipient, nonce }) {
+            return {
+                accountId,
+                publicKey: 'ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi',
+                // 64-byte zero signature, base64 — fine for frontend tests; the
+                // real gateway verifies signatures, but it isn't exercised here.
+                signature: btoa(String.fromCharCode(...new Uint8Array(64))),
+            };
+        },
+        async signOut() {},
+    });
 }
 
+// Build and cache a gateway access token using the mocked wallet.
 export async function mockArizGatewayAccess() {
-    const {token } = await createAccessTokenPayload();
-    localStorage.setItem(ACCESS_TOKEN_SESSION_STORAGE_KEY, token);
+    await getAccessToken();
 }
+
+describe('arizgatewayaccess (NEP-413)', () => {
+    beforeEach(() => {
+        localStorage.removeItem(ACCESS_TOKEN_SESSION_STORAGE_KEY);
+        __setTestWallet(null);
+    });
+
+    it('builds a NEP-413 bearer token and caches it', async () => {
+        mockWalletAuthenticationData('alice.near');
+        const token = await getAccessToken();
+
+        const payload = JSON.parse(new TextDecoder().decode(Uint8Array.from(atob(token), c => c.charCodeAt(0))));
+        expect(payload.accountId).to.equal('alice.near');
+        expect(payload.recipient).to.equal('arizportfolio.near');
+        expect(payload.publicKey).to.match(/^ed25519:/);
+        expect(typeof payload.signature).to.equal('string');
+        expect(JSON.parse(payload.message)).to.have.property('issuedAt');
+
+        const cached = JSON.parse(localStorage.getItem(ACCESS_TOKEN_SESSION_STORAGE_KEY));
+        expect(cached.token).to.equal(token);
+        expect(cached.accountId).to.equal('alice.near');
+    });
+
+    it('reuses the cached token on the next call (no re-sign)', async () => {
+        mockWalletAuthenticationData('alice.near');
+        const first = await getAccessToken();
+        // Drop the wallet: a re-sign would now throw, so a second token proves caching.
+        __setTestWallet(null);
+        const second = await getAccessToken();
+        expect(second).to.equal(first);
+    });
+
+    it('isSignedIn is true with a fresh cached token, false after logout clears it', async () => {
+        mockWalletAuthenticationData('alice.near');
+        await getAccessToken();
+        expect(await isSignedIn()).to.equal(true);
+
+        localStorage.removeItem(ACCESS_TOKEN_SESSION_STORAGE_KEY);
+        __setTestWallet(null);
+        expect(await isSignedIn()).to.equal(false);
+    });
+});

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -8,7 +8,8 @@
     <script type="importmap">
     {
       "imports": {
-        "near-api-js": "https://ga.jspm.io/npm:near-api-js@4.0.2/lib/browser-index.js"
+        "near-api-js": "https://ga.jspm.io/npm:near-api-js@4.0.2/lib/browser-index.js",
+        "@hot-labs/near-connect": "https://esm.sh/@hot-labs/near-connect@0.11.4"
       },
       "scopes": {
         "https://ga.jspm.io/": {

--- a/public_html/near/rpc.js
+++ b/public_html/near/rpc.js
@@ -9,6 +9,40 @@ export async function queryMultipleRPC(queryFunction) {
 }
 
 /**
+ * Call a contract view function via JSON-RPC and return the decoded JSON result.
+ * @param {string} contractId
+ * @param {string} methodName
+ * @param {object} [args]
+ * @returns {Promise<any>} the parsed return value (null if the method returned nothing)
+ */
+export async function callViewFunction(contractId, methodName, args = {}) {
+    const response = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 'view',
+            method: 'query',
+            params: {
+                request_type: 'call_function',
+                finality: 'final',
+                account_id: contractId,
+                method_name: methodName,
+                args_base64: btoa(JSON.stringify(args))
+            }
+        })
+    });
+    const result = await response.json();
+    if (result.error) {
+        throw new Error(result.error.data || result.error.message || JSON.stringify(result.error));
+    }
+    if (result?.result?.result) {
+        return JSON.parse(new TextDecoder().decode(new Uint8Array(result.result.result)));
+    }
+    return null;
+}
+
+/**
  * Fetch ft_metadata from a fungible token contract
  * @param {string} contractId - The fungible token contract ID
  * @returns {Promise<{spec: string, name: string, symbol: string, decimals: number, icon?: string}|null>}


### PR DESCRIPTION
## Summary

Frontend for NEP-413 auth and the ARIZ operator-deduction flow. Pairs with ariz-gateway#12 (backend) and petersalomonsen/near-accounting-export#58 (worker metrics, merged).

### NEP-413 login (replaces MyNearWallet + register_token)
- `arizgatewayaccess.js`: login via `@hot-labs/near-connect` `NearConnector.connect()` (lazy dynamic import). `getAccessToken()` signs a NEP-413 message and caches the Bearer token (reused under the gateway's 1h window). Public API preserved. Added `signAndSendTransaction(receiverId, actions)` for contract calls.
- `app.js`: refresh the login button in-page (no redirect).
- `index.html`: `@hot-labs/near-connect` in the import map (ESM via esm.sh).

### Ariz credits page
- New `arizcredits-page` (nav: **Ariz credits**): shows ARIZ balance (`ft_balance_of`), gateway authorisation (`view_authorisation`) and spend today (`view_spent_since_reset`); buttons to **buy ARIZ** (`buy_tokens_for_near`, 0.5 NEAR → 3 ARIZ), **authorise** with a daily cap (`authorize_deduction`) and **revoke** (`revoke_deduction`), via `wallet.signAndSendTransaction`.
- `rpc.js`: generic `callViewFunction`.

## Tests
Full frontend suite: **118 passed, 0 failed** (incl. reworked shared wallet mocks + 7 ARIZ-credits tests + 3 NEP-413 token tests).

## Deploy dependency
Login/credits work end-to-end only once ariz-gateway#12 is deployed (NEP-413 verification + the arizcredits.near JS upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)