### PR TITLE
storage: allow first push to an empty remote (back up an existing local repo)

### DIFF
--- a/public_html/storage/wasmgitworker.js
+++ b/public_html/storage/wasmgitworker.js
@@ -103,6 +103,11 @@ self.onmessage = async (msg) => {
         captureOutput = true;
         callMain(['fetch', 'origin']);
         callMain(['merge', 'origin/master']);
+        // On the first push to a brand-new (empty) remote there is no
+        // origin/master to fetch or merge, so those steps "fail" harmlessly.
+        // Only a failed push is fatal — so judge success on the push alone.
+        stdout = '';
+        stderr = '';
         callMain(['push']);
         captureOutput = false;
         if (stderr) {


### PR DESCRIPTION
## What

Makes the Storage page's **Synchronize** able to push an existing, only-in-browser
repo to a brand-new (empty) git remote for the first time.

## Why

For an existing local repo (`.git` present), Synchronize ran
`fetch → merge origin/master → push` and threw on *any* stderr. A fresh remote has
no `origin/master`, so the merge errored and aborted before the push succeeded —
so you couldn't get an unbacked, browser-only repo onto a remote in the first place.
(Exactly the situation for the live `arizportfolio.near.page` data.)

## How

One spot in [wasmgitworker.js](public_html/storage/wasmgitworker.js) `sync`: clear
`stdout`/`stderr` after fetch/merge so the expected empty-remote fetch/merge errors
are ignored and **only a failed push is fatal**. Normal sync (remote already has
history) is unchanged; a genuine divergence still surfaces as a push rejection
(non-fast-forward).

## Verified

Drove the **real** worker (lg2 0.0.10 / IDBFS), served non-isolated like web4,
against a local empty git remote:
- existing local repo → set empty remote → `sync()` → ✅ first push lands the
  commits on the bare remote
- follow-up change → `sync()` → ✅ still works (remote now has history)
- bare remote ends with the expected commits and file contents

(No in-suite test added — the app's web-test-runner config has no git server wired
for the wasm-git remote; happy to add that harness if wanted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)