### PR TITLE
Fix endless wNEAR price re-prompt (write/read key mismatch)

### DIFF
--- a/public_html/storage/domainobjectstore.js
+++ b/public_html/storage/domainobjectstore.js
@@ -261,16 +261,22 @@ export async function writeStakingData(account, stakingpool_id, stakingData) {
     await writeFile(stakingDataPath, JSON.stringify(stakingData, null, 1));
 }
 
+// Normalize the price-storage token so reads and writes always agree on the
+// file path. wNEAR tracks NEAR 1:1, so it shares NEAR's price file (the gateway
+// aliases it too). Must be applied in getPriceDataPath — applying it only on
+// read previously meant writes landed under wNEAR/ while reads looked in NEAR/,
+// causing an endless "price missing locally" re-prompt per date.
+function normalizePriceToken(token) {
+    if (!token) return 'NEAR';
+    if (token.toUpperCase() === 'WNEAR') return 'NEAR';
+    return token;
+}
+
 function getPriceDataPath(token, targetCurrency) {
-    return `${pricedatadir}/${token}/${targetCurrency.toLowerCase()}.json`;
+    return `${pricedatadir}/${normalizePriceToken(token)}/${targetCurrency.toLowerCase()}.json`;
 }
 
 export async function getHistoricalPriceData(token, targetCurrency) {
-    if (!token) {
-        token = 'NEAR';
-    } else if (token === 'wNEAR') {
-        token = 'NEAR';
-    }
     const pricedatapath = getPriceDataPath(token, targetCurrency);
     if (await exists(pricedatapath)) {
         return JSON.parse(await readTextFile(pricedatapath));

--- a/public_html/storage/domainobjectstore.spec.js
+++ b/public_html/storage/domainobjectstore.spec.js
@@ -26,6 +26,14 @@ describe('domainobjectstore', () => {
         await setHistoricalPriceData('NEAR', 'USD', pricedata);
         expect(await getHistoricalPriceData('NEAR', 'USD')).to.deep.equal(pricedata);
     });
+    it('should store wNEAR pricedata under NEAR so writes are visible on read', async () => {
+        // wNEAR tracks NEAR 1:1 and shares NEAR's price file. Writing under wNEAR
+        // must be readable back under wNEAR (and under NEAR) - otherwise the
+        // year-report re-prompts "price missing locally" for every date.
+        await setHistoricalPriceData('wNEAR', 'NOK', { '2026-05-27': 23.64 });
+        expect(await getHistoricalPriceData('wNEAR', 'NOK')).to.deep.equal({ '2026-05-27': 23.64 });
+        expect(await getHistoricalPriceData('NEAR', 'NOK')).to.deep.equal({ '2026-05-27': 23.64 });
+    });
     it('should get all fungible token transactions', async () => {
         const accountId = 'petersalomonsen.near';
         let transactions = await getAllFungibleTokenTransactions(accountId);


### PR DESCRIPTION
## Problem

On the year report, with wNEAR selected, the "Price for wNEAR-nok on <date> is missing locally — fetch from Ariz Gateway?" dialog reappeared for **every single date**, even though the gateway clearly returned the full history (visible in the Network Preview pane).

## Cause

In `storage/domainobjectstore.js`:
- `getHistoricalPriceData('wNEAR')` remapped `wNEAR → NEAR` and read `NEAR/<cur>.json`
- `setHistoricalPriceData('wNEAR')` did **not** remap — it wrote `wNEAR/<cur>.json`

So clicking "Yes" fetched and saved the history under `wNEAR/`, but the next lookup read from `NEAR/` and still found nothing → re-prompt forever.

## Fix

Centralize the `wNEAR → NEAR` (and empty → NEAR) normalization in `getPriceDataPath`, so reads and writes always resolve to the same file. Added a round-trip regression test (write under wNEAR → readable under both wNEAR and NEAR).

## Tests
`wtr public_html/storage/domainobjectstore.spec.js` → 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)