### PR TITLE
Accounts: payer model — drop per-account fund/authorize

### DIFF
--- a/public_html/accounts/accounts-page.component.html.js
+++ b/public_html/accounts/accounts-page.component.html.js
@@ -1,17 +1,8 @@
 export default /*html*/ `
 <template id="accountRowTemplate">
-    <div class="account-row mb-3">
-        <div class="input-group">
-            <input type="text" class="accountname form-control" placeholder="account.near">
-            <input type="number" class="fundamount form-control" min="0" step="any" value="1"
-                   style="max-width:6rem" title="ARIZ to fund / daily cap">
-            <button class="btn btn-outline-primary fundButton" type="button"
-                    title="Send ARIZ to this account from your connected wallet">Fund</button>
-            <button class="btn btn-outline-success authorizeButton" type="button"
-                    title="Authorize syncing — signs with this account's own wallet">Authorize</button>
-            <button class="btn btn-danger removeAccountButton" type="button"><i class="bi bi-trash"></i></button>
-        </div>
-        <div class="arizstatus small text-muted mt-1">…</div>
+    <div class="input-group">
+        <input type="text" class="accountname form-control"></td>
+        <button class="btn btn-danger removeAccountButton"><i class="bi bi-trash"></i></button>
     </div>
 </template>
 
@@ -19,15 +10,13 @@ export default /*html*/ `
     <div class="card-header">Accounts</div>
     <div class="card-body">
         <p class="text-muted small mb-2">
-            For the gateway to sync an account it must hold ARIZ and authorize deductions.
-            <strong>Fund</strong> sends ARIZ from your connected wallet; <strong>Authorize</strong> is signed by the
-            account's own wallet (connect it when prompted).
+            Add the accounts you want to monitor, then <strong>load from server</strong>. Each account you load is
+            billed to your logged-in account — set up ARIZ once on the <em>Ariz credits</em> page (buy + authorize).
         </p>
         <div id="accountsTable"></div>
     </div>
     <div class="card-footer">
         <button id="addAccountButton" class="btn btn-primary">Add account</button>
-        <button type="button" class="btn btn-outline-primary ms-2" id="fundallbutton" title="Fund every listed account that has no ARIZ, from your connected wallet">Fund all</button>
         <button type="button" class="btn btn-success ms-2" id="loadfromexportbutton" title="Download complete transaction history from server">load from server</button>
     </div>
 </div>

--- a/public_html/accounts/accounts-page.component.js
+++ b/public_html/accounts/accounts-page.component.js
@@ -4,18 +4,6 @@ import accountsPageComponentHtml from './accounts-page.component.html.js';
 import { modalAlert } from '../ui/modal.js';
 import { accountsconfigfile, getAccounts, setAccounts } from '../storage/domainobjectstore.js';
 import { exists } from '../storage/gitstorage.js';
-import { getAccountId, signAndSendTransaction, loginToArizGateway } from '../arizgateway/arizgatewayaccess.js';
-import {
-    ARIZCREDITS_CONTRACT_ID,
-    formatAriz,
-    parseAriz,
-    getArizBalance,
-    getAuthorisation,
-    getStorageBalance,
-    authorizeAction,
-    ftTransferAction,
-    storageDepositAction,
-} from '../arizcredits/arizcredits.js';
 
 customElements.define('accounts-page',
     class extends HTMLElement {
@@ -34,8 +22,6 @@ customElements.define('accounts-page',
                 await this.storeAccounts();
             };
             document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
-
-            this.shadowRoot.getElementById('fundallbutton').addEventListener('click', () => this.fundAll());
 
             this.shadowRoot.getElementById('loadfromexportbutton').addEventListener('click', async () => {
                 try {
@@ -77,114 +63,12 @@ customElements.define('accounts-page',
             }
             accountNameInput.addEventListener('change', async () => {
                 await this.storeAccounts();
-                this.refreshRowStatus(accountsRow);
                 this.dispatchChangeEvent();
             });
             accountsRow.querySelector('.removeAccountButton').onclick = async () => {
                 accountsRow.remove();
                 await this.storeAccounts();
             };
-            accountsRow.querySelector('.fundButton').onclick = () => this.fundRow(accountsRow);
-            accountsRow.querySelector('.authorizeButton').onclick = () => this.authorizeRow(accountsRow);
-
-            if (accountname) this.refreshRowStatus(accountsRow);
-        }
-
-        rowAccountId(row) {
-            return (row.querySelector('.accountname').value || '').trim();
-        }
-
-        // Load ARIZ balance + authorisation status for a row's account (best-effort).
-        async refreshRowStatus(row) {
-            const statusEl = row.querySelector('.arizstatus');
-            const accountId = this.rowAccountId(row);
-            if (!accountId) { statusEl.textContent = ''; return; }
-            statusEl.textContent = 'checking ARIZ status…';
-            try {
-                const [balance, auth] = await Promise.all([getArizBalance(accountId), getAuthorisation(accountId)]);
-                const funded = BigInt(balance || '0') > 0n;
-                const bits = [`balance: ${formatAriz(balance)} ARIZ`,
-                    auth ? `authorised ${formatAriz(auth.max_per_day)}/day` : 'not authorised'];
-                const ready = funded && auth;
-                statusEl.textContent = `${ready ? '✓ ready to sync — ' : ''}${bits.join(' · ')}`;
-                statusEl.classList.toggle('text-success', ready);
-                statusEl.classList.toggle('text-muted', !ready);
-            } catch (e) {
-                statusEl.textContent = 'could not read ARIZ status';
-            }
-        }
-
-        // Send ARIZ to this row's account from the connected wallet (registering it first if needed).
-        async fundRow(row) {
-            const accountId = this.rowAccountId(row);
-            if (!accountId) return;
-            const amount = row.querySelector('.fundamount').value;
-            if (!amount || Number(amount) <= 0) {
-                return modalAlert('Enter an amount', 'Enter how much ARIZ to fund.');
-            }
-            try {
-                if (!(await getAccountId())) {
-                    await modalAlert('Log in first', 'Connect a wallet (Login, top right) to fund from — it sends ARIZ to this account.');
-                    return;
-                }
-                setProgressbarValue('indeterminate', `Funding ${accountId} with ${amount} ARIZ…`);
-                const actions = [];
-                const storage = await getStorageBalance(accountId);
-                if (!storage) actions.push(storageDepositAction(accountId)); // register to receive ARIZ
-                actions.push(ftTransferAction(accountId, parseAriz(amount)));
-                await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, actions);
-                setProgressbarValue(null);
-                await this.refreshRowStatus(row);
-            } catch (e) {
-                setProgressbarValue(null);
-                modalAlert('Funding failed', e?.message || String(e));
-            }
-        }
-
-        // Authorize the gateway to deduct from this account — must be signed by the account itself.
-        async authorizeRow(row) {
-            const accountId = this.rowAccountId(row);
-            if (!accountId) return;
-            const cap = row.querySelector('.fundamount').value;
-            if (!cap || Number(cap) <= 0) {
-                return modalAlert('Enter a daily cap', 'Enter the ARIZ/day cap (the amount field) before authorising.');
-            }
-            try {
-                let connected = await getAccountId();
-                if (connected !== accountId) {
-                    await modalAlert('Connect this account',
-                        `Authorisation must be signed by <b>${accountId}</b> itself. You'll be asked to connect its wallet.`);
-                    await loginToArizGateway();
-                    connected = await getAccountId();
-                }
-                if (connected !== accountId) {
-                    return modalAlert('Account mismatch',
-                        `Connected as <b>${connected || 'nobody'}</b>, but this row is <b>${accountId}</b>. Connect that account and try again.`);
-                }
-                setProgressbarValue('indeterminate', `Authorising ${accountId}…`);
-                await signAndSendTransaction(ARIZCREDITS_CONTRACT_ID, [authorizeAction(parseAriz(cap))]);
-                setProgressbarValue(null);
-                await this.refreshRowStatus(row);
-            } catch (e) {
-                setProgressbarValue(null);
-                modalAlert('Authorisation failed', e?.message || String(e));
-            }
-        }
-
-        // Fund every listed account that currently holds no ARIZ, from the connected wallet.
-        async fundAll() {
-            if (!(await getAccountId())) {
-                return modalAlert('Log in first', 'Connect a wallet to fund from.');
-            }
-            const rows = Array.from(this.accountsTable.querySelectorAll('.account-row'))
-                .filter(r => this.rowAccountId(r));
-            for (const row of rows) {
-                const accountId = this.rowAccountId(row);
-                let balance = '0';
-                try { balance = await getArizBalance(accountId); } catch { /* treat as unfunded */ }
-                if (BigInt(balance || '0') > 0n) continue; // already funded
-                await this.fundRow(row);
-            }
         }
 
         setAccounts(accountsArray) {

--- a/public_html/accounts/accounts-page.component.spec.js
+++ b/public_html/accounts/accounts-page.component.spec.js
@@ -1,5 +1,4 @@
 import './accounts-page.component.js';
-import { __setTestWallet } from '../arizgateway/arizgatewayaccess.js';
 
 describe('accounts-page.component', () => {
     let configComponent;
@@ -7,7 +6,7 @@ describe('accounts-page.component', () => {
     before(async () => {
         configComponent = document.createElement('accounts-page');
         document.documentElement.appendChild(configComponent);
-        shadowRoot = await configComponent.readyPromise;    
+        shadowRoot = await configComponent.readyPromise;
     });
     after(() => {
         configComponent.remove();
@@ -42,89 +41,5 @@ describe('accounts-page.component', () => {
         accountNameInput.dispatchEvent(new Event('change'));
         await changePromise;
         expect(configComponent.getAccounts()[1]).to.equal('test.near');
-    });
-});
-
-function rpc(json) {
-    return { json: async () => ({ result: { result: Array.from(new TextEncoder().encode(json)) } }) };
-}
-
-describe('accounts-page ARIZ actions', () => {
-    let origFetch, sent, el;
-
-    function setWallet(accountId) {
-        __setTestWallet({
-            accountId,
-            async getAccounts() { return [{ accountId }]; },
-            async signAndSendTransaction(p) { sent.push(p); return { status: 'ok' }; },
-            async signMessage() { return { accountId, publicKey: 'ed25519:x', signature: '' }; },
-            async signOut() {},
-        });
-    }
-
-    beforeEach(async () => {
-        sent = [];
-        setWallet('funder.near');
-        origFetch = globalThis.fetch;
-        globalThis.fetch = async (_url, opts) => {
-            const body = JSON.parse(opts.body);
-            const m = body.params.method_name;
-            const args = JSON.parse(atob(body.params.args_base64));
-            if (m === 'storage_balance_of') {
-                return rpc(args.account_id === 'registered.near' ? JSON.stringify({ total: '1', available: '0' }) : 'null');
-            }
-            if (m === 'ft_balance_of') return rpc('"0"');
-            return rpc('null'); // view_js_func etc.
-        };
-        el = document.createElement('accounts-page');
-        document.body.appendChild(el);
-        await el.readyPromise;
-    });
-
-    afterEach(() => {
-        globalThis.fetch = origFetch;
-        __setTestWallet(null);
-        el.remove();
-    });
-
-    it('fundRow registers + transfers ARIZ for an unregistered account', async () => {
-        el.addAccountRow('new.near');
-        const row = el.accountsTable.lastElementChild;
-        row.querySelector('.fundamount').value = '2';
-        await el.fundRow(row);
-
-        expect(sent.length).to.equal(1);
-        expect(sent[0].receiverId).to.equal('arizcredits.near');
-        const actions = sent[0].actions;
-        expect(actions[0].params.methodName).to.equal('storage_deposit');
-        expect(actions[1].params.methodName).to.equal('ft_transfer');
-        expect(actions[1].params.args).to.deep.equal({ receiver_id: 'new.near', amount: '2000000' });
-    });
-
-    it('fundRow skips storage_deposit for an already-registered account', async () => {
-        el.addAccountRow('registered.near');
-        const row = el.accountsTable.lastElementChild;
-        row.querySelector('.fundamount').value = '1';
-        await el.fundRow(row);
-
-        const actions = sent[0].actions;
-        expect(actions.length).to.equal(1);
-        expect(actions[0].params.methodName).to.equal('ft_transfer');
-        expect(actions[0].params.args.amount).to.equal('1000000');
-    });
-
-    it('authorizeRow signs authorize_deduction when connected as that account', async () => {
-        setWallet('self.near');
-        el.addAccountRow('self.near');
-        const row = el.accountsTable.lastElementChild;
-        row.querySelector('.fundamount').value = '1';
-        await el.authorizeRow(row);
-
-        expect(sent.length).to.equal(1);
-        expect(sent[0].actions[0].params.args).to.deep.equal({
-            function_name: 'authorize_deduction',
-            operator_account: 'arizcredits.near',
-            max_amount_per_day: '1000000',
-        });
     });
 });


### PR DESCRIPTION
## Summary

Pairs with ariz-gateway#24 (payer model). The logged-in account now pays for the accounts it monitors, so the per-account **Fund/Authorize** UI from #53 is removed. The Accounts page returns to a simple list: add accounts + **load from server** — loading bills them to your logged-in account, which you set up **once** (buy ARIZ + authorize) on the **Ariz credits** page. Added a short explanatory note.

`arizcredits.js` (shared helpers used by the Ariz credits page) is kept.

## Tests
Full frontend suite: **124 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)