### PR TITLE
Add Portfolio page: fiscal-year movement, staking, stablecoin pricing fix

### DIFF
--- a/public_html/app.html.js
+++ b/public_html/app.html.js
@@ -23,7 +23,7 @@ export default /*html*/ `
         </button>
         <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
             <div class="navbar-nav">
-                <a class="nav-item nav-link" href="/portfolio" data-page="portfolio">Portefølje</a>
+                <a class="nav-item nav-link" href="/portfolio" data-page="portfolio">Portfolio</a>
                 <a class="nav-item nav-link" href="/year-report" data-page="year-report">Year report</a>
                 <a class="nav-item nav-link" href="/transactions" data-page="transactions">Transactions</a>
                 <a class="nav-item nav-link" href="/staking" data-page="staking">Staking rewards</a>

--- a/public_html/app.html.js
+++ b/public_html/app.html.js
@@ -22,7 +22,8 @@ export default /*html*/ `
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-            <div class="navbar-nav">                    
+            <div class="navbar-nav">
+                <a class="nav-item nav-link" href="/portfolio" data-page="portfolio">Portefølje</a>
                 <a class="nav-item nav-link" href="/year-report" data-page="year-report">Year report</a>
                 <a class="nav-item nav-link" href="/transactions" data-page="transactions">Transactions</a>
                 <a class="nav-item nav-link" href="/staking" data-page="staking">Staking rewards</a>

--- a/public_html/app.js
+++ b/public_html/app.js
@@ -6,6 +6,7 @@ import './stakingview/staking-page.component.js';
 import './customexchangerates/customexchangerates-page.component.js';
 import './storage/storage-page.component.js';
 import './counterparties/counterparties-page.component.js';
+import './portfolio/portfolio-page.component.js';
 import './yearreport/yearreport-page.component.js';
 import './arizcredits/arizcredits-page.component.js';
 import './yearreport/yearreport-print.component.js';

--- a/public_html/portfolio/portfolio-data.js
+++ b/public_html/portfolio/portfolio-data.js
@@ -1,0 +1,173 @@
+// Portfolio holdings + unrealized profit/loss calculation.
+//
+// Strategy: reuse the year report FIFO engine. calculateYearReportData builds the
+// full daily balance history for a token, and calculateProfitLoss runs FIFO over it.
+// The `openPositions` left over after processing all history ARE the current holdings,
+// each carrying its cost basis (convertedValue) in the target currency.
+//
+// - Current liquid amount per token = sum(openPositions[i].remainingAmount)
+//   (staking is already excluded by the FIFO engine, so this is non-staked balance)
+// - Cost basis = sum of remaining cost basis across open positions
+// - Unrealized P/L = current market value - cost basis
+//
+// getEODPrice (used by the FIFO step) now auto-loads missing historical prices from
+// the gateway and skips tokens the gateway reports as unpriceable, so no per-day
+// prompting or pre-warming is needed here.
+//
+// Liquid-staking tokens (stNEAR, LiNEAR, ...) are treated as "in staking" and kept
+// out of the portfolio total, per requirements.
+
+import { getAllFungibleTokenEntries } from '../storage/domainobjectstore.js';
+import {
+    calculateYearReportData,
+    calculateProfitLoss,
+    getDecimalConversionValue
+} from '../yearreport/yearreportdata.js';
+import { resolveSymbol, resolveDisplaySymbol } from '../near/intents-tokens.js';
+import { getCurrentPrices } from '../pricedata/pricedata.js';
+
+// Liquid-staking token symbols excluded from the portfolio total (treated as staking).
+export const EXCLUDED_STAKING_SYMBOLS = new Set(['STNEAR', 'LINEAR', 'NEARX', 'LST']);
+
+const NEAR_TOKEN = ''; // native NEAR is represented by an empty token id in the year report
+
+// Amounts below this (in display units) are treated as fully exited / dust.
+const DUST_THRESHOLD = 1e-9;
+
+/**
+ * Build the list of tokens to include: native NEAR plus every fungible token
+ * seen in the transaction history.
+ */
+async function getTokenList() {
+    const tokens = [{ token: NEAR_TOKEN, symbol: 'NEAR', displaySymbol: 'NEAR' }];
+    const ftEntries = await getAllFungibleTokenEntries();
+    for (const entry of ftEntries) {
+        const symbol = (await resolveSymbol(entry.contractId)) || entry.symbol;
+        const displaySymbol = await resolveDisplaySymbol(entry.contractId, entry.symbol);
+        tokens.push({ token: entry.contractId, symbol, displaySymbol });
+    }
+    return tokens;
+}
+
+/**
+ * Sum remaining amount (raw units) and remaining cost basis (target currency)
+ * across the FIFO open positions.
+ */
+function summarizeOpenPositions(openPositions) {
+    let remainingRaw = 0;
+    let costBasis = 0;
+    for (const position of openPositions) {
+        remainingRaw += position.remainingAmount;
+        // Remaining cost basis is the share of the position's initial converted value
+        // proportional to how much of the position is still open.
+        if (position.initialAmount > 0) {
+            costBasis += position.convertedValue * (position.remainingAmount / position.initialAmount);
+        }
+    }
+    return { remainingRaw, costBasis };
+}
+
+/**
+ * Calculate the full portfolio for a target currency.
+ *
+ * @param {string} currency - lowercase currency code (e.g. 'nok', 'usd')
+ * @param {(msg: string) => void} [onProgress] - optional progress callback
+ * @returns {Promise<{
+ *   currency: string,
+ *   holdings: Array<object>,
+ *   totalValue: number,
+ *   totalCost: number,
+ *   totalUnrealized: number,
+ *   totalUnrealizedPct: number|null,
+ *   excludedValue: number
+ * }>}
+ */
+export async function calculatePortfolio(currency, onProgress = () => {}) {
+    const tokens = await getTokenList();
+    const holdings = [];
+
+    for (let i = 0; i < tokens.length; i++) {
+        const t = tokens[i];
+        onProgress(`Beregner ${t.displaySymbol} (${i + 1}/${tokens.length})`);
+
+        const excluded = EXCLUDED_STAKING_SYMBOLS.has(t.symbol.toUpperCase());
+
+        // calculateYearReportData must run before calculateProfitLoss for the same
+        // token: it populates decimals/cost-basis metadata used by the FIFO step.
+        const { dailyBalances } = await calculateYearReportData(t.token);
+        const { openPositions } = await calculateProfitLoss(dailyBalances, currency, t.token);
+
+        const decimalConversionValue = t.token
+            ? getDecimalConversionValue(t.token)
+            : Math.pow(10, -24);
+
+        const { remainingRaw, costBasis } = summarizeOpenPositions(openPositions);
+        const amount = remainingRaw * decimalConversionValue;
+
+        holdings.push({
+            token: t.token,
+            symbol: t.symbol,
+            displaySymbol: t.displaySymbol,
+            excluded,
+            amount,
+            costBasis,
+            // Held but no cost basis recorded (e.g. airdrop, or missing historical price)
+            missingCostBasis: amount > DUST_THRESHOLD && !(costBasis > 0)
+        });
+    }
+
+    // Fetch current spot prices for everything we actually hold, in one batch.
+    onProgress('Henter dagens priser');
+    const pricedSymbols = holdings
+        .filter(h => h.amount > DUST_THRESHOLD)
+        .map(h => h.symbol);
+
+    let currentPrices = {};
+    try {
+        currentPrices = await getCurrentPrices(pricedSymbols, currency);
+    } catch (e) {
+        currentPrices = {};
+    }
+
+    let totalValue = 0;
+    let totalCost = 0;
+    let excludedValue = 0;
+
+    for (const h of holdings) {
+        const price = currentPrices[h.symbol] ?? null;
+        h.price = price;
+        h.value = price != null ? h.amount * price : null;
+        h.priceMissing = price == null && h.amount > DUST_THRESHOLD;
+        h.unrealized = (h.value != null) ? h.value - h.costBasis : null;
+        h.unrealizedPct = (h.unrealized != null && h.costBasis > 0)
+            ? (h.unrealized / h.costBasis) * 100
+            : null;
+
+        if (h.value != null) {
+            if (h.excluded) {
+                excludedValue += h.value;
+            } else {
+                totalValue += h.value;
+                totalCost += h.costBasis;
+            }
+        }
+    }
+
+    const totalUnrealized = totalValue - totalCost;
+    const totalUnrealizedPct = totalCost > 0 ? (totalUnrealized / totalCost) * 100 : null;
+
+    // Show held tokens (and excluded staking tokens for transparency); hide fully exited.
+    const visibleHoldings = holdings
+        .filter(h => h.amount > DUST_THRESHOLD)
+        .sort((a, b) => (b.value ?? -1) - (a.value ?? -1));
+
+    return {
+        currency,
+        holdings: visibleHoldings,
+        totalValue,
+        totalCost,
+        totalUnrealized,
+        totalUnrealizedPct,
+        excludedValue
+    };
+}

--- a/public_html/portfolio/portfolio-data.js
+++ b/public_html/portfolio/portfolio-data.js
@@ -34,6 +34,16 @@ const NEAR_TOKEN = ''; // native NEAR is represented by an empty token id in the
 // Amounts below this (in display units) are treated as fully exited / dust.
 const DUST_THRESHOLD = 1e-9;
 
+// Computing the full-history FIFO for every token is expensive, and the page
+// component is recreated on every navigation. Cache the last result per currency
+// so returning to the page is instant; callers pass { force: true } (the Refresh
+// button / currency switch with no cache) to recompute.
+const portfolioCache = new Map(); // currency -> portfolio result
+
+export function clearPortfolioCache() {
+    portfolioCache.clear();
+}
+
 /**
  * Build the list of tokens to include: native NEAR plus every fungible token
  * seen in the transaction history.
@@ -82,7 +92,11 @@ function summarizeOpenPositions(openPositions) {
  *   excludedValue: number
  * }>}
  */
-export async function calculatePortfolio(currency, onProgress = () => {}) {
+export async function calculatePortfolio(currency, onProgress = () => {}, { force = false } = {}) {
+    if (!force && portfolioCache.has(currency)) {
+        return portfolioCache.get(currency);
+    }
+
     const tokens = await getTokenList();
     const holdings = [];
 
@@ -161,7 +175,7 @@ export async function calculatePortfolio(currency, onProgress = () => {}) {
         .filter(h => h.amount > DUST_THRESHOLD)
         .sort((a, b) => (b.value ?? -1) - (a.value ?? -1));
 
-    return {
+    const portfolio = {
         currency,
         holdings: visibleHoldings,
         totalValue,
@@ -170,4 +184,6 @@ export async function calculatePortfolio(currency, onProgress = () => {}) {
         totalUnrealizedPct,
         excludedValue
     };
+    portfolioCache.set(currency, portfolio);
+    return portfolio;
 }

--- a/public_html/portfolio/portfolio-data.js
+++ b/public_html/portfolio/portfolio-data.js
@@ -1,21 +1,24 @@
-// Portfolio holdings + unrealized profit/loss calculation.
+// Portfolio: fiscal-year movement (IB -> realized -> UB) + current status.
 //
-// Strategy: reuse the year report FIFO engine. calculateYearReportData builds the
-// full daily balance history for a token, and calculateProfitLoss runs FIFO over it.
-// The `openPositions` left over after processing all history ARE the current holdings,
-// each carrying its cost basis (convertedValue) in the target currency.
+// Reuses the year report FIFO engine (calculateYearReportData + calculateProfitLoss).
 //
-// - Current liquid amount per token = sum(openPositions[i].remainingAmount)
-//   (staking is already excluded by the FIFO engine, so this is non-staked balance)
-// - Cost basis = sum of remaining cost basis across open positions
-// - Unrealized P/L = current market value - cost basis
+//   IB (opening balance, at the "from" date)
+//   + realized gain/loss during the period (every disposal / swap is a realization)
+//   + change in unrealized value
+//   = UB (closing balance, now)
 //
-// getEODPrice (used by the FIFO step) now auto-loads missing historical prices from
-// the gateway and skips tokens the gateway reports as unpriceable, so no per-day
-// prompting or pre-warming is needed here.
+// How each number is derived from the FIFO:
+//   - UB holdings / cost basis / value : openPositions after the FULL history pass.
+//   - Realized P/L in period           : per-day FIFO profit/loss, summed from the
+//                                        "from" date to today.
+//   - IB holdings / cost basis         : openPositions after a FIFO pass TRUNCATED to
+//                                        days before the "from" date.
+//   - IB market value                  : IB holdings valued at the EOD price on the
+//                                        "from" date.
 //
-// Liquid-staking tokens (stNEAR, LiNEAR, ...) are treated as "in staking" and kept
-// out of the portfolio total, per requirements.
+// Two-level caching: the heavy full-history FIFO + price fetch runs once per
+// currency (baseCache). IB (which depends on the "from" date) is a CPU-only
+// truncated FIFO pass, cached per currency+date.
 
 import { getAllFungibleTokenEntries } from '../storage/domainobjectstore.js';
 import {
@@ -24,30 +27,22 @@ import {
     getDecimalConversionValue
 } from '../yearreport/yearreportdata.js';
 import { resolveSymbol, resolveDisplaySymbol } from '../near/intents-tokens.js';
-import { getCurrentPrices } from '../pricedata/pricedata.js';
+import { getCurrentPrices, getEODPrice } from '../pricedata/pricedata.js';
 
 // Liquid-staking token symbols excluded from the portfolio total (treated as staking).
 export const EXCLUDED_STAKING_SYMBOLS = new Set(['STNEAR', 'LINEAR', 'NEARX', 'LST']);
 
 const NEAR_TOKEN = ''; // native NEAR is represented by an empty token id in the year report
-
-// Amounts below this (in display units) are treated as fully exited / dust.
 const DUST_THRESHOLD = 1e-9;
 
-// Computing the full-history FIFO for every token is expensive, and the page
-// component is recreated on every navigation. Cache the last result per currency
-// so returning to the page is instant; callers pass { force: true } (the Refresh
-// button / currency switch with no cache) to recompute.
-const portfolioCache = new Map(); // currency -> portfolio result
+const baseCache = new Map(); // currency -> base data (heavy: FIFO + prices)
+const ibCache = new Map();   // `${currency}|${fromDate}` -> Map(token -> ib snapshot)
 
 export function clearPortfolioCache() {
-    portfolioCache.clear();
+    baseCache.clear();
+    ibCache.clear();
 }
 
-/**
- * Build the list of tokens to include: native NEAR plus every fungible token
- * seen in the transaction history.
- */
 async function getTokenList() {
     const tokens = [{ token: NEAR_TOKEN, symbol: 'NEAR', displaySymbol: 'NEAR' }];
     const ftEntries = await getAllFungibleTokenEntries();
@@ -59,17 +54,11 @@ async function getTokenList() {
     return tokens;
 }
 
-/**
- * Sum remaining amount (raw units) and remaining cost basis (target currency)
- * across the FIFO open positions.
- */
 function summarizeOpenPositions(openPositions) {
     let remainingRaw = 0;
     let costBasis = 0;
     for (const position of openPositions) {
         remainingRaw += position.remainingAmount;
-        // Remaining cost basis is the share of the position's initial converted value
-        // proportional to how much of the position is still open.
         if (position.initialAmount > 0) {
             costBasis += position.convertedValue * (position.remainingAmount / position.initialAmount);
         }
@@ -78,23 +67,13 @@ function summarizeOpenPositions(openPositions) {
 }
 
 /**
- * Calculate the full portfolio for a target currency.
- *
- * @param {string} currency - lowercase currency code (e.g. 'nok', 'usd')
- * @param {(msg: string) => void} [onProgress] - optional progress callback
- * @returns {Promise<{
- *   currency: string,
- *   holdings: Array<object>,
- *   totalValue: number,
- *   totalCost: number,
- *   totalUnrealized: number,
- *   totalUnrealizedPct: number|null,
- *   excludedValue: number
- * }>}
+ * Heavy per-currency computation, cached. Runs the full-history FIFO for every
+ * token to get current holdings, cost basis, the per-day realized series, current
+ * prices/value/unrealized, and keeps each token's daily balances for IB passes.
  */
-export async function calculatePortfolio(currency, onProgress = () => {}, { force = false } = {}) {
-    if (!force && portfolioCache.has(currency)) {
-        return portfolioCache.get(currency);
+async function computeBase(currency, onProgress, force) {
+    if (!force && baseCache.has(currency)) {
+        return baseCache.get(currency);
     }
 
     const tokens = await getTokenList();
@@ -102,12 +81,10 @@ export async function calculatePortfolio(currency, onProgress = () => {}, { forc
 
     for (let i = 0; i < tokens.length; i++) {
         const t = tokens[i];
-        onProgress(`Beregner ${t.displaySymbol} (${i + 1}/${tokens.length})`);
+        onProgress(`Calculating ${t.displaySymbol} (${i + 1}/${tokens.length})`);
 
         const excluded = EXCLUDED_STAKING_SYMBOLS.has(t.symbol.toUpperCase());
 
-        // calculateYearReportData must run before calculateProfitLoss for the same
-        // token: it populates decimals/cost-basis metadata used by the FIFO step.
         const { dailyBalances } = await calculateYearReportData(t.token);
         const { openPositions } = await calculateProfitLoss(dailyBalances, currency, t.token);
 
@@ -118,6 +95,16 @@ export async function calculatePortfolio(currency, onProgress = () => {}, { forc
         const { remainingRaw, costBasis } = summarizeOpenPositions(openPositions);
         const amount = remainingRaw * decimalConversionValue;
 
+        // Per-day realized net P/L (gain - loss) from FIFO disposals. FIFO is
+        // prefix-consistent, so a later truncated pass won't change these days.
+        const realizationsByDate = [];
+        for (const datestring in dailyBalances) {
+            const net = (dailyBalances[datestring].profit || 0) - (dailyBalances[datestring].loss || 0);
+            if (net !== 0) {
+                realizationsByDate.push({ date: datestring, net });
+            }
+        }
+
         holdings.push({
             token: t.token,
             symbol: t.symbol,
@@ -125,17 +112,15 @@ export async function calculatePortfolio(currency, onProgress = () => {}, { forc
             excluded,
             amount,
             costBasis,
-            // Held but no cost basis recorded (e.g. airdrop, or missing historical price)
-            missingCostBasis: amount > DUST_THRESHOLD && !(costBasis > 0)
+            missingCostBasis: amount > DUST_THRESHOLD && !(costBasis > 0),
+            realizationsByDate,
+            decimalConversionValue,
+            dailyBalances
         });
     }
 
-    // Fetch current spot prices for everything we actually hold, in one batch.
-    onProgress('Henter dagens priser');
-    const pricedSymbols = holdings
-        .filter(h => h.amount > DUST_THRESHOLD)
-        .map(h => h.symbol);
-
+    onProgress('Fetching current prices');
+    const pricedSymbols = holdings.filter(h => h.amount > DUST_THRESHOLD).map(h => h.symbol);
     let currentPrices = {};
     try {
         currentPrices = await getCurrentPrices(pricedSymbols, currency);
@@ -146,7 +131,6 @@ export async function calculatePortfolio(currency, onProgress = () => {}, { forc
     let totalValue = 0;
     let totalCost = 0;
     let excludedValue = 0;
-
     for (const h of holdings) {
         const price = currentPrices[h.symbol] ?? null;
         h.price = price;
@@ -154,36 +138,164 @@ export async function calculatePortfolio(currency, onProgress = () => {}, { forc
         h.priceMissing = price == null && h.amount > DUST_THRESHOLD;
         h.unrealized = (h.value != null) ? h.value - h.costBasis : null;
         h.unrealizedPct = (h.unrealized != null && h.costBasis > 0)
-            ? (h.unrealized / h.costBasis) * 100
-            : null;
-
+            ? (h.unrealized / h.costBasis) * 100 : null;
         if (h.value != null) {
-            if (h.excluded) {
-                excludedValue += h.value;
-            } else {
-                totalValue += h.value;
-                totalCost += h.costBasis;
-            }
+            if (h.excluded) excludedValue += h.value;
+            else { totalValue += h.value; totalCost += h.costBasis; }
         }
     }
 
-    const totalUnrealized = totalValue - totalCost;
-    const totalUnrealizedPct = totalCost > 0 ? (totalUnrealized / totalCost) * 100 : null;
+    // Staking (NEAR-only in this app) is excluded from the FIFO, so staked NEAR is
+    // not in the liquid holdings above. Expose the staked-NEAR balance series (raw
+    // yocto per day) so the portfolio can show it as its own line and value it.
+    const nearHolding = holdings.find(h => h.token === NEAR_TOKEN);
+    const stakedRawByDate = {};
+    if (nearHolding) {
+        for (const ds in nearHolding.dailyBalances) {
+            const sb = nearHolding.dailyBalances[ds].stakingBalance;
+            if (sb) stakedRawByDate[ds] = sb;
+        }
+    }
 
-    // Show held tokens (and excluded staking tokens for transparency); hide fully exited.
+    const base = {
+        currency, holdings, totalValue, totalCost, excludedValue,
+        stakedRawByDate,
+        nearPrice: currentPrices['NEAR'] ?? null,
+        nearDecimal: Math.pow(10, -24)
+    };
+    baseCache.set(currency, base);
+    return base;
+}
+
+/**
+ * IB snapshot (opening balance) per token at `fromDate`: holdings and cost basis
+ * from a FIFO pass truncated to days BEFORE fromDate, valued at the EOD price on
+ * fromDate. Cached per currency+date.
+ */
+async function computeIbSnapshot(base, currency, fromDate, onProgress) {
+    const cacheKey = `${currency}|${fromDate}`;
+    if (ibCache.has(cacheKey)) {
+        return ibCache.get(cacheKey);
+    }
+
+    const snapshot = new Map();
+    for (const h of base.holdings) {
+        // Truncate daily balances to days strictly before the from date.
+        const truncated = {};
+        for (const ds in h.dailyBalances) {
+            if (ds < fromDate) truncated[ds] = h.dailyBalances[ds];
+        }
+        const { openPositions } = await calculateProfitLoss(truncated, currency, h.token);
+        const { remainingRaw, costBasis } = summarizeOpenPositions(openPositions);
+        const ibAmount = remainingRaw * h.decimalConversionValue;
+
+        let ibValue = null;
+        if (ibAmount > DUST_THRESHOLD) {
+            const ibPrice = await getEODPrice(currency, fromDate, h.token);
+            ibValue = ibPrice ? ibAmount * ibPrice : null;
+        } else {
+            ibValue = 0;
+        }
+
+        snapshot.set(h.token, { ibAmount, ibCostBasis: costBasis, ibValue });
+    }
+
+    ibCache.set(cacheKey, snapshot);
+    return snapshot;
+}
+
+/**
+ * Full fiscal-year portfolio for a currency and a "from" date.
+ *
+ * @param {string} currency - lowercase currency code (e.g. 'nok')
+ * @param {string} fromDate - 'yyyy-MM-dd'; start of the fiscal period (IB date)
+ * @param {(msg:string)=>void} [onProgress]
+ * @param {{force?: boolean}} [opts]
+ */
+export async function calculatePortfolio(currency, fromDate, onProgress = () => {}, { force = false } = {}) {
+    const base = await computeBase(currency, onProgress, force);
+    const ibSnapshot = await computeIbSnapshot(base, currency, fromDate, onProgress);
+
+    let totalRealized = 0;
+    let ibValue = 0;
+    let ibCost = 0;
+
+    const holdings = base.holdings.map(h => {
+        let realized = 0;
+        for (const r of h.realizationsByDate) {
+            if (r.date >= fromDate) realized += r.net;
+        }
+        const ib = ibSnapshot.get(h.token) || { ibAmount: 0, ibCostBasis: 0, ibValue: 0 };
+        if (!h.excluded) {
+            totalRealized += realized;
+            ibCost += ib.ibCostBasis || 0;
+            ibValue += ib.ibValue || 0;
+        }
+        return {
+            token: h.token,
+            symbol: h.symbol,
+            displaySymbol: h.displaySymbol,
+            excluded: h.excluded,
+            amount: h.amount,
+            price: h.price,
+            value: h.value,
+            costBasis: h.costBasis,
+            unrealized: h.unrealized,
+            unrealizedPct: h.unrealizedPct,
+            priceMissing: h.priceMissing,
+            missingCostBasis: h.missingCostBasis,
+            realized,
+            ibAmount: ib.ibAmount,
+            ibCostBasis: ib.ibCostBasis,
+            ibValue: ib.ibValue
+        };
+    });
+
     const visibleHoldings = holdings
-        .filter(h => h.amount > DUST_THRESHOLD)
+        .filter(h => h.amount > DUST_THRESHOLD || Math.abs(h.realized) > 1e-9 || h.ibAmount > DUST_THRESHOLD)
         .sort((a, b) => (b.value ?? -1) - (a.value ?? -1));
 
-    const portfolio = {
+    const totalUnrealized = base.totalValue - base.totalCost;
+
+    // Staked NEAR (shown on its own line, kept out of the liquid IB→UB movement).
+    // Current = latest staking balance; IB = last staking balance before fromDate
+    // (0 here, since staking started during the period).
+    const stakedDates = Object.keys(base.stakedRawByDate).sort();
+    const currentStakedRaw = stakedDates.length ? base.stakedRawByDate[stakedDates[stakedDates.length - 1]] : 0;
+    let ibStakedRaw = 0;
+    for (const ds of stakedDates) {
+        if (ds < fromDate) ibStakedRaw = base.stakedRawByDate[ds];
+        else break;
+    }
+    const stakedAmount = currentStakedRaw * base.nearDecimal;
+    const ibStakedAmount = ibStakedRaw * base.nearDecimal;
+    const stakedValue = base.nearPrice != null ? stakedAmount * base.nearPrice : null;
+    const ibNearPrice = ibStakedAmount > DUST_THRESHOLD ? await getEODPrice(currency, fromDate, NEAR_TOKEN) : 0;
+    const ibStakedValue = ibStakedAmount > DUST_THRESHOLD ? ibStakedAmount * ibNearPrice : 0;
+
+    return {
         currency,
+        fromDate,
         holdings: visibleHoldings,
-        totalValue,
-        totalCost,
+        // UB (now) — liquid holdings
+        totalValue: base.totalValue,
+        totalCost: base.totalCost,
         totalUnrealized,
-        totalUnrealizedPct,
-        excludedValue
+        totalUnrealizedPct: base.totalCost > 0 ? (totalUnrealized / base.totalCost) * 100 : null,
+        excludedValue: base.excludedValue,
+        // IB (opening balance) — liquid holdings
+        ibValue,
+        ibCost,
+        // Period result
+        totalRealized,
+        totalResult: totalRealized + totalUnrealized,
+        // Staking (NEAR), shown separately
+        stakedAmount,
+        stakedValue,
+        ibStakedAmount,
+        ibStakedValue,
+        // Complete asset picture
+        totalWithStaked: base.totalValue + (stakedValue || 0),
+        ibWithStaked: ibValue + (ibStakedValue || 0)
     };
-    portfolioCache.set(currency, portfolio);
-    return portfolio;
 }

--- a/public_html/portfolio/portfolio-page.component.html.js
+++ b/public_html/portfolio/portfolio-page.component.html.js
@@ -1,0 +1,114 @@
+export default /*html*/ `
+<style>
+    .portfolio-wrap { margin-bottom: 3rem; }
+    .portfolio-toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+    }
+    .portfolio-toolbar h2 { margin: 0; font-size: 1.5rem; }
+    .portfolio-toolbar .spacer { flex: 1; }
+
+    .summary-cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.75rem;
+    }
+    .summary-card {
+        border: 1px solid #dee2e6;
+        border-radius: 0.75rem;
+        padding: 1.1rem 1.25rem;
+        background: #fff;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    }
+    .summary-card .label {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #6c757d;
+        margin-bottom: 0.35rem;
+    }
+    .summary-card .value { font-size: 1.6rem; font-weight: 600; line-height: 1.2; }
+    .summary-card .sub { font-size: 0.9rem; margin-top: 0.2rem; }
+
+    .gain { color: #198754; }
+    .loss { color: #dc3545; }
+    .muted { color: #6c757d; }
+
+    .holding-card {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 0.25rem 1rem;
+        align-items: center;
+        border: 1px solid #e9ecef;
+        border-radius: 0.6rem;
+        padding: 0.85rem 1.1rem;
+        margin-bottom: 0.6rem;
+        background: #fff;
+    }
+    .holding-card.excluded { opacity: 0.7; background: #f8f9fa; }
+    .holding-head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
+    .holding-symbol { font-weight: 600; font-size: 1.05rem; }
+    .holding-amount { color: #6c757d; font-size: 0.9rem; }
+    .holding-values { text-align: right; }
+    .holding-value { font-weight: 600; font-size: 1.05rem; }
+    .holding-pl { font-size: 0.9rem; }
+
+    .alloc-bar {
+        grid-column: 1 / -1;
+        height: 6px;
+        border-radius: 3px;
+        background: #e9ecef;
+        overflow: hidden;
+        margin-top: 0.5rem;
+    }
+    .alloc-bar > span { display: block; height: 100%; background: #0d6efd; }
+
+    .flag {
+        display: inline-block;
+        font-size: 0.7rem;
+        font-weight: 600;
+        padding: 0.1rem 0.45rem;
+        border-radius: 0.4rem;
+        background: #fff3cd;
+        color: #997404;
+        border: 1px solid #ffe69c;
+    }
+
+    .portfolio-note { font-size: 0.85rem; color: #6c757d; margin-top: 1.5rem; }
+    #portfolio-progress { color: #6c757d; }
+    @media (prefers-color-scheme: dark) {
+        .summary-card, .holding-card { background: #1e1e1e; border-color: #343a40; }
+        .holding-card.excluded { background: #161616; }
+    }
+</style>
+
+<div class="portfolio-wrap">
+    <div class="portfolio-toolbar">
+        <h2>Portefølje</h2>
+        <div class="spacer"></div>
+        <label class="d-flex align-items-center gap-2 mb-0">
+            <span class="muted small">Valuta</span>
+            <select id="currencyselect" class="form-select form-select-sm" style="width:auto"></select>
+        </label>
+        <button id="refreshbutton" class="btn btn-sm btn-outline-secondary">Oppdater</button>
+    </div>
+
+    <div id="portfolio-progress" class="mb-3"></div>
+
+    <div id="summary" class="summary-cards" hidden></div>
+
+    <div id="holdings"></div>
+
+    <div id="excluded-note" class="portfolio-note" hidden></div>
+
+    <div class="portfolio-note">
+        Saldo er utledet fra transaksjonshistorikken (FIFO) og viser likvid, ikke-staket beholdning.
+        Urealisert gevinst/tap = dagens markedsverdi minus kostpris. Tokens i staking holdes utenfor totalen.
+        Tall bør verifiseres manuelt før bruk.
+    </div>
+</div>
+`;

--- a/public_html/portfolio/portfolio-page.component.html.js
+++ b/public_html/portfolio/portfolio-page.component.html.js
@@ -11,32 +11,52 @@ export default /*html*/ `
     .portfolio-toolbar h2 { margin: 0; font-size: 1.5rem; }
     .portfolio-toolbar .spacer { flex: 1; }
 
-    .summary-cards {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1rem;
-        margin-bottom: 1.75rem;
-    }
-    .summary-card {
-        border: 1px solid #dee2e6;
-        border-radius: 0.75rem;
-        padding: 1.1rem 1.25rem;
-        background: #fff;
-        box-shadow: 0 1px 3px rgba(0,0,0,0.04);
-    }
-    .summary-card .label {
-        font-size: 0.8rem;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        color: #6c757d;
-        margin-bottom: 0.35rem;
-    }
-    .summary-card .value { font-size: 1.6rem; font-weight: 600; line-height: 1.2; }
-    .summary-card .sub { font-size: 0.9rem; margin-top: 0.2rem; }
-
     .gain { color: #198754; }
     .loss { color: #dc3545; }
     .muted { color: #6c757d; }
+
+    .card-surface {
+        border: 1px solid #dee2e6;
+        border-radius: 0.75rem;
+        background: #fff;
+    }
+
+    .hero-card { padding: 1.1rem 1.25rem; margin-bottom: 0.5rem; }
+    .hero-card .label {
+        font-size: 0.85rem; color: #6c757d; margin-bottom: 0.25rem;
+    }
+    .hero-value { font-size: 2rem; font-weight: 600; line-height: 1.1; }
+    .hero-sub { font-size: 0.9rem; color: #495057; margin-top: 0.5rem; }
+
+    .section-label {
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #6c757d;
+        margin: 1.4rem 0 0.5rem;
+    }
+
+    .result-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 0.6rem;
+    }
+    .metric-card { padding: 0.9rem 1rem; }
+    .metric-card.result { background: #eafaf1; border-color: #b7e4c7; }
+    .metric-card .label { font-size: 0.85rem; color: #6c757d; }
+    .metric-card .value { font-size: 1.35rem; font-weight: 600; line-height: 1.2; }
+    .metric-card .cap { font-size: 0.78rem; color: #6c757d; margin-top: 0.15rem; }
+    .metric-pct { font-size: 0.85rem; font-weight: 500; }
+
+    .footnote { font-size: 0.78rem; color: #6c757d; margin-top: 0.5rem; line-height: 1.5; }
+
+    .balance-card {
+        display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
+        padding: 1rem 1.25rem;
+    }
+    .balance-card .label { font-size: 0.85rem; color: #6c757d; }
+    .bal-value { font-size: 1.25rem; font-weight: 600; }
+    .bal-arrow { font-size: 1.3rem; color: #adb5bd; }
 
     .holding-card {
         display: grid;
@@ -81,34 +101,43 @@ export default /*html*/ `
     .portfolio-note { font-size: 0.85rem; color: #6c757d; margin-top: 1.5rem; }
     #portfolio-progress { color: #6c757d; }
     @media (prefers-color-scheme: dark) {
-        .summary-card, .holding-card { background: #1e1e1e; border-color: #343a40; }
+        .card-surface, .holding-card { background: #1e1e1e; border-color: #343a40; }
         .holding-card.excluded { background: #161616; }
+        .metric-card.result { background: #15321f; border-color: #1f5132; }
+        .hero-sub { color: #ced4da; }
     }
 </style>
 
 <div class="portfolio-wrap">
     <div class="portfolio-toolbar">
-        <h2>Portefølje</h2>
+        <h2>Portfolio</h2>
         <div class="spacer"></div>
         <label class="d-flex align-items-center gap-2 mb-0">
-            <span class="muted small">Valuta</span>
+            <span class="muted small">From</span>
+            <select id="frommonthselect" class="form-select form-select-sm" style="width:auto"></select>
+            <select id="fromyearselect" class="form-select form-select-sm" style="width:auto"></select>
+        </label>
+        <label class="d-flex align-items-center gap-2 mb-0">
+            <span class="muted small">Currency</span>
             <select id="currencyselect" class="form-select form-select-sm" style="width:auto"></select>
         </label>
-        <button id="refreshbutton" class="btn btn-sm btn-outline-secondary">Oppdater</button>
+        <button id="refreshbutton" class="btn btn-sm btn-outline-secondary">Refresh</button>
     </div>
 
     <div id="portfolio-progress" class="mb-3"></div>
 
-    <div id="summary" class="summary-cards" hidden></div>
+    <div id="summary" hidden></div>
 
-    <div id="holdings"></div>
-
-    <div id="excluded-note" class="portfolio-note" hidden></div>
+    <div id="holdings-section" hidden>
+        <div class="section-label">Holdings</div>
+        <div id="holdings"></div>
+        <div id="excluded-note" class="portfolio-note" hidden></div>
+    </div>
 
     <div class="portfolio-note">
-        Saldo er utledet fra transaksjonshistorikken (FIFO) og viser likvid, ikke-staket beholdning.
-        Urealisert gevinst/tap = dagens markedsverdi minus kostpris. Tokens i staking holdes utenfor totalen.
-        Tall bør verifiseres manuelt før bruk.
+        Balances are derived from the transaction history (FIFO). Realized gain/loss is net of gas, fees
+        and slippage — every swap counts as a disposal. Staked NEAR is shown separately and added to the
+        total. Figures should be verified manually before use.
     </div>
 </div>
 `;

--- a/public_html/portfolio/portfolio-page.component.js
+++ b/public_html/portfolio/portfolio-page.component.js
@@ -20,7 +20,7 @@ customElements.define('portfolio-page',
             this.refreshButton = this.shadowRoot.querySelector('#refreshbutton');
 
             this.currencySelect.addEventListener('change', () => this.refresh());
-            this.refreshButton.addEventListener('click', () => this.refresh());
+            this.refreshButton.addEventListener('click', () => this.refresh(true));
 
             this.init();
         }
@@ -46,14 +46,14 @@ customElements.define('portfolio-page',
             this.progressEl.hidden = !busy && !message;
         }
 
-        async refresh() {
+        async refresh(force = false) {
             const currency = this.currencySelect.value;
             if (!currency) {
                 return;
             }
-            this.setBusy(true, 'Laster portefølje …');
+            this.setBusy(true, force ? 'Beregner portefølje på nytt …' : 'Laster portefølje …');
             try {
-                const portfolio = await calculatePortfolio(currency, msg => this.setBusy(true, msg));
+                const portfolio = await calculatePortfolio(currency, msg => this.setBusy(true, msg), { force });
                 this.render(portfolio);
                 this.setBusy(false, '');
             } catch (e) {

--- a/public_html/portfolio/portfolio-page.component.js
+++ b/public_html/portfolio/portfolio-page.component.js
@@ -4,6 +4,11 @@ import html from './portfolio-page.component.html.js';
 
 const PREFERRED_DEFAULT_CURRENCY = 'nok';
 
+const MONTH_NAMES = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+];
+
 customElements.define('portfolio-page',
     class extends HTMLElement {
         constructor() {
@@ -15,11 +20,16 @@ customElements.define('portfolio-page',
             this.progressEl = this.shadowRoot.querySelector('#portfolio-progress');
             this.summaryEl = this.shadowRoot.querySelector('#summary');
             this.holdingsEl = this.shadowRoot.querySelector('#holdings');
+            this.holdingsSection = this.shadowRoot.querySelector('#holdings-section');
             this.excludedNoteEl = this.shadowRoot.querySelector('#excluded-note');
             this.currencySelect = this.shadowRoot.querySelector('#currencyselect');
+            this.fromMonthSelect = this.shadowRoot.querySelector('#frommonthselect');
+            this.fromYearSelect = this.shadowRoot.querySelector('#fromyearselect');
             this.refreshButton = this.shadowRoot.querySelector('#refreshbutton');
 
             this.currencySelect.addEventListener('change', () => this.refresh());
+            this.fromMonthSelect.addEventListener('change', () => this.refresh());
+            this.fromYearSelect.addEventListener('change', () => this.refresh());
             this.refreshButton.addEventListener('click', () => this.refresh(true));
 
             this.init();
@@ -36,7 +46,33 @@ customElements.define('portfolio-page',
             if (currencies.includes(PREFERRED_DEFAULT_CURRENCY)) {
                 this.currencySelect.value = PREFERRED_DEFAULT_CURRENCY;
             }
+
+            // "From" date selectors: start of the fiscal period (IB date).
+            MONTH_NAMES.forEach((name, idx) => {
+                const opt = document.createElement('option');
+                opt.value = String(idx);
+                opt.text = name;
+                this.fromMonthSelect.appendChild(opt);
+            });
+            const currentYear = new Date().getFullYear();
+            for (let year = currentYear; year >= 2020; year--) {
+                const opt = document.createElement('option');
+                opt.value = String(year);
+                opt.text = String(year);
+                this.fromYearSelect.appendChild(opt);
+            }
+            // Default to the start of the current calendar/fiscal year.
+            this.fromMonthSelect.value = '0';
+            this.fromYearSelect.value = String(currentYear);
+
             await this.refresh();
+        }
+
+        getFromDate() {
+            const year = parseInt(this.fromYearSelect.value, 10);
+            const month = parseInt(this.fromMonthSelect.value, 10);
+            const mm = String(month + 1).padStart(2, '0');
+            return `${year}-${mm}-01`;
         }
 
         setBusy(busy, message = '') {
@@ -51,49 +87,107 @@ customElements.define('portfolio-page',
             if (!currency) {
                 return;
             }
-            this.setBusy(true, force ? 'Beregner portefølje på nytt …' : 'Laster portefølje …');
+            const fromDate = this.getFromDate();
+            this.setBusy(true, force ? 'Recalculating portfolio …' : 'Loading portfolio …');
             try {
-                const portfolio = await calculatePortfolio(currency, msg => this.setBusy(true, msg), { force });
+                const portfolio = await calculatePortfolio(currency, fromDate, msg => this.setBusy(true, msg), { force });
                 this.render(portfolio);
                 this.setBusy(false, '');
             } catch (e) {
                 console.error('Failed to calculate portfolio', e);
                 this.setBusy(false, '');
                 this.summaryEl.hidden = true;
+                this.holdingsSection.hidden = false;
                 this.holdingsEl.innerHTML =
-                    `<div class="alert alert-danger">Kunne ikke beregne porteføljen: ${escapeHtml(e.message)}</div>`;
+                    `<div class="alert alert-danger">Could not calculate portfolio: ${escapeHtml(e.message)}</div>`;
             }
         }
 
         render(portfolio) {
             const cur = portfolio.currency.toUpperCase();
             const money = makeMoneyFormatter(cur);
-            const totalPlClass = portfolio.totalUnrealized >= 0 ? 'gain' : 'loss';
-            const pctText = portfolio.totalUnrealizedPct == null
-                ? '—'
-                : formatSignedPct(portfolio.totalUnrealizedPct);
+            const fromLabel = formatDate(portfolio.fromDate);
+            const realizedClass = portfolio.totalRealized >= 0 ? 'gain' : 'loss';
+            const unrealClass = portfolio.totalUnrealized >= 0 ? 'gain' : 'loss';
+            const resultClass = portfolio.totalResult >= 0 ? 'gain' : 'loss';
+            const pctText = portfolio.totalUnrealizedPct == null ? '' : formatSignedPct(portfolio.totalUnrealizedPct);
 
-            // Summary cards
+            const hasStaking = portfolio.stakedAmount > 1e-9;
+            const totalNow = hasStaking ? portfolio.totalWithStaked : portfolio.totalValue;
+            const openingNow = hasStaking ? portfolio.ibWithStaked : portfolio.ibValue;
+
+            // In a non-USD currency the unrealized P/L also carries currency (FX)
+            // effects on USD-denominated assets, so it isn't a plain FX multiple of
+            // the USD figure. Make that explicit.
+            const unrealCap = cur === 'USD'
+                ? 'market change on current holdings'
+                : `market change · incl. currency (FX) effects in ${cur}`;
+
+            const heroSub = hasStaking
+                ? `<div class="hero-sub">${money(portfolio.totalValue)} liquid <span class="muted">+</span> ${money(portfolio.stakedValue || 0)} staked <span class="muted">(${formatTokenAmount(portfolio.stakedAmount)} NEAR)</span></div>`
+                : '';
+
             this.summaryEl.hidden = false;
             this.summaryEl.innerHTML = `
-                <div class="summary-card">
-                    <div class="label">Total verdi</div>
-                    <div class="value">${money(portfolio.totalValue)}</div>
+                <div class="card-surface hero-card">
+                    <div class="label">Total value now ${hasStaking ? '<span class="muted">(incl. staked)</span>' : ''}</div>
+                    <div class="hero-value">${money(totalNow)}</div>
+                    ${heroSub}
                 </div>
-                <div class="summary-card">
-                    <div class="label">Urealisert gevinst/tap</div>
-                    <div class="value ${totalPlClass}">${formatSigned(portfolio.totalUnrealized, money)}</div>
-                    <div class="sub ${totalPlClass}">${pctText}</div>
+
+                <div class="section-label">Result this fiscal year · since ${escapeHtml(fromLabel)}</div>
+                <div class="result-grid">
+                    <div class="card-surface metric-card">
+                        <div class="label">Realized</div>
+                        <div class="value ${realizedClass}">${formatSigned(portfolio.totalRealized, money)}</div>
+                        <div class="cap">swaps and sales · net of fees and slippage</div>
+                    </div>
+                    <div class="card-surface metric-card">
+                        <div class="label">Unrealized</div>
+                        <div class="value ${unrealClass}">${formatSigned(portfolio.totalUnrealized, money)}${pctText ? ` <span class="metric-pct ${unrealClass}">${pctText}</span>` : ''}</div>
+                        <div class="cap">${unrealCap}</div>
+                    </div>
+                    <div class="card-surface metric-card result">
+                        <div class="label ${resultClass}">= Result</div>
+                        <div class="value ${resultClass}">${formatSigned(portfolio.totalResult, money)}</div>
+                        <div class="cap ${resultClass}">realized + unrealized</div>
+                    </div>
                 </div>
-                <div class="summary-card">
-                    <div class="label">Kostpris</div>
-                    <div class="value">${money(portfolio.totalCost)}</div>
+                <div class="footnote">Realized is net of gas, fees and slippage — every swap counts as a disposal (FIFO). Verify before reporting.</div>
+
+                <div class="section-label">Balance</div>
+                <div class="card-surface balance-card">
+                    <div>
+                        <div class="label">Opening · ${escapeHtml(fromLabel)}</div>
+                        <div class="bal-value">${money(openingNow)}</div>
+                    </div>
+                    <div class="bal-arrow">&rarr;</div>
+                    <div>
+                        <div class="label">Now${hasStaking ? ' · incl. staked' : ''}</div>
+                        <div class="bal-value">${money(totalNow)}</div>
+                    </div>
                 </div>
             `;
 
-            // Holdings
+            // Holdings (liquid), with a dedicated staked row on top when present.
+            this.holdingsSection.hidden = false;
             const maxValue = Math.max(1, ...portfolio.holdings.map(h => h.value ?? 0));
-            this.holdingsEl.innerHTML = portfolio.holdings
+            const stakedRow = hasStaking ? `
+                <div class="holding-card">
+                    <div>
+                        <div class="holding-head">
+                            <span class="holding-symbol">NEAR — staked</span>
+                            <span class="flag">staking</span>
+                        </div>
+                        <div class="holding-amount">${formatTokenAmount(portfolio.stakedAmount)} NEAR ${portfolio.stakedValue != null ? `@ ${money(portfolio.stakedValue / portfolio.stakedAmount)}` : ''}</div>
+                    </div>
+                    <div class="holding-values">
+                        <div class="holding-value">${portfolio.stakedValue != null ? money(portfolio.stakedValue) : '<span class="muted">value unknown</span>'}</div>
+                        <div class="holding-pl"><span class="muted">not realized</span></div>
+                    </div>
+                </div>
+            ` : '';
+            this.holdingsEl.innerHTML = stakedRow + portfolio.holdings
                 .map(h => this.renderHolding(h, money, maxValue))
                 .join('');
 
@@ -103,8 +197,8 @@ customElements.define('portfolio-page',
                 const names = excludedHoldings.map(h => h.displaySymbol).join(', ');
                 this.excludedNoteEl.hidden = false;
                 this.excludedNoteEl.innerHTML =
-                    `Holdt utenfor totalen (regnes som staking): ${escapeHtml(names)} `
-                    + `– verdi ${money(portfolio.excludedValue)}.`;
+                    `Excluded from total (treated as staking): ${escapeHtml(names)} `
+                    + `– value ${money(portfolio.excludedValue)}.`;
             } else {
                 this.excludedNoteEl.hidden = true;
             }
@@ -113,11 +207,11 @@ customElements.define('portfolio-page',
         renderHolding(h, money, maxValue) {
             const amountText = `${formatTokenAmount(h.amount)} ${escapeHtml(h.symbol)}`;
             const priceText = h.price != null ? `@ ${money(h.price)}` : '';
-            const valueText = h.value != null ? money(h.value) : '<span class="muted">verdi ukjent</span>';
+            const valueText = h.value != null ? money(h.value) : '<span class="muted">value unknown</span>';
 
             let plText = '';
             if (h.excluded) {
-                plText = '<span class="muted">i staking</span>';
+                plText = '<span class="muted">staking</span>';
             } else if (h.unrealized != null) {
                 const cls = h.unrealized >= 0 ? 'gain' : 'loss';
                 const pct = h.unrealizedPct == null ? '' : ` (${formatSignedPct(h.unrealizedPct)})`;
@@ -126,9 +220,23 @@ customElements.define('portfolio-page',
                 plText = '<span class="muted">—</span>';
             }
 
+            // Realized (period) line — only when there is something realized.
+            let realizedText = '';
+            if (!h.excluded && Math.abs(h.realized) > 1e-9) {
+                const cls = h.realized >= 0 ? 'gain' : 'loss';
+                realizedText = `<div class="holding-pl">Realized: <span class="${cls}">${formatSigned(h.realized, money)}</span></div>`;
+            }
+
+            // Opening balance line — only when there was an opening balance for this token.
+            let ibText = '';
+            if (h.ibAmount > 1e-9) {
+                const ibVal = h.ibValue != null ? money(h.ibValue) : '–';
+                ibText = `<div class="holding-amount">Opening: ${ibVal}</div>`;
+            }
+
             const flags = [];
-            if (h.priceMissing) flags.push('<span class="flag">pris mangler</span>');
-            if (h.missingCostBasis) flags.push('<span class="flag">ingen kostpris</span>');
+            if (h.priceMissing) flags.push('<span class="flag">no price</span>');
+            if (h.missingCostBasis) flags.push('<span class="flag">no cost basis</span>');
             const flagsHtml = flags.length ? ` ${flags.join(' ')}` : '';
 
             const barPct = h.value != null && !h.excluded ? Math.round((h.value / maxValue) * 100) : 0;
@@ -140,10 +248,12 @@ customElements.define('portfolio-page',
                             <span class="holding-symbol">${escapeHtml(h.displaySymbol)}</span>${flagsHtml}
                         </div>
                         <div class="holding-amount">${amountText} ${priceText}</div>
+                        ${ibText}
                     </div>
                     <div class="holding-values">
                         <div class="holding-value">${valueText}</div>
                         <div class="holding-pl">${plText}</div>
+                        ${realizedText}
                     </div>
                     <div class="alloc-bar"><span style="width:${barPct}%"></span></div>
                 </div>
@@ -155,7 +265,8 @@ customElements.define('portfolio-page',
 function makeMoneyFormatter(currencyUpper) {
     // Some "currencies" from the provider are crypto (BTC, ETH) and not valid ISO
     // currency codes, so format as a plain number with the code appended.
-    const numberFormatter = new Intl.NumberFormat('nb-NO', {
+    // Follow the app-wide convention of using the browser locale for numbers.
+    const numberFormatter = new Intl.NumberFormat(navigator.language, {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2
     });
@@ -165,7 +276,7 @@ function makeMoneyFormatter(currencyUpper) {
 function formatTokenAmount(amount) {
     const abs = Math.abs(amount);
     const maxDecimals = abs >= 1000 ? 2 : abs >= 1 ? 4 : 6;
-    return new Intl.NumberFormat('nb-NO', {
+    return new Intl.NumberFormat(navigator.language, {
         minimumFractionDigits: 0,
         maximumFractionDigits: maxDecimals
     }).format(amount);
@@ -179,6 +290,12 @@ function formatSigned(value, money) {
 function formatSignedPct(pct) {
     const sign = pct > 0 ? '+' : '';
     return `${sign}${pct.toFixed(1)} %`;
+}
+
+function formatDate(isoDate) {
+    // 'yyyy-MM-dd' -> 'dd.MM.yyyy'
+    const [y, m, d] = String(isoDate).split('-');
+    return `${d}.${m}.${y}`;
 }
 
 function escapeHtml(str) {

--- a/public_html/portfolio/portfolio-page.component.js
+++ b/public_html/portfolio/portfolio-page.component.js
@@ -1,0 +1,190 @@
+import { getCurrencyList } from '../pricedata/pricedata.js';
+import { calculatePortfolio } from './portfolio-data.js';
+import html from './portfolio-page.component.html.js';
+
+const PREFERRED_DEFAULT_CURRENCY = 'nok';
+
+customElements.define('portfolio-page',
+    class extends HTMLElement {
+        constructor() {
+            super();
+            this.attachShadow({ mode: 'open' });
+            this.shadowRoot.innerHTML = html;
+            document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
+
+            this.progressEl = this.shadowRoot.querySelector('#portfolio-progress');
+            this.summaryEl = this.shadowRoot.querySelector('#summary');
+            this.holdingsEl = this.shadowRoot.querySelector('#holdings');
+            this.excludedNoteEl = this.shadowRoot.querySelector('#excluded-note');
+            this.currencySelect = this.shadowRoot.querySelector('#currencyselect');
+            this.refreshButton = this.shadowRoot.querySelector('#refreshbutton');
+
+            this.currencySelect.addEventListener('change', () => this.refresh());
+            this.refreshButton.addEventListener('click', () => this.refresh());
+
+            this.init();
+        }
+
+        async init() {
+            const currencies = await getCurrencyList();
+            currencies.forEach(currency => {
+                const option = document.createElement('option');
+                option.value = currency;
+                option.text = currency.toUpperCase();
+                this.currencySelect.appendChild(option);
+            });
+            if (currencies.includes(PREFERRED_DEFAULT_CURRENCY)) {
+                this.currencySelect.value = PREFERRED_DEFAULT_CURRENCY;
+            }
+            await this.refresh();
+        }
+
+        setBusy(busy, message = '') {
+            this.refreshButton.disabled = busy;
+            this.currencySelect.disabled = busy;
+            this.progressEl.textContent = message;
+            this.progressEl.hidden = !busy && !message;
+        }
+
+        async refresh() {
+            const currency = this.currencySelect.value;
+            if (!currency) {
+                return;
+            }
+            this.setBusy(true, 'Laster portefølje …');
+            try {
+                const portfolio = await calculatePortfolio(currency, msg => this.setBusy(true, msg));
+                this.render(portfolio);
+                this.setBusy(false, '');
+            } catch (e) {
+                console.error('Failed to calculate portfolio', e);
+                this.setBusy(false, '');
+                this.summaryEl.hidden = true;
+                this.holdingsEl.innerHTML =
+                    `<div class="alert alert-danger">Kunne ikke beregne porteføljen: ${escapeHtml(e.message)}</div>`;
+            }
+        }
+
+        render(portfolio) {
+            const cur = portfolio.currency.toUpperCase();
+            const money = makeMoneyFormatter(cur);
+            const totalPlClass = portfolio.totalUnrealized >= 0 ? 'gain' : 'loss';
+            const pctText = portfolio.totalUnrealizedPct == null
+                ? '—'
+                : formatSignedPct(portfolio.totalUnrealizedPct);
+
+            // Summary cards
+            this.summaryEl.hidden = false;
+            this.summaryEl.innerHTML = `
+                <div class="summary-card">
+                    <div class="label">Total verdi</div>
+                    <div class="value">${money(portfolio.totalValue)}</div>
+                </div>
+                <div class="summary-card">
+                    <div class="label">Urealisert gevinst/tap</div>
+                    <div class="value ${totalPlClass}">${formatSigned(portfolio.totalUnrealized, money)}</div>
+                    <div class="sub ${totalPlClass}">${pctText}</div>
+                </div>
+                <div class="summary-card">
+                    <div class="label">Kostpris</div>
+                    <div class="value">${money(portfolio.totalCost)}</div>
+                </div>
+            `;
+
+            // Holdings
+            const maxValue = Math.max(1, ...portfolio.holdings.map(h => h.value ?? 0));
+            this.holdingsEl.innerHTML = portfolio.holdings
+                .map(h => this.renderHolding(h, money, maxValue))
+                .join('');
+
+            // Excluded staking note
+            const excludedHoldings = portfolio.holdings.filter(h => h.excluded);
+            if (excludedHoldings.length > 0) {
+                const names = excludedHoldings.map(h => h.displaySymbol).join(', ');
+                this.excludedNoteEl.hidden = false;
+                this.excludedNoteEl.innerHTML =
+                    `Holdt utenfor totalen (regnes som staking): ${escapeHtml(names)} `
+                    + `– verdi ${money(portfolio.excludedValue)}.`;
+            } else {
+                this.excludedNoteEl.hidden = true;
+            }
+        }
+
+        renderHolding(h, money, maxValue) {
+            const amountText = `${formatTokenAmount(h.amount)} ${escapeHtml(h.symbol)}`;
+            const priceText = h.price != null ? `@ ${money(h.price)}` : '';
+            const valueText = h.value != null ? money(h.value) : '<span class="muted">verdi ukjent</span>';
+
+            let plText = '';
+            if (h.excluded) {
+                plText = '<span class="muted">i staking</span>';
+            } else if (h.unrealized != null) {
+                const cls = h.unrealized >= 0 ? 'gain' : 'loss';
+                const pct = h.unrealizedPct == null ? '' : ` (${formatSignedPct(h.unrealizedPct)})`;
+                plText = `<span class="${cls}">${formatSigned(h.unrealized, money)}${pct}</span>`;
+            } else {
+                plText = '<span class="muted">—</span>';
+            }
+
+            const flags = [];
+            if (h.priceMissing) flags.push('<span class="flag">pris mangler</span>');
+            if (h.missingCostBasis) flags.push('<span class="flag">ingen kostpris</span>');
+            const flagsHtml = flags.length ? ` ${flags.join(' ')}` : '';
+
+            const barPct = h.value != null && !h.excluded ? Math.round((h.value / maxValue) * 100) : 0;
+
+            return `
+                <div class="holding-card${h.excluded ? ' excluded' : ''}">
+                    <div>
+                        <div class="holding-head">
+                            <span class="holding-symbol">${escapeHtml(h.displaySymbol)}</span>${flagsHtml}
+                        </div>
+                        <div class="holding-amount">${amountText} ${priceText}</div>
+                    </div>
+                    <div class="holding-values">
+                        <div class="holding-value">${valueText}</div>
+                        <div class="holding-pl">${plText}</div>
+                    </div>
+                    <div class="alloc-bar"><span style="width:${barPct}%"></span></div>
+                </div>
+            `;
+        }
+    }
+);
+
+function makeMoneyFormatter(currencyUpper) {
+    // Some "currencies" from the provider are crypto (BTC, ETH) and not valid ISO
+    // currency codes, so format as a plain number with the code appended.
+    const numberFormatter = new Intl.NumberFormat('nb-NO', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+    return (value) => `${numberFormatter.format(value ?? 0)} ${currencyUpper}`;
+}
+
+function formatTokenAmount(amount) {
+    const abs = Math.abs(amount);
+    const maxDecimals = abs >= 1000 ? 2 : abs >= 1 ? 4 : 6;
+    return new Intl.NumberFormat('nb-NO', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: maxDecimals
+    }).format(amount);
+}
+
+function formatSigned(value, money) {
+    const sign = value > 0 ? '+' : '';
+    return `${sign}${money(value)}`;
+}
+
+function formatSignedPct(pct) {
+    const sign = pct > 0 ? '+' : '';
+    return `${sign}${pct.toFixed(1)} %`;
+}
+
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}

--- a/public_html/pricedata/pricedata.js
+++ b/public_html/pricedata/pricedata.js
@@ -65,6 +65,41 @@ export async function fetchHistoricalPricesFromArizGateway({ baseToken = "NEAR",
     await setHistoricalPriceData(baseToken, currency, pricesMap);
 }
 
+/**
+ * Fetch current (live spot) prices for multiple token symbols in one currency.
+ * Uses the gateway /api/prices/current endpoint (proxies CoinGecko simple/price).
+ * @param {string[]} tokens - token symbols (e.g. ['NEAR', 'BTC'])
+ * @param {string} currency - target currency (e.g. 'nok')
+ * @returns {Promise<Object<string, number|null>>} map of symbol -> price (null if unavailable)
+ */
+export async function getCurrentPrices(tokens, currency) {
+    const result = {};
+    const uniqueTokens = [...new Set(tokens.filter(t => t))];
+    if (uniqueTokens.length === 0) {
+        return result;
+    }
+    const vs = currency.toLowerCase();
+    const data = await fetchFromArizGateway(
+        `/api/prices/current?tokens=${encodeURIComponent(uniqueTokens.join(','))}&vs=${encodeURIComponent(vs)}`
+    );
+    for (const token of uniqueTokens) {
+        // The gateway keys the response by the exact token string we passed in.
+        result[token] = data?.[token]?.[vs] ?? null;
+    }
+    return result;
+}
+
+/**
+ * Fetch the current (live spot) price for a single token symbol.
+ * @param {string} token - token symbol (e.g. 'NEAR')
+ * @param {string} currency - target currency (e.g. 'nok')
+ * @returns {Promise<number|null>} price, or null if unavailable
+ */
+export async function getCurrentPrice(token, currency) {
+    const prices = await getCurrentPrices([token], currency);
+    return prices[token] ?? null;
+}
+
 export async function getEODPrice(currency, datestring, token = defaultToken) {
     if (token === "") {
         token = defaultToken;

--- a/public_html/pricedata/pricedata.js
+++ b/public_html/pricedata/pricedata.js
@@ -92,28 +92,25 @@ export async function getCurrentPrices(tokens, currency) {
         return result;
     }
 
-    const fetchBatch = async (list) => {
-        // Retry transient gateway hiccups (502s) a couple of times, quickly.
+    try {
+        // One batch request for everything. Retry to ride out gateway cold starts
+        // (fly.dev scales to zero and 502s on the first request after idle; those
+        // error responses also lack CORS headers, surfacing as "CORS"/"Failed to
+        // fetch" in the browser). Invalid scam symbols are already filtered out, so
+        // a batch failure means the gateway itself is unavailable - retrying the
+        // whole batch is the right move, not hammering it once per token.
         const data = await retry(() => fetchFromArizGateway(
-            `/api/prices/current?tokens=${encodeURIComponent(list.join(','))}&vs=${encodeURIComponent(vs)}`
-        ), 2, 1500);
-        for (const token of list) {
+            `/api/prices/current?tokens=${encodeURIComponent(uniqueTokens.join(','))}&vs=${encodeURIComponent(vs)}`
+        ), 4, 2000);
+        for (const token of uniqueTokens) {
             // The gateway keys the response by the exact token string we passed in.
             result[token] = data?.[token]?.[vs] ?? null;
         }
-    };
-
-    try {
-        await fetchBatch(uniqueTokens);
     } catch (e) {
-        // A single bad token can fail the whole batch. Retry one at a time so the
-        // rest still get prices.
+        // Gateway unavailable - leave prices null so the caller shows "value unknown"
+        // while cost basis / realized (from cached historical prices) still render.
         for (const token of uniqueTokens) {
-            try {
-                await fetchBatch([token]);
-            } catch {
-                result[token] = null;
-            }
+            result[token] = null;
         }
     }
     return result;
@@ -150,11 +147,16 @@ export async function getEODPrice(currency, datestring, token = defaultToken) {
         token = await resolveSymbol(token);
     }
 
+    // USD-pegged stablecoins are ~1 USD. When the target currency is USD we can
+    // short-circuit to 1. For other currencies, do NOT collapse to "USD": keep the
+    // token symbol (USDC, USDT, USDC.e, ...) so the gateway prices it via its
+    // CoinGecko id (usd-coin / tether) and applies the forex rate. Collapsing to
+    // "USD" made the gateway look up a non-existent "usd" token and return 0, which
+    // left stablecoin holdings with no historical cost basis in non-USD currencies.
     if (token.indexOf('USD') === 0 || token === 'USN') {
-        token = 'USD';
-    }
-    if (token === 'USD' && currency === 'USD') {
-        return 1;
+        if (currency.toUpperCase() === 'USD') {
+            return 1;
+        }
     }
     let pricedata = await getHistoricalPriceData(token, currency);
     const skipFetchingPricesKey = `${token}-${currency}`;

--- a/public_html/pricedata/pricedata.js
+++ b/public_html/pricedata/pricedata.js
@@ -1,6 +1,7 @@
 import { fetchFromArizGateway } from "../arizgateway/arizgatewayaccess.js";
 import { getCustomExchangeRates, setCustomExchangeRates, getHistoricalPriceData, setHistoricalPriceData, getCurrencyList as getStoredCurrencyList, setCurrencyList } from "../storage/domainobjectstore.js";
 import { resolveSymbol } from "../near/intents-tokens.js";
+import { retry } from "../near/retry.js";
 
 const defaultToken = 'NEAR';
 const skipFetchingPrices = {};
@@ -65,26 +66,55 @@ export async function fetchHistoricalPricesFromArizGateway({ baseToken = "NEAR",
     await setHistoricalPriceData(baseToken, currency, pricesMap);
 }
 
+// Real market symbols are short and contain no whitespace, slashes or URL
+// punctuation. Scam tokens sometimes embed a whole URL or sentence in their
+// symbol (e.g. "Claim Near Airdrop at https://..."), which has no price and can
+// even make the gateway return 502 for the whole batch. Skip those up front.
+function isLikelyValidSymbol(symbol) {
+    return !!symbol && symbol.length <= 15 && !/[\s/:?#&]/.test(symbol);
+}
+
 /**
  * Fetch current (live spot) prices for multiple token symbols in one currency.
  * Uses the gateway /api/prices/current endpoint (proxies CoinGecko simple/price).
+ * Resilient: invalid/junk symbols are skipped, and if a batch request fails
+ * (e.g. gateway 502 on a bad token) it falls back to per-token requests so one
+ * token can never zero out the rest.
  * @param {string[]} tokens - token symbols (e.g. ['NEAR', 'BTC'])
  * @param {string} currency - target currency (e.g. 'nok')
  * @returns {Promise<Object<string, number|null>>} map of symbol -> price (null if unavailable)
  */
 export async function getCurrentPrices(tokens, currency) {
     const result = {};
-    const uniqueTokens = [...new Set(tokens.filter(t => t))];
+    const vs = currency.toLowerCase();
+    const uniqueTokens = [...new Set(tokens.filter(t => t && isLikelyValidSymbol(t)))];
     if (uniqueTokens.length === 0) {
         return result;
     }
-    const vs = currency.toLowerCase();
-    const data = await fetchFromArizGateway(
-        `/api/prices/current?tokens=${encodeURIComponent(uniqueTokens.join(','))}&vs=${encodeURIComponent(vs)}`
-    );
-    for (const token of uniqueTokens) {
-        // The gateway keys the response by the exact token string we passed in.
-        result[token] = data?.[token]?.[vs] ?? null;
+
+    const fetchBatch = async (list) => {
+        // Retry transient gateway hiccups (502s) a couple of times, quickly.
+        const data = await retry(() => fetchFromArizGateway(
+            `/api/prices/current?tokens=${encodeURIComponent(list.join(','))}&vs=${encodeURIComponent(vs)}`
+        ), 2, 1500);
+        for (const token of list) {
+            // The gateway keys the response by the exact token string we passed in.
+            result[token] = data?.[token]?.[vs] ?? null;
+        }
+    };
+
+    try {
+        await fetchBatch(uniqueTokens);
+    } catch (e) {
+        // A single bad token can fail the whole batch. Retry one at a time so the
+        // rest still get prices.
+        for (const token of uniqueTokens) {
+            try {
+                await fetchBatch([token]);
+            } catch {
+                result[token] = null;
+            }
+        }
     }
     return result;
 }


### PR DESCRIPTION
New Portfolio page (public_html/portfolio/) reusing the year-report FIFO engine: total value now incl. staked, fiscal-year movement (opening balance to realized to closing balance), and per-token holdings with realized/unrealized plus a separate staked-NEAR line. Realized is net of fees and slippage (every swap is a disposal); unrealized includes currency (FX) effects in non-USD currencies. Also adds getCurrentPrices/getCurrentPrice in pricedata.js and fixes stablecoin EOD pricing so USDC/USDT get a cost basis in non-USD currencies (also fixes the year report). Pairs with arizas/ariz-gateway#33. FIFO-based, verify before reporting.