### PR TITLE
Portfolio price-outage UX + FIFO precision fix + minimal web4 bodyUrl contract

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,6 +1,14 @@
-Build the Ariz Portfolio app and deploy it to the ariz-gateway NEAR contract.
+Build the Ariz Portfolio app and deploy it as the live frontend at https://arizportfolio.near.page.
 
 The ariz-gateway repo (https://github.com/ArizHQ/ariz-gateway) should be cloned as a sibling directory to this repo.
+
+## How serving works (since the web4 bodyUrl switch)
+
+The `arizportfolio.near` web4 contract returns `Web4Response::BodyUrl` pointing at
+`https://arizgateway.fly.dev/`, which serves the bundle from `server/public/index.html`.
+So **the frontend is just a file on the gateway** — updating it needs only a gateway
+deploy (push to `main` → Fly auto-deploys), **no contract redeploy**. The contract is
+deployed once and only needs touching if the gateway URL or web4 behavior changes.
 
 ## Steps
 
@@ -8,24 +16,28 @@ The ariz-gateway repo (https://github.com/ArizHQ/ariz-gateway) should be cloned 
    ```
    yarn dist
    ```
-   This runs rollup to bundle `public_html/index.html` into a single `dist/index.html` file with all JS inlined.
+   Rollup bundles `public_html/index.html` into a single self-contained `dist/index.html`.
 
-2. **Base64-encode and copy to contract** (ariz-gateway is in `../ariz-gateway`):
+2. **Copy the bundle into the gateway** (ariz-gateway is in `../ariz-gateway`):
    ```
-   base64 -i dist/index.html -o ../ariz-gateway/contract/src/web4/index.html.base64
-   ```
-
-3. **Build the NEAR contract**:
-   ```
-   cd ../ariz-gateway/contract && cargo near build non-reproducible-wasm
-   ```
-   This produces `target/near/ariz_gateway.wasm`.
-
-4. **Deploy the contract**:
-   ```
-   cd ../ariz-gateway/contract && near contract deploy arizportfolio.near use-file target/near/ariz_gateway.wasm without-init-call network-config mainnet sign-with-keychain send
+   cp dist/index.html ../ariz-gateway/server/public/index.html
    ```
 
-5. **Verify** by checking https://arizportfolio.near.page in a browser.
+3. **Commit + push** in ariz-gateway (a PR, or directly to `main`) — pushing to `main`
+   triggers the Fly deploy that serves the new bundle:
+   ```
+   cd ../ariz-gateway && git add server/public/index.html && git commit -m "frontend: update bundle" && git push
+   ```
 
-IMPORTANT: Always ask for confirmation before step 4 (deploy). Show the wasm file size and confirm the user wants to deploy to mainnet.
+4. **Verify** at https://arizportfolio.near.page (hard-refresh). web4 may cache the
+   fetched body briefly, so allow a short propagation delay.
+
+IMPORTANT: pushing to `ariz-gateway` `main` auto-deploys to production via Fly — confirm before pushing.
+
+## Contract (rare)
+
+Only if the web4 contract itself must change (e.g. repoint `body_url`): edit
+`../ariz-gateway/contract/src/web4/handler.rs`, then
+`cd ../ariz-gateway/contract && cargo near build non-reproducible-wasm` and
+`near contract deploy arizportfolio.near use-file target/near/ariz_gateway.wasm without-init-call network-config mainnet sign-with-keychain send`.
+Confirm the wasm size and the mainnet deploy first.

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -36,8 +36,19 @@ IMPORTANT: pushing to `ariz-gateway` `main` auto-deploys to production via Fly â
 
 ## Contract (rare)
 
-Only if the web4 contract itself must change (e.g. repoint `body_url`): edit
-`../ariz-gateway/contract/src/web4/handler.rs`, then
-`cd ../ariz-gateway/contract && cargo near build non-reproducible-wasm` and
-`near contract deploy arizportfolio.near use-file target/near/ariz_gateway.wasm without-init-call network-config mainnet sign-with-keychain send`.
-Confirm the wasm size and the mainnet deploy first.
+`arizportfolio.near` runs a minimal 126-byte WAT contract whose `web4_get` returns
+the `bodyUrl` (it replaced the old 123 KB Rust contract, freeing ~1.2 NEAR). You
+only need to redeploy it to repoint the gateway URL.
+
+1. Rebuild â€” regenerates `web4contract/web4contract.wat` + `.wasm` (both gitignored;
+   `web4contract.wat.js` is the source). Override the URL with `WEB4_BODY_URL`:
+   ```
+   node web4contract/web4contract.wat.js
+   ```
+2. Deploy (confirm the wasm size and the mainnet deploy first):
+   ```
+   near contract deploy arizportfolio.near use-file web4contract/web4contract.wasm without-init-call network-config mainnet sign-with-keychain send
+   ```
+
+The retired Rust source still lives in `../ariz-gateway/contract` if the
+token-registry methods ever need restoring.

--- a/public_html/portfolio/portfolio-data.js
+++ b/public_html/portfolio/portfolio-data.js
@@ -27,7 +27,7 @@ import {
     getDecimalConversionValue
 } from '../yearreport/yearreportdata.js';
 import { resolveSymbol, resolveDisplaySymbol } from '../near/intents-tokens.js';
-import { getCurrentPrices, getEODPrice } from '../pricedata/pricedata.js';
+import { getCurrentPrices, getEODPrice, PriceServiceUnavailableError } from '../pricedata/pricedata.js';
 
 // Liquid-staking token symbols excluded from the portfolio total (treated as staking).
 export const EXCLUDED_STAKING_SYMBOLS = new Set(['STNEAR', 'LINEAR', 'NEARX', 'LST']);
@@ -122,10 +122,19 @@ async function computeBase(currency, onProgress, force) {
     onProgress('Fetching current prices');
     const pricedSymbols = holdings.filter(h => h.amount > DUST_THRESHOLD).map(h => h.symbol);
     let currentPrices = {};
+    let pricesUnavailable = false;
     try {
         currentPrices = await getCurrentPrices(pricedSymbols, currency);
     } catch (e) {
+        // Price service unreachable (transient, affects every token). Keep going so
+        // cached cost basis / realized still render, but flag it so the page can say
+        // so explicitly rather than making every holding look like it has "no price".
         currentPrices = {};
+        if (e instanceof PriceServiceUnavailableError) {
+            pricesUnavailable = true;
+        } else {
+            throw e;
+        }
     }
 
     let totalValue = 0;
@@ -160,6 +169,7 @@ async function computeBase(currency, onProgress, force) {
     const base = {
         currency, holdings, totalValue, totalCost, excludedValue,
         stakedRawByDate,
+        pricesUnavailable,
         nearPrice: currentPrices['NEAR'] ?? null,
         nearDecimal: Math.pow(10, -24)
     };
@@ -276,6 +286,7 @@ export async function calculatePortfolio(currency, fromDate, onProgress = () => 
     return {
         currency,
         fromDate,
+        pricesUnavailable: base.pricesUnavailable,
         holdings: visibleHoldings,
         // UB (now) — liquid holdings
         totalValue: base.totalValue,

--- a/public_html/portfolio/portfolio-page.component.html.js
+++ b/public_html/portfolio/portfolio-page.component.html.js
@@ -50,6 +50,11 @@ export default /*html*/ `
 
     .footnote { font-size: 0.78rem; color: #6c757d; margin-top: 0.5rem; line-height: 1.5; }
 
+    .price-warning {
+        background: #fff8e1; border: 1px solid #ffe082; color: #6d4c00;
+        padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 0.9rem; line-height: 1.5;
+    }
+
     .balance-card {
         display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
         padding: 1rem 1.25rem;

--- a/public_html/portfolio/portfolio-page.component.js
+++ b/public_html/portfolio/portfolio-page.component.js
@@ -129,6 +129,12 @@ customElements.define('portfolio-page',
 
             this.summaryEl.hidden = false;
             this.summaryEl.innerHTML = `
+                ${portfolio.pricesUnavailable ? `
+                <div class="card-surface price-warning" role="alert">
+                    ⚠ Couldn't reach the price service, so current values are unavailable.
+                    Cost basis and realized P/L below are from cached price history.
+                    Try <strong>Refresh</strong> in a moment.
+                </div>` : ''}
                 <div class="card-surface hero-card">
                     <div class="label">Total value now ${hasStaking ? '<span class="muted">(incl. staked)</span>' : ''}</div>
                     <div class="hero-value">${money(totalNow)}</div>

--- a/public_html/pricedata/pricedata.js
+++ b/public_html/pricedata/pricedata.js
@@ -6,6 +6,22 @@ import { retry } from "../near/retry.js";
 const defaultToken = 'NEAR';
 const skipFetchingPrices = {};
 
+/**
+ * Thrown when the price service (Ariz gateway) can't be reached for the current
+ * spot prices after retries - i.e. a transient outage that affects *every* token,
+ * as opposed to a single token genuinely having no price. Carries the token list
+ * so the caller can show a clear "price service unavailable" banner instead of
+ * making every holding look like it individually has "no price".
+ */
+export class PriceServiceUnavailableError extends Error {
+    constructor(tokens, cause) {
+        super(`Price service unavailable (could not fetch current prices for ${tokens.length} token(s))`);
+        this.name = 'PriceServiceUnavailableError';
+        this.tokens = tokens;
+        this.cause = cause;
+    }
+}
+
 export function setSkipFetchingPrices(token, currency) {
     skipFetchingPrices[`${token}-${currency}`] = true;
 }
@@ -92,26 +108,30 @@ export async function getCurrentPrices(tokens, currency) {
         return result;
     }
 
+    // One batch request for everything. Retry to ride out gateway cold starts
+    // (fly.dev 502s on the first request after a restart/idle; those error
+    // responses also lack CORS headers, surfacing as "CORS"/"Failed to fetch" in
+    // the browser). Invalid scam symbols are already filtered out, so a batch
+    // failure means the gateway itself is unavailable - retrying the whole batch
+    // is the right move, not hammering it once per token.
+    //
+    // If retries are exhausted we let the error propagate: the caller must be able
+    // to tell "the price service is unreachable" (transient, everything affected -
+    // show a banner, keep cached cost basis) apart from "this token genuinely has
+    // no price" (a per-token null below, e.g. scam tokens / ARIZ). Swallowing the
+    // error here would collapse both into an indistinguishable "no price".
+    let data;
     try {
-        // One batch request for everything. Retry to ride out gateway cold starts
-        // (fly.dev scales to zero and 502s on the first request after idle; those
-        // error responses also lack CORS headers, surfacing as "CORS"/"Failed to
-        // fetch" in the browser). Invalid scam symbols are already filtered out, so
-        // a batch failure means the gateway itself is unavailable - retrying the
-        // whole batch is the right move, not hammering it once per token.
-        const data = await retry(() => fetchFromArizGateway(
+        data = await retry(() => fetchFromArizGateway(
             `/api/prices/current?tokens=${encodeURIComponent(uniqueTokens.join(','))}&vs=${encodeURIComponent(vs)}`
         ), 4, 2000);
-        for (const token of uniqueTokens) {
-            // The gateway keys the response by the exact token string we passed in.
-            result[token] = data?.[token]?.[vs] ?? null;
-        }
     } catch (e) {
-        // Gateway unavailable - leave prices null so the caller shows "value unknown"
-        // while cost basis / realized (from cached historical prices) still render.
-        for (const token of uniqueTokens) {
-            result[token] = null;
-        }
+        throw new PriceServiceUnavailableError(uniqueTokens, e);
+    }
+    for (const token of uniqueTokens) {
+        // The gateway keys the response by the exact token string we passed in. A
+        // null here means the gateway is reachable but has no price for this token.
+        result[token] = data?.[token]?.[vs] ?? null;
     }
     return result;
 }

--- a/public_html/yearreport/yearreportdata.js
+++ b/public_html/yearreport/yearreportdata.js
@@ -336,7 +336,13 @@ export async function calculateProfitLoss(dailyBalances, targetCurrency, token) 
                         openPositions.shift();
                     }
                 }
-                if (dayRealizedAmount < withdrawalAmount) {
+                // Tolerate float64 rounding: summing large raw (yocto) position
+                // amounts loses ~1e-16 relative precision, so dayRealizedAmount can
+                // fall a few units short of withdrawalAmount even when they're the
+                // same position set. Only a shortfall beyond that noise floor is a
+                // real bug worth reporting (a genuine one is on the order of whole
+                // tokens, i.e. >>1e-9 relative).
+                if (withdrawalAmount - dayRealizedAmount > withdrawalAmount * 1e-9) {
                     console.error(`should not happen: withdrawn amount larger than available positions. wanted to withdraw: ${withdrawalAmount}, available: ${dayRealizedAmount}`);
                 }
             };

--- a/web4contract/web4contract.wat.js
+++ b/web4contract/web4contract.wat.js
@@ -1,21 +1,33 @@
-import { writeFile, readFile } from 'fs/promises';
+import { writeFile } from 'fs/promises';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
 
-// Read the built index.html and encode as base64
-const indexHtml = await readFile(new URL('../dist/index.html', import.meta.url));
-const base64Body = indexHtml.toString('base64');
+// Minimal web4 contract for arizportfolio.near.
+//
+// web4_get returns a fixed `bodyUrl`, so the NEAR web4 gateway (*.near.page)
+// fetches the frontend bundle from the Ariz gateway server-side and serves it
+// under the arizportfolio.near.page origin. That keeps the app on .near.page
+// (URL unchanged, OPFS/IndexedDB data preserved) - it is NOT a client-side
+// redirect to fly.dev.
+//
+// This replaces the previous ~123 KB Rust contract (whose token-registry methods
+// are unused) with a ~0.6 KB wasm that does the one thing still needed, freeing
+// ~1.2 NEAR of storage staking. The contract reads no input, so web4_get can
+// never panic on a malformed request.
+//
+// Override the target with WEB4_BODY_URL when building for a different gateway.
+const BODY_URL = process.env.WEB4_BODY_URL || 'https://arizgateway.fly.dev/';
 
-const web4json = {
-    contentType: "text/html; charset=UTF-8",
-    body: base64Body
-};
+const web4jsonstring = JSON.stringify({ bodyUrl: BODY_URL });
 
-const web4jsonstring = JSON.stringify(web4json);
+// Each wasm memory page is 64 KiB; the body is tiny but keep the math general.
+const memoryPages = Math.max(1, Math.ceil(web4jsonstring.length / 65536));
 
-// Calculate number of 64KB memory pages needed (each page = 65536 bytes)
-const memoryPages = Math.ceil(web4jsonstring.length / 65536);
+// Escape for a wat data-string literal (backslash and double-quote only).
+const escaped = web4jsonstring.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
-await writeFile(new URL('web4contract.wat', import.meta.url), `
-(module
+// value_return(value_len, value_ptr): return memory[0 .. len] as the view result.
+const wat = `(module
     (import "env" "value_return" (func $value_return (param i64 i64)))
     (func (export "web4_get")
       i64.const ${web4jsonstring.length}
@@ -23,5 +35,15 @@ await writeFile(new URL('web4contract.wat', import.meta.url), `
       call $value_return
     )
     (memory ${memoryPages})
-    (data (i32.const 0) "${web4jsonstring.replace(/\\/g, "\\\\").replace(/\"/g,"\\\"")}")
-)`);
+    (data (i32.const 0) "${escaped}")
+)
+`;
+
+const watPath = fileURLToPath(new URL('web4contract.wat', import.meta.url));
+const wasmPath = fileURLToPath(new URL('web4contract.wasm', import.meta.url));
+
+await writeFile(watPath, wat);
+execFileSync('wat2wasm', [watPath, '-o', wasmPath]);
+
+console.log(`web4_get -> ${web4jsonstring} (${web4jsonstring.length} bytes)`);
+console.log(`built ${wasmPath}`);


### PR DESCRIPTION
Today's portfolio fixes plus the web4 contract slim-down.

## 1. Distinguish a price-service outage from "no price"
When the Ariz gateway is momentarily unreachable (e.g. during a deploy/restart), the batch current-price fetch failed and **every** holding silently showed "no price" / "value unknown" with a 0 total — identical to a token that genuinely has no price. Observed live right after a deploy.

- `getCurrentPrices` now throws a typed `PriceServiceUnavailableError` on a gateway outage, vs returning a per-token `null` for genuinely-unpriced tokens.
- `portfolio-data.js` catches it and sets a `pricesUnavailable` flag (still renders cached cost basis / realized).
- The page shows a clear banner instead of mislabelling every holding.

## 2. FIFO float-precision warning
Summing large yocto position amounts loses ~1e-16 relative precision, which tripped `should not happen: withdrawn amount larger than available positions` for a ~3e+9-yocto shortfall out of 5e+25. Now only flags a genuine shortfall (> 1e-9 relative).

## 3. Minimal web4 `bodyUrl` contract (replaces the 123 KB Rust contract)
`arizportfolio.near` only needs `web4_get` to return a fixed `bodyUrl`; the Rust contract's token-registry methods are unused. `web4contract.wat.js` now generates a **126-byte** contract returning `{"bodyUrl":"https://arizgateway.fly.dev/"}` that reads no input. Behavior is identical (app stays on the `arizportfolio.near.page` origin, OPFS data preserved), but it frees **~1.2 NEAR** of storage staking.

**Already deployed to mainnet** (tx `BVEsfbbi6NhaeDPiMCj6j7UE9DS35eg7GNtEhJsKdQEi`); on-chain code size is now 126 bytes and `web4_get` returns the expected JSON. The `/deploy` skill's contract section now documents the WAT flow.

## 4. `/deploy` skill
Rewritten for the web4 bodyUrl flow: a frontend update is a gateway push (Fly auto-deploys), no contract redeploy.

## Test
`web-test-runner` — 134 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)