### PR TITLE
web4: make arizportfolio.near a simple redirect contract (retire the Rust ariz_gateway contract)

### DIFF
--- a/web4contract/web4contract.wat.js
+++ b/web4contract/web4contract.wat.js
@@ -1,8 +1,24 @@
-import { writeFile, readFile } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 
-// Read the built index.html and encode as base64
-const indexHtml = await readFile(new URL('../dist/index.html', import.meta.url));
-const base64Body = indexHtml.toString('base64');
+// arizportfolio.near.page redirects to the gateway-hosted frontend. The gateway
+// (an Express server) can set the cross-origin isolation headers the OPFS-based
+// wasm-git build needs; web4 serves with fixed headers and can't. The redirect is
+// client-side so the path/query/hash are preserved (deep links keep working), and
+// it's reversible - point this back at the inlined bundle to undo.
+const target = process.env.WEB4_REDIRECT_TARGET ?? 'https://arizgateway.fly.dev';
+
+const redirectHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ariz Portfolio</title>
+<script>location.replace(${JSON.stringify(target)} + location.pathname + location.search + location.hash);</script>
+</head>
+<body>Redirecting to <a href="${target}">${target.replace(/^https?:\/\//, '')}</a>…</body>
+</html>`;
+
+const base64Body = Buffer.from(redirectHtml).toString('base64');
 
 const web4json = {
     contentType: "text/html; charset=UTF-8",


### PR DESCRIPTION
## What

Switch `arizportfolio.near` from the Rust `ariz_gateway` contract (in the
ariz-gateway repo, which embedded the bundle + carried a now-dead on-chain token
registry) to the minimal WAT web4 contract here, which serves a tiny client-side
redirect to `https://arizgateway.fly.dev` (path/query/hash preserved).

## Why

- The frontend is now hosted by the gateway (which can set the COOP/COEP headers
  the OPFS wasm-git build needs); arizportfolio.near just needs to redirect there.
- The Rust contract's access-token mechanism (`register_token` /
  `get_account_id_for_token`) is unused — auth is NEP-413 at the gateway now, and
  the gateway README already flags those methods as "unused now and slated for
  removal." So a simple web4 contract is sufficient.

## Deploy (manual — mainnet keychain)

```bash
npm run web4contract          # regenerates .wat + .wasm (659-byte contract)
npm run web4contract:deploy   # near contract deploy arizportfolio.near … sign-with-keychain
```

Deploying this WAT contract over the account retires the Rust contract for serving
the page (old state remains but is ignored). Prerequisite: confirm
`https://arizgateway.fly.dev/` works end-to-end first. Reversible.

## Follow-ups (not in this PR)

- Update the `/deploy` skill (`.claude/commands/deploy.md`) — it still documents
  embedding the bundle into the Rust contract.
- Remove the dead Rust contract + token registry from ariz-gateway, and the
  duplicate deploy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)