### PR TITLE
Accounts: per-account ARIZ funding + authorization (multi-account billing)

### DIFF
--- a/public_html/accounts/accounts-page.component.html.js
+++ b/public_html/accounts/accounts-page.component.html.js
@@ -1,18 +1,33 @@
 export default /*html*/ `
 <template id="accountRowTemplate">
-    <div class="input-group">
-        <input type="text" class="accountname form-control"></td>
-        <button class="btn btn-danger removeAccountButton"><i class="bi bi-trash"></i></button>
+    <div class="account-row mb-3">
+        <div class="input-group">
+            <input type="text" class="accountname form-control" placeholder="account.near">
+            <input type="number" class="fundamount form-control" min="0" step="any" value="1"
+                   style="max-width:6rem" title="ARIZ to fund / daily cap">
+            <button class="btn btn-outline-primary fundButton" type="button"
+                    title="Send ARIZ to this account from your connected wallet">Fund</button>
+            <button class="btn btn-outline-success authorizeButton" type="button"
+                    title="Authorize syncing — signs with this account's own wallet">Authorize</button>
+            <button class="btn btn-danger removeAccountButton" type="button"><i class="bi bi-trash"></i></button>
+        </div>
+        <div class="arizstatus small text-muted mt-1">…</div>
     </div>
 </template>
 
 <div class="card">
     <div class="card-header">Accounts</div>
     <div class="card-body">
+        <p class="text-muted small mb-2">
+            For the gateway to sync an account it must hold ARIZ and authorize deductions.
+            <strong>Fund</strong> sends ARIZ from your connected wallet; <strong>Authorize</strong> is signed by the
+            account's own wallet (connect it when prompted).
+        </p>
         <div id="accountsTable"></div>
     </div>
     <div class="card-footer">
         <button id="addAccountButton" class="btn btn-primary">Add account</button>
+        <button type="button" class="btn btn-outline-primary ms-2" id="fundallbutton" title="Fund every listed account that has no ARIZ, from your connected wallet">Fund all</button>
         <button type="button" class="btn btn-success ms-2" id="loadfromexportbutton" title="Download complete transaction history from server">load from server</button>
     </div>
 </div>

--- a/public_html/accounts/accounts-page.component.js
+++ b/public_html/accounts/accounts-page.component.js
@@ -4,6 +4,18 @@ import accountsPageComponentHtml from './accounts-page.component.html.js';
 import { modalAlert } from '../ui/modal.js';
 import { accountsconfigfile, getAccounts, setAccounts } from '../storage/domainobjectstore.js';
 import { exists } from '../storage/gitstorage.js';
+import { getAccountId, signAndSendTransaction, loginToArizGateway } from '../arizgateway/arizgatewayaccess.js';
+import {
+    ARIZCREDITS_CONTRACT_ID,
+    formatAriz,
+    parseAriz,
+    getArizBalance,
+    getAuthorisation,
+    getStorageBalance,
+    authorizeAction,
+    ftTransferAction,
+    storageDepositAction,
+} from '../arizcredits/arizcredits.js';
 
 customElements.define('accounts-page',
     class extends HTMLElement {
@@ -20,8 +32,10 @@ customElements.define('accounts-page',
             this.shadowRoot.querySelector('#addAccountButton').onclick = async () => {
                 this.addAccountRow();
                 await this.storeAccounts();
-            }
+            };
             document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
+
+            this.shadowRoot.getElementById('fundallbutton').addEventListener('click', () => this.fundAll());
 
             this.shadowRoot.getElementById('loadfromexportbutton').addEventListener('click', async () => {
                 try {
@@ -42,7 +56,7 @@ customElements.define('accounts-page',
 
                 this.dispatchChangeEvent();
             });
-            
+
             if (await exists(accountsconfigfile)) {
                 this.setAccounts(await getAccounts());
             }
@@ -61,14 +75,116 @@ customElements.define('accounts-page',
             if (accountname) {
                 accountNameInput.value = accountname;
             }
-            accountNameInput.addEventListener('change', async (e) => {
+            accountNameInput.addEventListener('change', async () => {
                 await this.storeAccounts();
-                this.dispatchChangeEvent()
+                this.refreshRowStatus(accountsRow);
+                this.dispatchChangeEvent();
             });
             accountsRow.querySelector('.removeAccountButton').onclick = async () => {
                 accountsRow.remove();
                 await this.storeAccounts();
             };
+            accountsRow.querySelector('.fundButton').onclick = () => this.fundRow(accountsRow);
+            accountsRow.querySelector('.authorizeButton').onclick = () => this.authorizeRow(accountsRow);
+
+            if (accountname) this.refreshRowStatus(accountsRow);
+        }
+
+        rowAccountId(row) {
+            return (row.querySelector('.accountname').value || '').trim();
+        }
+
+        // Load ARIZ balance + authorisation status for a row's account (best-effort).
+        async refreshRowStatus(row) {
+            const statusEl = row.querySelector('.arizstatus');
+            const accountId = this.rowAccountId(row);
+            if (!accountId) { statusEl.textContent = ''; return; }
+            statusEl.textContent = 'checking ARIZ status…';
+            try {
+                const [balance, auth] = await Promise.all([getArizBalance(accountId), getAuthorisation(accountId)]);
+                const funded = BigInt(balance || '0') > 0n;
+                const bits = [`balance: ${formatAriz(balance)} ARIZ`,
+                    auth ? `authorised ${formatAriz(auth.max_per_day)}/day` : 'not authorised'];
+                const ready = funded && auth;
+                statusEl.textContent = `${ready ? '✓ ready to sync — ' : ''}${bits.join(' · ')}`;
+                statusEl.classList.toggle('text-success', ready);
+                statusEl.classList.toggle('text-muted', !ready);
+            } catch (e) {
+                statusEl.textContent = 'could not read ARIZ status';
+            }
+        }
+
+        // Send ARIZ to this row's account from the connected wallet (registering it first if needed).
+        async fundRow(row) {
+            const accountId = this.rowAccountId(row);
+            if (!accountId) return;
+            const amount = row.querySelector('.fundamount').value;
+            if (!amount || Number(amount) <= 0) {
+                return modalAlert('Enter an amount', 'Enter how much ARIZ to fund.');
+            }
+            try {
+                if (!(await getAccountId())) {
+                    await modalAlert('Log in first', 'Connect a wallet (Login, top right) to fund from — it sends ARIZ to this account.');
+                    return;
+                }
+                setProgressbarValue('indeterminate', `Funding ${accountId} with ${amount} ARIZ…`);
+                const actions = [];
+                const storage = await getStorageBalance(accountId);
+                if (!storage) actions.push(storageDepositAction(accountId)); // register to receive ARIZ
+                actions.push(ftTransferAction(accountId, parseAriz(amount)));
+                await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, actions);
+                setProgressbarValue(null);
+                await this.refreshRowStatus(row);
+            } catch (e) {
+                setProgressbarValue(null);
+                modalAlert('Funding failed', e?.message || String(e));
+            }
+        }
+
+        // Authorize the gateway to deduct from this account — must be signed by the account itself.
+        async authorizeRow(row) {
+            const accountId = this.rowAccountId(row);
+            if (!accountId) return;
+            const cap = row.querySelector('.fundamount').value;
+            if (!cap || Number(cap) <= 0) {
+                return modalAlert('Enter a daily cap', 'Enter the ARIZ/day cap (the amount field) before authorising.');
+            }
+            try {
+                let connected = await getAccountId();
+                if (connected !== accountId) {
+                    await modalAlert('Connect this account',
+                        `Authorisation must be signed by <b>${accountId}</b> itself. You'll be asked to connect its wallet.`);
+                    await loginToArizGateway();
+                    connected = await getAccountId();
+                }
+                if (connected !== accountId) {
+                    return modalAlert('Account mismatch',
+                        `Connected as <b>${connected || 'nobody'}</b>, but this row is <b>${accountId}</b>. Connect that account and try again.`);
+                }
+                setProgressbarValue('indeterminate', `Authorising ${accountId}…`);
+                await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [authorizeAction(parseAriz(cap))]);
+                setProgressbarValue(null);
+                await this.refreshRowStatus(row);
+            } catch (e) {
+                setProgressbarValue(null);
+                modalAlert('Authorisation failed', e?.message || String(e));
+            }
+        }
+
+        // Fund every listed account that currently holds no ARIZ, from the connected wallet.
+        async fundAll() {
+            if (!(await getAccountId())) {
+                return modalAlert('Log in first', 'Connect a wallet to fund from.');
+            }
+            const rows = Array.from(this.accountsTable.querySelectorAll('.account-row'))
+                .filter(r => this.rowAccountId(r));
+            for (const row of rows) {
+                const accountId = this.rowAccountId(row);
+                let balance = '0';
+                try { balance = await getArizBalance(accountId); } catch { /* treat as unfunded */ }
+                if (BigInt(balance || '0') > 0n) continue; // already funded
+                await this.fundRow(row);
+            }
         }
 
         setAccounts(accountsArray) {

--- a/public_html/accounts/accounts-page.component.spec.js
+++ b/public_html/accounts/accounts-page.component.spec.js
@@ -1,4 +1,5 @@
 import './accounts-page.component.js';
+import { __setTestWallet } from '../arizgateway/arizgatewayaccess.js';
 
 describe('accounts-page.component', () => {
     let configComponent;
@@ -41,5 +42,89 @@ describe('accounts-page.component', () => {
         accountNameInput.dispatchEvent(new Event('change'));
         await changePromise;
         expect(configComponent.getAccounts()[1]).to.equal('test.near');
+    });
+});
+
+function rpc(json) {
+    return { json: async () => ({ result: { result: Array.from(new TextEncoder().encode(json)) } }) };
+}
+
+describe('accounts-page ARIZ actions', () => {
+    let origFetch, sent, el;
+
+    function setWallet(accountId) {
+        __setTestWallet({
+            accountId,
+            async getAccounts() { return [{ accountId }]; },
+            async signAndSendTransaction(p) { sent.push(p); return { status: 'ok' }; },
+            async signMessage() { return { accountId, publicKey: 'ed25519:x', signature: '' }; },
+            async signOut() {},
+        });
+    }
+
+    beforeEach(async () => {
+        sent = [];
+        setWallet('funder.near');
+        origFetch = globalThis.fetch;
+        globalThis.fetch = async (_url, opts) => {
+            const body = JSON.parse(opts.body);
+            const m = body.params.method_name;
+            const args = JSON.parse(atob(body.params.args_base64));
+            if (m === 'storage_balance_of') {
+                return rpc(args.account_id === 'registered.near' ? JSON.stringify({ total: '1', available: '0' }) : 'null');
+            }
+            if (m === 'ft_balance_of') return rpc('"0"');
+            return rpc('null'); // view_js_func etc.
+        };
+        el = document.createElement('accounts-page');
+        document.body.appendChild(el);
+        await el.readyPromise;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = origFetch;
+        __setTestWallet(null);
+        el.remove();
+    });
+
+    it('fundRow registers + transfers ARIZ for an unregistered account', async () => {
+        el.addAccountRow('new.near');
+        const row = el.accountsTable.lastElementChild;
+        row.querySelector('.fundamount').value = '2';
+        await el.fundRow(row);
+
+        expect(sent.length).to.equal(1);
+        expect(sent[0].receiverId).to.equal('arizcredits.near');
+        const actions = sent[0].actions;
+        expect(actions[0].params.methodName).to.equal('storage_deposit');
+        expect(actions[1].params.methodName).to.equal('ft_transfer');
+        expect(actions[1].params.args).to.deep.equal({ receiver_id: 'new.near', amount: '2000000' });
+    });
+
+    it('fundRow skips storage_deposit for an already-registered account', async () => {
+        el.addAccountRow('registered.near');
+        const row = el.accountsTable.lastElementChild;
+        row.querySelector('.fundamount').value = '1';
+        await el.fundRow(row);
+
+        const actions = sent[0].actions;
+        expect(actions.length).to.equal(1);
+        expect(actions[0].params.methodName).to.equal('ft_transfer');
+        expect(actions[0].params.args.amount).to.equal('1000000');
+    });
+
+    it('authorizeRow signs authorize_deduction when connected as that account', async () => {
+        setWallet('self.near');
+        el.addAccountRow('self.near');
+        const row = el.accountsTable.lastElementChild;
+        row.querySelector('.fundamount').value = '1';
+        await el.authorizeRow(row);
+
+        expect(sent.length).to.equal(1);
+        expect(sent[0].actions[0].params.args).to.deep.equal({
+            function_name: 'authorize_deduction',
+            operator_account: 'arizcredits.near',
+            max_amount_per_day: '1000000',
+        });
     });
 });

--- a/public_html/arizcredits/arizcredits-page.component.js
+++ b/public_html/arizcredits/arizcredits-page.component.js
@@ -1,43 +1,20 @@
 import { getAccountId, signAndSendTransaction } from '../arizgateway/arizgatewayaccess.js';
-import { callViewFunction } from '../near/rpc.js';
+import {
+    ARIZCREDITS_CONTRACT_ID,
+    formatAriz,
+    parseAriz,
+    jsFunctionCall,
+    getArizBalance,
+    getAuthorisation,
+    getSpentSinceReset,
+    buyTokensAction,
+    authorizeAction,
+    revokeAction,
+} from './arizcredits.js';
 import html from './arizcredits-page.component.html.js';
 
-export const ARIZCREDITS_CONTRACT_ID = 'arizcredits.near';
-// The operator the user authorises is the contract account itself (see the
-// contract's deduct: operator === current_account_id).
-export const OPERATOR_ACCOUNT = ARIZCREDITS_CONTRACT_ID;
-export const ARIZ_DECIMALS = 6;
-const GAS = '300000000000000'; // 300 Tgas
-const HALF_NEAR = '500000000000000000000000'; // 0.5 NEAR — buy_tokens_for_near price
-
-/** Format a raw 6-decimal ARIZ amount (string) as a human-readable number. */
-export function formatAriz(raw) {
-    const n = BigInt(raw ?? '0');
-    const base = 10n ** BigInt(ARIZ_DECIMALS);
-    const whole = n / base;
-    const frac = (n % base).toString().padStart(ARIZ_DECIMALS, '0').replace(/0+$/, '');
-    return frac ? `${whole}.${frac}` : `${whole}`;
-}
-
-/** Parse a human ARIZ amount ("1.5") to a raw 6-decimal integer string. */
-export function parseAriz(value) {
-    const [w, f = ''] = String(value).trim().split('.');
-    const frac = (f + '0'.repeat(ARIZ_DECIMALS)).slice(0, ARIZ_DECIMALS);
-    return (BigInt(w || '0') * 10n ** BigInt(ARIZ_DECIMALS) + BigInt(frac || '0')).toString();
-}
-
-/** Build a wallet-selector FunctionCall action that dispatches an on-chain JS method. */
-export function jsFunctionCall(functionName, extraArgs = {}, deposit = '0') {
-    return {
-        type: 'FunctionCall',
-        params: {
-            methodName: 'call_js_func',
-            args: { function_name: functionName, ...extraArgs },
-            gas: GAS,
-            deposit,
-        },
-    };
-}
+// Re-export the pure helpers so existing specs importing them from here keep working.
+export { formatAriz, parseAriz, jsFunctionCall, ARIZCREDITS_CONTRACT_ID };
 
 customElements.define('arizcredits-page',
     class extends HTMLElement {
@@ -66,7 +43,6 @@ customElements.define('arizcredits-page',
             el.style.display = message ? '' : 'none';
         }
 
-        // Run an action, then refresh; surface errors instead of throwing.
         async _run(action) {
             this._setError('');
             try {
@@ -92,13 +68,9 @@ customElements.define('arizcredits-page',
             this.shadowRoot.getElementById('acct').textContent = accountId;
 
             const [balance, auth, spent] = await Promise.all([
-                callViewFunction(ARIZCREDITS_CONTRACT_ID, 'ft_balance_of', { account_id: accountId }).catch(() => '0'),
-                callViewFunction(ARIZCREDITS_CONTRACT_ID, 'view_js_func', {
-                    function_name: 'view_authorisation', user: accountId, operator_account: OPERATOR_ACCOUNT,
-                }).catch(() => null),
-                callViewFunction(ARIZCREDITS_CONTRACT_ID, 'view_js_func', {
-                    function_name: 'view_spent_since_reset', user: accountId, operator_account: OPERATOR_ACCOUNT,
-                }).catch(() => '0'),
+                getArizBalance(accountId),
+                getAuthorisation(accountId),
+                getSpentSinceReset(accountId),
             ]);
 
             this.shadowRoot.getElementById('balance').textContent = `${formatAriz(balance)} ARIZ`;
@@ -110,7 +82,7 @@ customElements.define('arizcredits-page',
         }
 
         async buy() {
-            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [jsFunctionCall('buy_tokens_for_near', {}, HALF_NEAR)]);
+            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [buyTokensAction()]);
         }
 
         async authorize() {
@@ -118,15 +90,10 @@ customElements.define('arizcredits-page',
             if (!value || Number(value) <= 0) {
                 throw new Error('Enter a daily cap greater than 0');
             }
-            const max_amount_per_day = parseAriz(value);
-            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [
-                jsFunctionCall('authorize_deduction', { operator_account: OPERATOR_ACCOUNT, max_amount_per_day }),
-            ]);
+            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [authorizeAction(parseAriz(value))]);
         }
 
         async revoke() {
-            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [
-                jsFunctionCall('revoke_deduction', { operator_account: OPERATOR_ACCOUNT }),
-            ]);
+            await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [revokeAction()]);
         }
     });

--- a/public_html/arizcredits/arizcredits.js
+++ b/public_html/arizcredits/arizcredits.js
@@ -1,0 +1,93 @@
+import { callViewFunction } from '../near/rpc.js';
+
+// Shared ARIZ-credits helpers: constants, amount formatting, on-chain view
+// helpers, and wallet-selector action builders. Used by both the Ariz credits
+// page and the Accounts page.
+
+export const ARIZCREDITS_CONTRACT_ID = 'arizcredits.near';
+// The operator a user authorises is the contract account itself (the contract's
+// deduct uses operator === current_account_id).
+export const OPERATOR_ACCOUNT = ARIZCREDITS_CONTRACT_ID;
+export const ARIZ_DECIMALS = 6;
+
+const GAS = '300000000000000'; // 300 Tgas
+const HALF_NEAR = '500000000000000000000000'; // 0.5 NEAR — buy_tokens_for_near price
+const ONE_YOCTO = '1'; // ft_transfer requires exactly 1 yoctoNEAR
+const STORAGE_DEPOSIT = '1250000000000000000000'; // 0.00125 NEAR — NEP-145 registration
+
+/** Format a raw 6-decimal ARIZ amount (string) as a human-readable number. */
+export function formatAriz(raw) {
+    const n = BigInt(raw ?? '0');
+    const base = 10n ** BigInt(ARIZ_DECIMALS);
+    const whole = n / base;
+    const frac = (n % base).toString().padStart(ARIZ_DECIMALS, '0').replace(/0+$/, '');
+    return frac ? `${whole}.${frac}` : `${whole}`;
+}
+
+/** Parse a human ARIZ amount ("1.5") to a raw 6-decimal integer string. */
+export function parseAriz(value) {
+    const [w, f = ''] = String(value).trim().split('.');
+    const frac = (f + '0'.repeat(ARIZ_DECIMALS)).slice(0, ARIZ_DECIMALS);
+    return (BigInt(w || '0') * 10n ** BigInt(ARIZ_DECIMALS) + BigInt(frac || '0')).toString();
+}
+
+// ---- on-chain view helpers ----
+
+export async function getArizBalance(accountId) {
+    return (await callViewFunction(ARIZCREDITS_CONTRACT_ID, 'ft_balance_of', { account_id: accountId }).catch(() => '0')) ?? '0';
+}
+
+export async function getAuthorisation(accountId) {
+    return callViewFunction(ARIZCREDITS_CONTRACT_ID, 'view_js_func', {
+        function_name: 'view_authorisation', user: accountId, operator_account: OPERATOR_ACCOUNT,
+    }).catch(() => null);
+}
+
+export async function getSpentSinceReset(accountId) {
+    return (await callViewFunction(ARIZCREDITS_CONTRACT_ID, 'view_js_func', {
+        function_name: 'view_spent_since_reset', user: accountId, operator_account: OPERATOR_ACCOUNT,
+    }).catch(() => '0')) ?? '0';
+}
+
+/** NEP-145 storage balance (null when the account isn't registered to hold ARIZ). */
+export async function getStorageBalance(accountId) {
+    return callViewFunction(ARIZCREDITS_CONTRACT_ID, 'storage_balance_of', { account_id: accountId }).catch(() => null);
+}
+
+// ---- wallet-selector action builders ----
+
+/** A FunctionCall action that dispatches an on-chain JS method via call_js_func. */
+export function jsFunctionCall(functionName, extraArgs = {}, deposit = '0') {
+    return {
+        type: 'FunctionCall',
+        params: { methodName: 'call_js_func', args: { function_name: functionName, ...extraArgs }, gas: GAS, deposit },
+    };
+}
+
+export function buyTokensAction() {
+    return jsFunctionCall('buy_tokens_for_near', {}, HALF_NEAR);
+}
+
+export function authorizeAction(maxAmountPerDayRaw) {
+    return jsFunctionCall('authorize_deduction', { operator_account: OPERATOR_ACCOUNT, max_amount_per_day: maxAmountPerDayRaw });
+}
+
+export function revokeAction() {
+    return jsFunctionCall('revoke_deduction', { operator_account: OPERATOR_ACCOUNT });
+}
+
+/** Standard NEP-141 ft_transfer of ARIZ to a receiver. */
+export function ftTransferAction(receiverId, amountRaw) {
+    return {
+        type: 'FunctionCall',
+        params: { methodName: 'ft_transfer', args: { receiver_id: receiverId, amount: amountRaw }, gas: GAS, deposit: ONE_YOCTO },
+    };
+}
+
+/** Register an account for ARIZ storage so it can receive tokens. */
+export function storageDepositAction(accountId) {
+    return {
+        type: 'FunctionCall',
+        params: { methodName: 'storage_deposit', args: { account_id: accountId, registration_only: true }, gas: GAS, deposit: STORAGE_DEPOSIT },
+    };
+}

--- a/public_html/arizcredits/arizcredits.spec.js
+++ b/public_html/arizcredits/arizcredits.spec.js
@@ -1,0 +1,53 @@
+import {
+    formatAriz, parseAriz, jsFunctionCall,
+    buyTokensAction, authorizeAction, revokeAction, ftTransferAction, storageDepositAction,
+    OPERATOR_ACCOUNT,
+} from './arizcredits.js';
+
+describe('arizcredits shared helpers', () => {
+    it('formatAriz / parseAriz round-trip 6-decimal amounts', () => {
+        expect(formatAriz('3000000')).to.equal('3');
+        expect(formatAriz('1500000')).to.equal('1.5');
+        expect(formatAriz('1')).to.equal('0.000001');
+        expect(parseAriz('3')).to.equal('3000000');
+        expect(parseAriz('1.5')).to.equal('1500000');
+        expect(parseAriz('0.000001')).to.equal('1');
+    });
+
+    it('jsFunctionCall wraps an on-chain JS method in call_js_func', () => {
+        const a = jsFunctionCall('foo', { x: 1 }, '7');
+        expect(a.type).to.equal('FunctionCall');
+        expect(a.params.methodName).to.equal('call_js_func');
+        expect(a.params.args).to.deep.equal({ function_name: 'foo', x: 1 });
+        expect(a.params.deposit).to.equal('7');
+    });
+
+    it('buyTokensAction attaches 0.5 NEAR', () => {
+        expect(buyTokensAction().params.args.function_name).to.equal('buy_tokens_for_near');
+        expect(buyTokensAction().params.deposit).to.equal('500000000000000000000000');
+    });
+
+    it('authorizeAction / revokeAction target the contract operator', () => {
+        const auth = authorizeAction('2500000');
+        expect(auth.params.args).to.deep.equal({
+            function_name: 'authorize_deduction', operator_account: OPERATOR_ACCOUNT, max_amount_per_day: '2500000',
+        });
+        expect(revokeAction().params.args).to.deep.equal({
+            function_name: 'revoke_deduction', operator_account: OPERATOR_ACCOUNT,
+        });
+    });
+
+    it('ftTransferAction uses NEP-141 ft_transfer with 1 yocto', () => {
+        const t = ftTransferAction('bob.near', '1000000');
+        expect(t.params.methodName).to.equal('ft_transfer');
+        expect(t.params.args).to.deep.equal({ receiver_id: 'bob.near', amount: '1000000' });
+        expect(t.params.deposit).to.equal('1');
+    });
+
+    it('storageDepositAction registers the target account', () => {
+        const s = storageDepositAction('bob.near');
+        expect(s.params.methodName).to.equal('storage_deposit');
+        expect(s.params.args).to.deep.equal({ account_id: 'bob.near', registration_only: true });
+        expect(BigInt(s.params.deposit) > 0n).to.equal(true);
+    });
+});


### PR DESCRIPTION
## Summary

Manage many accounts' gateway billing from the **Accounts page**, so users can onboard all their accounts without logging into each one to buy ARIZ.

Per account row:
- **Status** — live ARIZ balance + authorisation (`✓ ready to sync` when funded + authorised).
- **Fund** / **Fund all** — sends ARIZ to the account **from your connected wallet** (`storage_deposit` to register it if needed, then `ft_transfer`). One funder funds all your accounts.
- **Authorize** — must be signed by the account itself (it connects that account's wallet when prompted), because `authorize_deduction` uses `predecessor_account_id` as the consenting account. Pre-funding means it's a single tap, no buying.

So: centralized funding (one signer) + per-account authorization (one signature each) — exactly the model that fits the gateway's payment gate.

## Refactor
Extracted the shared ARIZ helpers (constants, `formatAriz`/`parseAriz`, on-chain view helpers, wallet-selector action builders) into `arizcredits/arizcredits.js`; the Ariz credits page imports them (re-exporting the pure helpers for its spec). `signAndSendTransaction(receiverId, actions)` (added with the login PR) is reused for all contract calls.

## Tests
New `arizcredits.js` helper/action-builder specs + Accounts-page fund/authorize tx-building tests (injected wallet + stubbed RPC). **Full frontend suite: 127 passed.**

## Note
near-connect is single-account-per-session, so authorizing N accounts means connecting each once (inherent — each account's signature *is* its authorization). Funding doesn't require switching (any connected wallet can fund others).

🤖 Generated with [Claude Code](https://claude.com/claude-code)