### PR TITLE
storage: NEP-413 account + gateway git remote; CLI clone/refresh commands

### DIFF
--- a/playwright_tests/tests/wasmgit.spec.js
+++ b/playwright_tests/tests/wasmgit.spec.js
@@ -1,61 +1,26 @@
 import { test, expect } from "@playwright/test";
 import { pause500ifRecordingVideo } from "../util/videorecording.js";
 
-test("should clone wasm-git repository when providing access key", async ({ page }) => {
-  await page.goto(
-    "http://localhost:8081"
-  );
+// The Storage page now authenticates with the signed-in NEAR account (NEP-413)
+// and pushes to the user's repo on the Ariz gateway git server — there is no
+// access-key / remote-URL field any more. This smoke test verifies the new UI
+// replaced the old inputs. The full push/clone round-trip against the gateway
+// (which needs a wallet + the deployed gateway git server) is covered separately.
+test("storage page shows the gateway git UI (no legacy key/url inputs)", async ({ page }) => {
+  await page.goto("http://localhost:8081");
 
-  await page.getByRole('link', { name: 'Accounts' }).click();
+  await page.getByRole('link', { name: 'Storage' }).click();
   await pause500ifRecordingVideo(page);
 
-  await page.getByRole('button', { name: 'Add account' }).click();
-  await pause500ifRecordingVideo(page);
+  // New controls are present (locators pierce the open shadow root).
+  await expect(page.locator('#syncbutton')).toBeVisible();
+  await expect(page.locator('#copyclonebutton')).toBeVisible();
+  await expect(page.locator('#copyconfigbutton')).toBeVisible();
+  await expect(page.locator('#gatewayaccountspan')).toBeVisible();
+  await expect(page.locator('#downloadzipbutton')).toBeVisible();
 
-  await page.getByRole('textbox').fill('petermusic.near');
-  await pause500ifRecordingVideo(page);
-
-  const configureStorage = async () => {
-    await pause500ifRecordingVideo(page);
-    await page.getByRole('link', { name: 'Storage' }).click();
-    await pause500ifRecordingVideo(page);
-    const wasmgitaccesskeyinput = await page.locator('#wasmgitaccesskey');
-    await wasmgitaccesskeyinput.fill('test.near:3XV8JxA8VEngikCBXEqphLbymgK3NyMgAptDdBQURy5J');
-    await wasmgitaccesskeyinput.blur();
-    await expect(await page.locator('#wasmgitaccountspan')).toHaveText('test.near');
-
-    await pause500ifRecordingVideo(page);
-    await page.locator('#remoterepo').fill('http://localhost:15000/testrepo.git');
-    await pause500ifRecordingVideo(page);
-  };
-
-  await configureStorage();
-  await page.locator('#syncbutton').click();
-
-  await page.waitForTimeout(1000);
-  await expect(await page.locator('progress-bar')).not.toBeVisible();
-
-  await page.locator("#deletelocaldatabutton").click();
-
-  await page.waitForTimeout(1000);
-
-  await page.goto(
-    "http://localhost:8081"
-  );
-
-  await page.getByRole('link', { name: 'Accounts' }).click();
-  await pause500ifRecordingVideo(page);
-  await expect(page.getByRole('textbox')).not.toBeAttached();
-
-  await configureStorage();
-  await page.locator('#syncbutton').click();
-
-  await page.waitForTimeout(1000);
-  await expect(await page.locator('progress-bar')).not.toBeVisible();
-
-  await page.getByRole('link', { name: 'Accounts' }).
-  click();
-  await pause500ifRecordingVideo(page);
-  await expect(page.getByRole('textbox')).toHaveValue('petermusic.near');
+  // Legacy inputs are gone.
+  await expect(page.locator('#wasmgitaccesskey')).toHaveCount(0);
+  await expect(page.locator('#remoterepo')).toHaveCount(0);
   await pause500ifRecordingVideo(page);
 });

--- a/public_html/storage/storage-page.component.html.js
+++ b/public_html/storage/storage-page.component.html.js
@@ -1,19 +1,22 @@
 export default /*html*/ `<div class="card">
-    <div class="card-header">Store data on a git server</div>
+    <div class="card-header">Store data on the Ariz gateway git server</div>
     <div class="card-body">
-        <p>You may store a remote copy of your data in a git server, which you can then use to synchronize with other browsers and devices</p>
-
-        <p>Enter wasm-git access key</p>
+        <p>Your portfolio data lives in an in-browser git repository. <b>Synchronize</b> pushes it to your private repository on the Ariz gateway, authenticated with your signed-in NEAR account.</p>
+        <p>Signed in as: <span id="gatewayaccountspan">(not signed in)</span></p>
         <p>
-            <input id="wasmgitaccesskey" type="password" /> <span id="wasmgitaccountspan"></span>
+            <button class="btn btn-primary" id="syncbutton">Synchronize</button>
+            <button class="btn btn-secondary" id="downloadzipbutton">Download as zip file</button>
+            <button class="btn btn-outline-danger" id="deletelocaldatabutton">Delete local data</button>
         </p>
-        <p>
-        <label for="remoterepo" class="form-label">URL to git repository</label>
-        <input type="text" class="form-control" id="remoterepo" placeholder="https://wasm-git.petersalomonsen.com/YOUR_ACCOUNT-nearsight">
-        </p>
-        <button class="btn btn-primary" id="syncbutton">Synchronize</button>
-        <button class="btn btn-primary" id="deletelocaldatabutton">Delete local data</button>
-        <button class="btn btn-primary" id="downloadzipbutton">Download as zip file</button>
+        <hr />
+        <h6>Use from the command line (optional)</h6>
+        <p>Clone your repository, passing your current access token as an HTTP header:</p>
+        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code id="clonecmd">Sign in, then click &ldquo;Copy clone command&rdquo;.</code></pre>
+        <button class="btn btn-sm btn-outline-primary" id="copyclonebutton">Copy clone command</button>
+        <p class="mt-3">Token expired in an existing clone? Update it (run inside the cloned repo):</p>
+        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code id="configcmd">Sign in, then click &ldquo;Copy git config command&rdquo;.</code></pre>
+        <button class="btn btn-sm btn-outline-primary" id="copyconfigbutton">Copy git config command</button>
+        <p class="mt-2"><small class="text-muted">The access token is short-lived &mdash; re-copy when it expires.</small></p>
     </div>
 </div>
 <br />`;

--- a/public_html/storage/storage-page.component.js
+++ b/public_html/storage/storage-page.component.js
@@ -1,38 +1,22 @@
-import nearApi from 'near-api-js';
-import { exists, git_init, git_clone, configure_user, get_remote, set_remote, sync, commit_all, delete_local, readdir, push, exportAndDownloadZip } from './gitstorage.js';
+import { exists, git_init, git_clone, configure_user, set_remote, sync, commit_all, delete_local, readdir, push, exportAndDownloadZip } from './gitstorage.js';
 import wasmgitComponentHtml from './storage-page.component.html.js';
 import { modalAlert } from '../ui/modal.js';
 import { setProgressbarValue } from '../ui/progress-bar.js';
+import { getAccessToken, getAccountId, isSignedIn, loginToArizGateway, arizgatewayhost } from '../arizgateway/arizgatewayaccess.js';
 
-const nearconfig = {
-    nodeUrl: 'https://rpc.mainnet.fastnear.com',
-    walletUrl: 'https://wallet.near.org',
-    helperUrl: 'https://helper.mainnet.near.org',
-    //networkId: 'mainnet',
-    contractName: 'wasmgit.near',
-    deps: {}
-};
-export const createWalletConnection = async () => {
-    nearconfig.deps.keyStore = new nearApi.keyStores.BrowserLocalStorageKeyStore();
-    const near = await nearApi.connect(nearconfig);
-    const wc = new nearApi.WalletConnection(near, 'wasmgit');
-    return wc;
-}
+// One repository per account; the account is implied by the NEP-413 token, so the
+// repo name in the URL is a fixed label.
+const REPO_NAME = 'portfolio';
+export const gatewayRepoUrl = () => `${arizgatewayhost}/git/${REPO_NAME}`;
 
-export async function createAccessToken() {
-    const walletConnection = await createWalletConnection();
-    const accountId = walletConnection.getAccountId();
-    const tokenMessage = btoa(JSON.stringify({ accountId: accountId, iat: new Date().getTime() }));
-    const signature = await walletConnection.account().connection.signer
-        .signMessage(new TextEncoder().encode(tokenMessage), accountId);
-    return tokenMessage + '.' + btoa(String.fromCharCode(...signature.signature));
-}
-
-export async function useAccount(accountId, secretKey) {
-    const keypair = nearApi.utils.KeyPair.fromString(secretKey);
-    localStorage.setItem('wasmgit_wallet_auth_key', JSON.stringify({ accountId, allKeys: [keypair.publicKey.toString()] }))
-    await nearconfig.deps.keyStore.setKey(nearconfig.networkId, accountId, keypair);
-}
+// CLI helpers: the gateway git server authenticates the same NEP-413 bearer token
+// the app uses, passed as an HTTP header. `git -c http.extraHeader=...` is a
+// one-shot for cloning; `git config http.extraHeader ...` persists/refreshes it in
+// an existing clone (tokens are short-lived).
+export const gitCloneCommand = (token) =>
+    `git -c http.extraHeader="Authorization: Bearer ${token}" clone ${gatewayRepoUrl()}`;
+export const gitConfigCommand = (token) =>
+    `git config http.extraHeader "Authorization: Bearer ${token}"`;
 
 customElements.define('storage-page',
     class extends HTMLElement {
@@ -46,85 +30,102 @@ customElements.define('storage-page',
             this.shadowRoot.innerHTML = wasmgitComponentHtml;
             document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
 
-            this.shadowRoot.getElementById('wasmgitaccesskey').addEventListener('change', async (e) => {
-                const [accountId, accessKey] = e.target.value.split(':');
-                await useAccount(accountId, accessKey);
-                await this.loadAccountData();
-                this.shadowRoot.getElementById('wasmgitaccountspan').innerText = accountId;
-            });
-            this.deletelocaldatabutton = this.shadowRoot.querySelector('#deletelocaldatabutton');
+            this.accountSpan = this.shadowRoot.getElementById('gatewayaccountspan');
+            this.refreshAccount();
 
+            this.shadowRoot.getElementById('downloadzipbutton')
+                .addEventListener('click', () => exportAndDownloadZip());
+
+            this.deletelocaldatabutton = this.shadowRoot.getElementById('deletelocaldatabutton');
             this.deletelocaldatabutton.addEventListener('click', async () => {
-                console.log('delete local data');
                 this.deletelocaldatabutton.disabled = true;
                 await delete_local();
                 location.reload();
             });
-            this.downloadzipbutton = this.shadowRoot.querySelector('#downloadzipbutton');
-            this.downloadzipbutton.addEventListener('click', () => {
-                exportAndDownloadZip();
-            });
-            await this.loadAccountData();
 
-            this.remoteRepoInput = this.shadowRoot.querySelector('#remoterepo');
-            this.remoteRepoInput.addEventListener('change', async () => {
-                await set_remote(this.remoteRepoInput.value);
-            });
+            this.syncbutton = this.shadowRoot.getElementById('syncbutton');
+            this.syncbutton.addEventListener('click', () => this.synchronize());
 
-            this.remoteRepoInput.value = await get_remote();
-            this.syncbutton = this.shadowRoot.querySelector('#syncbutton');
-            this.syncbutton.addEventListener('click', async () => {
-                if (!this.remoteRepoInput.value) {
-                    return;
-                }
-                setProgressbarValue('indeterminate', 'syncing with remote');
-                try {
-                    this.syncbutton.disabled = true;
-                    if (!(await exists('.git'))) {
-                        if ((await readdir('.')).length == 2) {
-                            await git_clone(this.remoteRepoInput.value);
-                        } else {
-                            await git_init();
-                            await this.loadAccountData();
-                            await set_remote(this.remoteRepoInput.value);
-                            await commit_all();
-                            await push();
-                        }
-                    } else {
-                        await commit_all();
-                        await sync();
-                        this.dispatchSyncEvent();
-                    }
-                } catch (e) {
-                    console.error(e);
-                    await modalAlert('Error syncing with remote', e);
-                }
-                setProgressbarValue(null);
-                this.syncbutton.disabled = false;
-            });
+            this.shadowRoot.getElementById('copyclonebutton')
+                .addEventListener('click', () => this.copyCommand('clone'));
+            this.shadowRoot.getElementById('copyconfigbutton')
+                .addEventListener('click', () => this.copyCommand('config'));
+
             return this.shadowRoot;
+        }
+
+        async refreshAccount() {
+            let accountId = null;
+            try { accountId = await getAccountId(); } catch { /* not signed in */ }
+            this.accountSpan.innerText = accountId || '(not signed in)';
+        }
+
+        async ensureSignedIn() {
+            if (!(await isSignedIn())) {
+                await loginToArizGateway();
+            }
         }
 
         dispatchSyncEvent() {
             this.dispatchEvent(new Event('sync'));
         }
 
-        async loadAccountData() {
-            const walletConnection = await createWalletConnection();
-            let currentUser = {
-                accountId: walletConnection.getAccountId()
-            };
+        async synchronize() {
+            setProgressbarValue('indeterminate', 'syncing with the Ariz gateway');
+            this.syncbutton.disabled = true;
+            try {
+                await this.ensureSignedIn();
+                const accessToken = await getAccessToken();
+                const accountId = await getAccountId();
+                const url = gatewayRepoUrl();
+                // Configure the worker's user + bearer token (needed before any
+                // network op). git config user.* is best-effort here if there is no
+                // repo yet, so it's re-applied once a repo exists below.
+                const setUser = () => configure_user({ accessToken, username: accountId, useremail: accountId });
 
-            if (!currentUser.accountId) {
-                return;
+                await setUser();
+                this.accountSpan.innerText = accountId || '(not signed in)';
+
+                if (!(await exists('.git'))) {
+                    if ((await readdir('.')).length === 2) {
+                        // empty local store -> clone the existing repo from the gateway
+                        await git_clone(url);
+                        await setUser();
+                    } else {
+                        // existing data, never a repo -> init, commit and first push
+                        await git_init();
+                        await setUser();
+                        await set_remote(url);
+                        await commit_all();
+                        await push();
+                    }
+                } else {
+                    await setUser();
+                    await set_remote(url);
+                    await commit_all();
+                    await sync();
+                }
+                this.dispatchSyncEvent();
+            } catch (e) {
+                console.error(e);
+                await modalAlert('Error syncing with the Ariz gateway', e);
             }
+            setProgressbarValue(null);
+            this.syncbutton.disabled = false;
+        }
 
-            const accessToken = await createAccessToken();
-            const configureuserResult = await configure_user({
-                accessToken,
-                useremail: currentUser.accountId,
-                username: currentUser.accountId
-            });
-            console.log('configure user result', configureuserResult);
+        async copyCommand(kind) {
+            try {
+                await this.ensureSignedIn();
+                const token = await getAccessToken();
+                const cmd = kind === 'clone' ? gitCloneCommand(token) : gitConfigCommand(token);
+                this.shadowRoot.getElementById(kind === 'clone' ? 'clonecmd' : 'configcmd').textContent = cmd;
+                // Best-effort: the command is shown for manual copy even if the
+                // clipboard API is unavailable/blocked.
+                try { await navigator.clipboard.writeText(cmd); } catch { /* shown for manual copy */ }
+            } catch (e) {
+                console.error(e);
+                await modalAlert('Could not generate the command', e);
+            }
         }
     });

--- a/public_html/storage/storage-page.component.spec.js
+++ b/public_html/storage/storage-page.component.spec.js
@@ -1,16 +1,38 @@
-import nearApi from 'near-api-js';
-import { useAccount, createAccessToken } from './storage-page.component.js';
+import { gitCloneCommand, gitConfigCommand, gatewayRepoUrl } from './storage-page.component.js';
+import { mockWalletAuthenticationData } from '../arizgateway/arizgatewayaccess.spec.js';
 
 describe('storage-page component', () => {
-    it('should create an signed access token if an access key is provided', async () => {
-        const storagePageComponent = document.createElement('storage-page');
-        document.body.appendChild(storagePageComponent);
+    before(() => {
+        // A fake wallet so the component can resolve the signed-in account without
+        // loading the real wallet UI / hitting the network.
+        mockWalletAuthenticationData('test.near');
+    });
 
-        const keypair = nearApi.utils.KeyPairEd25519.fromRandom();
+    it('builds a clone command passing the NEP-413 token as an http.extraHeader', () => {
+        const cmd = gitCloneCommand('TOKEN123');
+        expect(cmd).to.contain('http.extraHeader="Authorization: Bearer TOKEN123"');
+        expect(cmd).to.contain(`clone ${gatewayRepoUrl()}`);
+        expect(cmd.startsWith('git -c ')).to.equal(true);
+        expect(gatewayRepoUrl()).to.contain('/git/');
+    });
 
-        await useAccount('test.near', keypair.secretKey);
-        const accessToken = await createAccessToken();
-        const accessTokenParts = accessToken.split('.');
-        expect(JSON.parse(atob(accessTokenParts[0])).accountId).to.equal('test.near');
+    it('builds a git config command to refresh an expired token in an existing clone', () => {
+        expect(gitConfigCommand('TOKEN123')).to.equal('git config http.extraHeader "Authorization: Bearer TOKEN123"');
+    });
+
+    it('renders the new UI without the legacy access-key / remote-url inputs', async () => {
+        const el = document.createElement('storage-page');
+        document.body.appendChild(el);
+        await el.readyPromise;
+        const $ = (id) => el.shadowRoot.getElementById(id);
+        // legacy inputs are gone
+        expect($('wasmgitaccesskey')).to.equal(null);
+        expect($('remoterepo')).to.equal(null);
+        // new controls are present
+        expect($('syncbutton')).to.not.equal(null);
+        expect($('copyclonebutton')).to.not.equal(null);
+        expect($('copyconfigbutton')).to.not.equal(null);
+        expect($('gatewayaccountspan')).to.not.equal(null);
+        el.remove();
     });
 });


### PR DESCRIPTION
## What

Reworks the Storage page to use the **signed-in NEAR account (NEP-413)** for the
git remote instead of a manually-entered access key + URL, and adds copy-able
**CLI commands** for using the repo from a terminal.

- **Removed:** the `wasmgitaccesskey` (`accountId:secretKey`) field, the
  `remoterepo` URL field, and the legacy `wasmgit.near` wallet flow
  (`createWalletConnection` / `createAccessToken` / `useAccount`).
- **Synchronize** now: signs in if needed → configures the in-browser git worker
  with the NEP-413 bearer token → pushes to a fixed per-account repo
  `…/git/portfolio` on the gateway (account implied by the token).
- **CLI helpers** (copy buttons):
  - `git -c http.extraHeader="Authorization: Bearer <token>" clone …/git/portfolio` (one-shot clone)
  - `git config http.extraHeader "Authorization: Bearer <token>"` (refresh an expired token in an existing clone)

## Why

The gateway git server ([ariz-gateway#30](https://github.com/arizas/ariz-gateway/pull/30))
authenticates with NEP-413 — the same token the app already mints. So the Storage
page should just use the logged-in account; no separate key. The CLI commands let
power users clone/pull/push the same repo from a terminal with their token as a header.

## Tests

- Unit (wtr): clone/config command builders, and a render check that the legacy
  inputs are gone and the new controls present. (8 storage specs pass.)
- e2e (Playwright): rewritten to a Storage-UI smoke test (new controls present,
  `#wasmgitaccesskey` / `#remoterepo` absent) — passes against the bundled app.
- Build verified.

## Follow-ups

- Full push/clone **round-trip** against the gateway (needs the deployed gateway
  git server + a wallet) — verify post-deploy.
- Depends on arizas/ariz-gateway#30 being deployed for the actual push to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)