### PR TITLE
Portfolio: value-over-time chart (staked + liquid)

### DIFF
--- a/public_html/portfolio/portfolio-chart.js
+++ b/public_html/portfolio/portfolio-chart.js
@@ -1,0 +1,197 @@
+// Zero-dependency stacked-area ("wave") chart for the portfolio value over time.
+//
+// Renders total portfolio value as two stacked bands - liquid (bottom) and staked
+// (top) - in plain SVG, with axes, gridlines and a hover crosshair + tooltip.
+// No external charting library.
+
+const LIQUID_STROKE = '#2a78d6';
+const LIQUID_FILL = 'rgba(42, 120, 214, 0.13)';
+const STAKED_STROKE = '#1baf7a';
+const STAKED_FILL = 'rgba(27, 175, 122, 0.18)';
+
+// viewBox geometry (SVG scales to container width; these are internal units)
+const W = 640, H = 260;
+const M = { left: 58, right: 16, top: 12, bottom: 26 };
+const PLOT_W = W - M.left - M.right;
+const PLOT_H = H - M.top - M.bottom;
+
+function compact(v) {
+    const a = Math.abs(v);
+    if (a >= 1e9) return (v / 1e9).toFixed(1) + 'B';
+    if (a >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+    if (a >= 1e3) return Math.round(v / 1e3) + 'k';
+    return String(Math.round(v));
+}
+
+// A "nice" axis maximum at or above value (1/2/2.5/5 * 10^n).
+function niceMax(value) {
+    if (value <= 0) return 1;
+    const exp = Math.floor(Math.log10(value));
+    const base = Math.pow(10, exp);
+    const f = value / base;
+    const nice = f <= 1 ? 1 : f <= 2 ? 2 : f <= 2.5 ? 2.5 : f <= 5 ? 5 : 10;
+    return nice * base;
+}
+
+function defaultDateShort(iso, granularity) {
+    const [y, m, d] = iso.split('-').map(Number);
+    const date = new Date(Date.UTC(y, m - 1, d));
+    if (granularity === 'month') {
+        return date.toLocaleDateString(navigator.language, { month: 'short', timeZone: 'UTC' });
+    }
+    return date.toLocaleDateString(navigator.language, { day: '2-digit', month: '2-digit', timeZone: 'UTC' });
+}
+
+function xForIndex(i, n) {
+    if (n <= 1) return M.left + PLOT_W / 2;
+    return M.left + (i / (n - 1)) * PLOT_W;
+}
+
+/**
+ * Render the value-over-time chart into a container element.
+ * @param {HTMLElement} container
+ * @param {{series:{date:string,liquid:number,staked:number,total:number}[], currency:string, granularity:string}} data
+ * @param {{formatMoney?:(v:number)=>string, formatDate?:(iso:string)=>string}} [opts]
+ */
+export function renderPortfolioChart(container, data, opts = {}) {
+    const series = data.series || [];
+    const granularity = data.granularity || 'month';
+    const money = opts.formatMoney || ((v) => String(Math.round(v)));
+    const dateLong = opts.formatDate || ((iso) => iso);
+    const dateShort = (iso) => defaultDateShort(iso, granularity);
+
+    const maxTotal = Math.max(0, ...series.map(p => p.total));
+
+    if (!series.length || maxTotal <= 0) {
+        container.innerHTML =
+            `<div class="chart-empty">No value history to show for this period.</div>`;
+        return;
+    }
+
+    const n = series.length;
+    const yMax = niceMax(maxTotal);
+    const y = (v) => M.top + PLOT_H - (v / yMax) * PLOT_H;
+    const x = (i) => xForIndex(i, n);
+
+    // Staked band: baseline -> staked line (bottom). Liquid band: staked line -> total line (top).
+    const baseY = M.top + PLOT_H;
+    const stakedTop = series.map((p, i) => `${x(i).toFixed(1)},${y(p.staked).toFixed(1)}`);
+    const totalTop = series.map((p, i) => `${x(i).toFixed(1)},${y(p.total).toFixed(1)}`);
+
+    const stakedArea =
+        `M ${x(0).toFixed(1)},${baseY.toFixed(1)} `
+        + `L ${stakedTop.join(' L ')} `
+        + `L ${x(n - 1).toFixed(1)},${baseY.toFixed(1)} Z`;
+
+    const liquidArea =
+        `M ${stakedTop.join(' L ')} `
+        + `L ${[...totalTop].reverse().join(' L ')} Z`;
+
+    const stakedLine = `M ${stakedTop.join(' L ')}`;
+    const totalLine = `M ${totalTop.join(' L ')}`;
+
+    // Gridlines + y labels (4 steps).
+    const gridSteps = 4;
+    let grid = '';
+    for (let s = 0; s <= gridSteps; s++) {
+        const val = (yMax / gridSteps) * s;
+        const gy = y(val);
+        grid += `<line class="grid" x1="${M.left}" y1="${gy.toFixed(1)}" x2="${(W - M.right)}" y2="${gy.toFixed(1)}"/>`;
+        grid += `<text class="axis y" x="${M.left - 8}" y="${(gy + 3.5).toFixed(1)}" text-anchor="end">${compact(val)}</text>`;
+    }
+
+    // X labels: up to ~6 evenly spaced.
+    const maxLabels = 6;
+    const stepIdx = Math.max(1, Math.ceil(n / maxLabels));
+    let xlabels = '';
+    for (let i = 0; i < n; i += stepIdx) {
+        xlabels += `<text class="axis x" x="${x(i).toFixed(1)}" y="${(H - 8)}" text-anchor="middle">${dateShort(series[i].date)}</text>`;
+    }
+    // Always label the final point.
+    if ((n - 1) % stepIdx !== 0) {
+        xlabels += `<text class="axis x" x="${x(n - 1).toFixed(1)}" y="${(H - 8)}" text-anchor="middle">${dateShort(series[n - 1].date)}</text>`;
+    }
+
+    container.innerHTML = `
+        <svg class="value-chart-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"
+             role="img" aria-label="Portfolio value over time, liquid and staked, stacked">
+            <style>
+                .value-chart-svg { width: 100%; height: 100%; display: block; }
+                .value-chart-svg .grid { stroke: #e9ecef; stroke-width: 1; }
+                .value-chart-svg .axis { fill: #6c757d; font-size: 11px; font-family: inherit; }
+                .value-chart-svg .cross { stroke: #adb5bd; stroke-width: 1; stroke-dasharray: 3 3; }
+                @media (prefers-color-scheme: dark) {
+                    .value-chart-svg .grid { stroke: #2c2c2a; }
+                    .value-chart-svg .axis { fill: #9a9a94; }
+                    .value-chart-svg .cross { stroke: #6c6c68; }
+                }
+            </style>
+            ${grid}
+            <path d="${stakedArea}" fill="${STAKED_FILL}"/>
+            <path d="${liquidArea}" fill="${LIQUID_FILL}"/>
+            <path d="${stakedLine}" fill="none" stroke="${STAKED_STROKE}" stroke-width="2" stroke-linejoin="round"/>
+            <path d="${totalLine}" fill="none" stroke="${LIQUID_STROKE}" stroke-width="2" stroke-linejoin="round"/>
+            ${xlabels}
+            <line class="cross" x1="0" y1="${M.top}" x2="0" y2="${baseY}" style="display:none"/>
+            <circle class="dot-liquid" r="3.5" fill="${LIQUID_STROKE}" style="display:none"/>
+            <circle class="dot-total" r="3.5" fill="${STAKED_STROKE}" style="display:none"/>
+            <rect class="hover-overlay" x="${M.left}" y="${M.top}" width="${PLOT_W}" height="${PLOT_H}"
+                  fill="transparent" style="cursor:crosshair"/>
+        </svg>
+        <div class="chart-tooltip" hidden></div>
+    `;
+
+    const svg = container.querySelector('svg');
+    const overlay = container.querySelector('.hover-overlay');
+    const cross = container.querySelector('.cross');
+    const dotL = container.querySelector('.dot-liquid');
+    const dotT = container.querySelector('.dot-total');
+    const tooltip = container.querySelector('.chart-tooltip');
+
+    function showAt(i) {
+        const p = series[i];
+        const px = x(i);
+        cross.setAttribute('x1', px);
+        cross.setAttribute('x2', px);
+        cross.style.display = '';
+        // Blue dot on the top (liquid) line; green dot on the staked boundary.
+        dotL.setAttribute('cx', px); dotL.setAttribute('cy', y(p.total)); dotL.style.display = '';
+        dotT.setAttribute('cx', px); dotT.setAttribute('cy', y(p.staked)); dotT.style.display = p.staked > 0 ? '' : 'none';
+
+        tooltip.hidden = false;
+        tooltip.innerHTML =
+            `<div class="tt-date">${dateLong(p.date)}</div>`
+            + `<div class="tt-row"><span class="tt-key"><i style="background:${STAKED_STROKE}"></i>Total</span><span class="tt-val">${money(p.total)}</span></div>`
+            + `<div class="tt-row"><span class="tt-key"><i style="background:${LIQUID_STROKE}"></i>Liquid</span><span class="tt-val">${money(p.liquid)}</span></div>`
+            + (p.staked > 0 ? `<div class="tt-row"><span class="tt-key"><i style="background:${STAKED_STROKE}"></i>Staked</span><span class="tt-val">${money(p.staked)}</span></div>` : '');
+
+        // Position tooltip in pixel space near the point, kept inside the container.
+        const cRect = container.getBoundingClientRect();
+        const sRect = svg.getBoundingClientRect();
+        const pxPixel = sRect.left - cRect.left + (px / W) * sRect.width;
+        let left = pxPixel + 12;
+        const ttW = tooltip.offsetWidth || 140;
+        if (left + ttW > cRect.width) left = pxPixel - ttW - 12;
+        if (left < 0) left = 4;
+        tooltip.style.left = `${left}px`;
+        tooltip.style.top = `4px`;
+    }
+
+    function hide() {
+        cross.style.display = 'none';
+        dotL.style.display = 'none';
+        dotT.style.display = 'none';
+        tooltip.hidden = true;
+    }
+
+    function indexFromEvent(evt) {
+        const rect = overlay.getBoundingClientRect();
+        const frac = Math.min(1, Math.max(0, (evt.clientX - rect.left) / rect.width));
+        return Math.round(frac * (n - 1));
+    }
+
+    overlay.addEventListener('mousemove', (e) => showAt(indexFromEvent(e)));
+    overlay.addEventListener('mouseleave', hide);
+    overlay.addEventListener('touchstart', (e) => { if (e.touches[0]) showAt(indexFromEvent(e.touches[0])); }, { passive: true });
+    overlay.addEventListener('touchmove', (e) => { if (e.touches[0]) showAt(indexFromEvent(e.touches[0])); }, { passive: true });
+}

--- a/public_html/portfolio/portfolio-chart.js
+++ b/public_html/portfolio/portfolio-chart.js
@@ -36,10 +36,11 @@ function niceMax(value) {
 function defaultDateShort(iso, granularity) {
     const [y, m, d] = iso.split('-').map(Number);
     const date = new Date(Date.UTC(y, m - 1, d));
+    // Axis labels are always English (like the rest of the portfolio UI), day-first.
     if (granularity === 'month') {
-        return date.toLocaleDateString(navigator.language, { month: 'short', timeZone: 'UTC' });
+        return date.toLocaleDateString('en-GB', { month: 'short', timeZone: 'UTC' });
     }
-    return date.toLocaleDateString(navigator.language, { day: '2-digit', month: '2-digit', timeZone: 'UTC' });
+    return date.toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit', timeZone: 'UTC' });
 }
 
 function xForIndex(i, n) {

--- a/public_html/portfolio/portfolio-data.js
+++ b/public_html/portfolio/portfolio-data.js
@@ -27,7 +27,7 @@ import {
     getDecimalConversionValue
 } from '../yearreport/yearreportdata.js';
 import { resolveSymbol, resolveDisplaySymbol } from '../near/intents-tokens.js';
-import { getCurrentPrices, getEODPrice } from '../pricedata/pricedata.js';
+import { getCurrentPrices, getEODPrice, getEODPriceMap } from '../pricedata/pricedata.js';
 
 // Liquid-staking token symbols excluded from the portfolio total (treated as staking).
 export const EXCLUDED_STAKING_SYMBOLS = new Set(['STNEAR', 'LINEAR', 'NEARX', 'LST']);
@@ -298,4 +298,152 @@ export async function calculatePortfolio(currency, fromDate, onProgress = () => 
         totalWithStaked: base.totalValue + (stakedValue || 0),
         ibWithStaked: ibValue + (ibStakedValue || 0)
     };
+}
+
+// ---------------------------------------------------------------------------
+// Value-over-time series (for the portfolio "wave" chart)
+// ---------------------------------------------------------------------------
+
+function toDate(isoDate) {
+    const [y, m, d] = isoDate.split('-').map(Number);
+    return new Date(Date.UTC(y, m - 1, d));
+}
+
+function toIso(date) {
+    return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Build the list of sample dates from fromDate to today (inclusive) at the given
+ * granularity. Today is always the final point so the chart ends "now".
+ *   - 'day'   : every calendar day
+ *   - 'week'  : every 7th day from fromDate
+ *   - 'month' : the 1st of each month from fromDate's month
+ */
+export function buildSampleDates(fromDate, today, granularity) {
+    const start = toDate(fromDate);
+    const end = toDate(today);
+    if (end < start) {
+        return [toIso(end)];
+    }
+    const dates = [];
+
+    if (granularity === 'day') {
+        for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+            dates.push(toIso(d));
+        }
+    } else if (granularity === 'week') {
+        for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 7)) {
+            dates.push(toIso(d));
+        }
+    } else {
+        // month: 1st of each month within range
+        let d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 1));
+        while (d <= end) {
+            dates.push(toIso(d < start ? start : d));
+            d = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
+        }
+    }
+
+    const lastIso = toIso(end);
+    if (dates[dates.length - 1] !== lastIso) {
+        dates.push(lastIso);
+    }
+    return dates;
+}
+
+// Index of the largest key <= date in an ascending array of 'yyyy-MM-dd' keys
+// (carry-forward lookup). Returns -1 if every key is after date.
+function latestAtOrBefore(sortedKeys, date) {
+    let lo = 0, hi = sortedKeys.length - 1, res = -1;
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (sortedKeys[mid] <= date) { res = mid; lo = mid + 1; } else { hi = mid - 1; }
+    }
+    return res;
+}
+
+/**
+ * Total portfolio value over time, split into liquid and staked, for a currency,
+ * period and granularity. Reuses the cached heavy base computation (FIFO + daily
+ * balances + price fetches), so it's cheap to re-run when only the granularity
+ * changes.
+ *
+ * For each sample date: liquid = Σ (on-chain balance that day × EOD price that day)
+ * over non-excluded tokens; staked = staked NEAR that day × NEAR EOD price that day.
+ * Missing prices carry forward the last known price (relevant past CoinGecko's
+ * ~365-day altcoin history limit). The final point is anchored to the current
+ * totals so the chart's end matches the summary cards exactly.
+ *
+ * @param {string} currency - lowercase currency code (e.g. 'nok')
+ * @param {string} fromDate - 'yyyy-MM-dd' start of the period
+ * @param {'day'|'week'|'month'} [granularity='month']
+ * @param {(msg:string)=>void} [onProgress]
+ * @param {{force?: boolean}} [opts]
+ * @returns {Promise<{currency,fromDate,granularity,series:{date,liquid,staked,total}[]}>}
+ */
+export async function calculatePortfolioSeries(currency, fromDate, granularity = 'month', onProgress = () => {}, { force = false } = {}) {
+    const base = await computeBase(currency, onProgress, force);
+    onProgress('Building value history');
+
+    const today = new Date().toISOString().slice(0, 10);
+    const sampleDates = buildSampleDates(fromDate, today, granularity);
+
+    // Price history per token, fetched once and looked up locally with carry-forward.
+    const priceCache = new Map(); // token -> { map, keys }
+    async function priceInfo(token) {
+        if (!priceCache.has(token)) {
+            const map = await getEODPriceMap(currency, token);
+            const keys = map.__constant != null ? null : Object.keys(map).sort();
+            priceCache.set(token, { map, keys });
+        }
+        return priceCache.get(token);
+    }
+    function priceOn(info, date) {
+        if (info.map.__constant != null) return info.map.__constant;
+        if (!info.keys.length) return 0;
+        const idx = latestAtOrBefore(info.keys, date);
+        return idx < 0 ? 0 : (info.map[info.keys[idx]] || 0);
+    }
+
+    const nearInfo = await priceInfo(NEAR_TOKEN);
+    const stakedKeys = Object.keys(base.stakedRawByDate).sort();
+
+    const series = [];
+    for (const d of sampleDates) {
+        let liquid = 0;
+        for (const h of base.holdings) {
+            if (h.excluded) continue;
+            const day = h.dailyBalances[d];
+            if (!day) continue;
+            const raw = Number(day.accountBalance);
+            if (!raw) continue;
+            const amount = raw * h.decimalConversionValue;
+            const price = priceOn(await priceInfo(h.token), d);
+            if (price) liquid += amount * price;
+        }
+
+        let staked = 0;
+        const sIdx = latestAtOrBefore(stakedKeys, d);
+        if (sIdx >= 0) {
+            const stakedRaw = base.stakedRawByDate[stakedKeys[sIdx]];
+            const nearPrice = priceOn(nearInfo, d);
+            if (stakedRaw && nearPrice) staked = stakedRaw * base.nearDecimal * nearPrice;
+        }
+
+        series.push({ date: d, liquid, staked, total: liquid + staked });
+    }
+
+    // Anchor the final point to the live totals so the chart end matches the cards.
+    if (series.length) {
+        const last = series[series.length - 1];
+        last.liquid = base.totalValue;
+        const currentStakedRaw = stakedKeys.length ? base.stakedRawByDate[stakedKeys[stakedKeys.length - 1]] : 0;
+        last.staked = (base.nearPrice != null && currentStakedRaw)
+            ? currentStakedRaw * base.nearDecimal * base.nearPrice
+            : last.staked;
+        last.total = last.liquid + last.staked;
+    }
+
+    return { currency, fromDate, granularity, series };
 }

--- a/public_html/portfolio/portfolio-data.spec.js
+++ b/public_html/portfolio/portfolio-data.spec.js
@@ -1,0 +1,50 @@
+import { buildSampleDates } from "./portfolio-data.js";
+
+describe('portfolio value-over-time sampling (buildSampleDates)', () => {
+    it('monthly: one point per month, first is the from date, last is today', () => {
+        const dates = buildSampleDates('2026-01-01', '2026-07-02', 'month');
+        expect(dates).to.deep.equal([
+            '2026-01-01', '2026-02-01', '2026-03-01',
+            '2026-04-01', '2026-05-01', '2026-06-01',
+            '2026-07-01', '2026-07-02'
+        ]);
+    });
+
+    it('monthly: a mid-month from date is kept as the first point', () => {
+        const dates = buildSampleDates('2026-01-15', '2026-03-10', 'month');
+        expect(dates[0]).to.equal('2026-01-15');
+        expect(dates).to.include('2026-02-01');
+        expect(dates).to.include('2026-03-01');
+        expect(dates[dates.length - 1]).to.equal('2026-03-10');
+    });
+
+    it('weekly: steps 7 days and always ends on today', () => {
+        const dates = buildSampleDates('2026-01-01', '2026-01-20', 'week');
+        expect(dates).to.deep.equal([
+            '2026-01-01', '2026-01-08', '2026-01-15', '2026-01-20'
+        ]);
+    });
+
+    it('weekly: no duplicate final point when today lands on the step', () => {
+        const dates = buildSampleDates('2026-01-01', '2026-01-15', 'week');
+        expect(dates).to.deep.equal(['2026-01-01', '2026-01-08', '2026-01-15']);
+    });
+
+    it('daily: every calendar day inclusive', () => {
+        const dates = buildSampleDates('2026-02-26', '2026-03-02', 'day');
+        expect(dates).to.deep.equal([
+            '2026-02-26', '2026-02-27', '2026-02-28',
+            '2026-03-01', '2026-03-02'
+        ]);
+    });
+
+    it('handles a from date equal to today (single point)', () => {
+        const dates = buildSampleDates('2026-07-02', '2026-07-02', 'month');
+        expect(dates).to.deep.equal(['2026-07-02']);
+    });
+
+    it('handles a from date after today gracefully (clamps to today)', () => {
+        const dates = buildSampleDates('2026-08-01', '2026-07-02', 'month');
+        expect(dates).to.deep.equal(['2026-07-02']);
+    });
+});

--- a/public_html/portfolio/portfolio-page.component.html.js
+++ b/public_html/portfolio/portfolio-page.component.html.js
@@ -100,11 +100,94 @@ export default /*html*/ `
 
     .portfolio-note { font-size: 0.85rem; color: #6c757d; margin-top: 1.5rem; }
     #portfolio-progress { color: #6c757d; }
+    /* Top section: info boxes (left) + value chart (right), 50/50. */
+    .top-section {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+        align-items: stretch;
+        margin-bottom: 0.5rem;
+    }
+    .top-section > #summary { min-width: 0; }
+
+    .chart-panel {
+        display: flex;
+        flex-direction: column;
+        border: 1px solid #dee2e6;
+        border-radius: 0.75rem;
+        background: #fff;
+        padding: 0.9rem 1rem;
+        min-width: 0;
+    }
+    .chart-head {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.4rem;
+    }
+    .chart-title {
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #6c757d;
+        margin-right: auto;
+    }
+    .granularity { display: inline-flex; border: 1px solid #ced4da; border-radius: 0.4rem; overflow: hidden; }
+    .granularity button {
+        border: 0;
+        border-left: 1px solid #ced4da;
+        background: transparent;
+        color: #495057;
+        font-size: 0.78rem;
+        padding: 0.2rem 0.6rem;
+        cursor: pointer;
+    }
+    .granularity button:first-child { border-left: 0; }
+    .granularity button.active { background: #e7f1ff; color: #0d6efd; font-weight: 600; }
+
+    .chart-legend { display: flex; gap: 1rem; font-size: 0.78rem; color: #6c757d; margin-bottom: 0.3rem; }
+    .chart-legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
+    .legend-swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+    .legend-swatch.liquid { background: #2a78d6; }
+    .legend-swatch.staked { background: #1baf7a; }
+
+    .chart-canvas { position: relative; flex: 1 1 auto; min-height: 210px; }
+    .chart-empty {
+        display: flex; align-items: center; justify-content: center;
+        height: 100%; min-height: 180px; color: #6c757d; font-size: 0.9rem;
+    }
+    .chart-tooltip {
+        position: absolute;
+        pointer-events: none;
+        background: #fff;
+        border: 1px solid #dee2e6;
+        border-radius: 0.5rem;
+        padding: 0.45rem 0.6rem;
+        font-size: 0.8rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+        min-width: 130px;
+        z-index: 2;
+    }
+    .chart-tooltip .tt-date { font-weight: 600; margin-bottom: 0.25rem; }
+    .chart-tooltip .tt-row { display: flex; justify-content: space-between; gap: 0.75rem; line-height: 1.5; }
+    .chart-tooltip .tt-key { display: inline-flex; align-items: center; gap: 0.35rem; color: #6c757d; }
+    .chart-tooltip .tt-key i { width: 9px; height: 9px; border-radius: 2px; display: inline-block; }
+    .chart-tooltip .tt-val { font-weight: 600; }
+
+    @media (max-width: 800px) {
+        .top-section { grid-template-columns: 1fr; }
+    }
+
     @media (prefers-color-scheme: dark) {
         .card-surface, .holding-card { background: #1e1e1e; border-color: #343a40; }
         .holding-card.excluded { background: #161616; }
         .metric-card.result { background: #15321f; border-color: #1f5132; }
         .hero-sub { color: #ced4da; }
+        .chart-panel { background: #1e1e1e; border-color: #343a40; }
+        .granularity, .granularity button { border-color: #343a40; }
+        .granularity button { color: #ced4da; }
+        .granularity button.active { background: #16324f; color: #6ea8fe; }
+        .chart-tooltip { background: #1e1e1e; border-color: #343a40; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
     }
 </style>
 
@@ -126,7 +209,24 @@ export default /*html*/ `
 
     <div id="portfolio-progress" class="mb-3"></div>
 
-    <div id="summary" hidden></div>
+    <div id="top-section" class="top-section" hidden>
+        <div id="summary" hidden></div>
+        <div id="chart-panel" class="chart-panel" hidden>
+            <div class="chart-head">
+                <span class="chart-title">Value over time</span>
+                <div class="granularity" role="group" aria-label="Chart resolution">
+                    <button type="button" data-granularity="day">Day</button>
+                    <button type="button" data-granularity="week">Week</button>
+                    <button type="button" data-granularity="month" class="active">Month</button>
+                </div>
+            </div>
+            <div class="chart-legend">
+                <span><i class="legend-swatch liquid"></i>Liquid</span>
+                <span><i class="legend-swatch staked"></i>Staked</span>
+            </div>
+            <div id="value-chart" class="chart-canvas"></div>
+        </div>
+    </div>
 
     <div id="holdings-section" hidden>
         <div class="section-label">Holdings</div>

--- a/public_html/portfolio/portfolio-page.component.js
+++ b/public_html/portfolio/portfolio-page.component.js
@@ -1,5 +1,6 @@
 import { getCurrencyList } from '../pricedata/pricedata.js';
-import { calculatePortfolio } from './portfolio-data.js';
+import { calculatePortfolio, calculatePortfolioSeries } from './portfolio-data.js';
+import { renderPortfolioChart } from './portfolio-chart.js';
 import html from './portfolio-page.component.html.js';
 
 const PREFERRED_DEFAULT_CURRENCY = 'nok';
@@ -18,7 +19,10 @@ customElements.define('portfolio-page',
             document.querySelectorAll('link').forEach(lnk => this.shadowRoot.appendChild(lnk.cloneNode()));
 
             this.progressEl = this.shadowRoot.querySelector('#portfolio-progress');
+            this.topSection = this.shadowRoot.querySelector('#top-section');
             this.summaryEl = this.shadowRoot.querySelector('#summary');
+            this.chartPanel = this.shadowRoot.querySelector('#chart-panel');
+            this.valueChart = this.shadowRoot.querySelector('#value-chart');
             this.holdingsEl = this.shadowRoot.querySelector('#holdings');
             this.holdingsSection = this.shadowRoot.querySelector('#holdings-section');
             this.excludedNoteEl = this.shadowRoot.querySelector('#excluded-note');
@@ -26,11 +30,21 @@ customElements.define('portfolio-page',
             this.fromMonthSelect = this.shadowRoot.querySelector('#frommonthselect');
             this.fromYearSelect = this.shadowRoot.querySelector('#fromyearselect');
             this.refreshButton = this.shadowRoot.querySelector('#refreshbutton');
+            this.granularityButtons = [...this.shadowRoot.querySelectorAll('.granularity button')];
+
+            // Chart resolution — reuses the page's currency + from-date; defaults to monthly.
+            this.granularity = 'month';
 
             this.currencySelect.addEventListener('change', () => this.refresh());
             this.fromMonthSelect.addEventListener('change', () => this.refresh());
             this.fromYearSelect.addEventListener('change', () => this.refresh());
             this.refreshButton.addEventListener('click', () => this.refresh(true));
+            this.granularityButtons.forEach(btn => btn.addEventListener('click', () => {
+                if (this.granularity === btn.dataset.granularity) return;
+                this.granularity = btn.dataset.granularity;
+                this.granularityButtons.forEach(b => b.classList.toggle('active', b === btn));
+                this.renderChart();
+            }));
 
             this.init();
         }
@@ -88,18 +102,42 @@ customElements.define('portfolio-page',
                 return;
             }
             const fromDate = this.getFromDate();
+            this.currentCurrency = currency;
+            this.currentFromDate = fromDate;
             this.setBusy(true, force ? 'Recalculating portfolio …' : 'Loading portfolio …');
             try {
                 const portfolio = await calculatePortfolio(currency, fromDate, msg => this.setBusy(true, msg), { force });
                 this.render(portfolio);
                 this.setBusy(false, '');
+                // Value-over-time chart reuses the (now cached) heavy computation.
+                await this.renderChart(force);
             } catch (e) {
                 console.error('Failed to calculate portfolio', e);
                 this.setBusy(false, '');
+                this.topSection.hidden = false;
                 this.summaryEl.hidden = true;
+                this.chartPanel.hidden = true;
                 this.holdingsSection.hidden = false;
                 this.holdingsEl.innerHTML =
                     `<div class="alert alert-danger">Could not calculate portfolio: ${escapeHtml(e.message)}</div>`;
+            }
+        }
+
+        async renderChart(force = false) {
+            if (!this.currentCurrency) {
+                return;
+            }
+            this.topSection.hidden = false;
+            this.chartPanel.hidden = false;
+            this.valueChart.innerHTML = '<div class="chart-empty">Building value history …</div>';
+            try {
+                const data = await calculatePortfolioSeries(
+                    this.currentCurrency, this.currentFromDate, this.granularity, () => {}, { force });
+                const money = makeMoneyFormatter(this.currentCurrency.toUpperCase());
+                renderPortfolioChart(this.valueChart, data, { formatMoney: money, formatDate: formatDate });
+            } catch (e) {
+                console.error('Failed to build value history', e);
+                this.valueChart.innerHTML = '<div class="chart-empty">Could not load value history.</div>';
             }
         }
 
@@ -127,6 +165,7 @@ customElements.define('portfolio-page',
                 ? `<div class="hero-sub">${money(portfolio.totalValue)} liquid <span class="muted">+</span> ${money(portfolio.stakedValue || 0)} staked <span class="muted">(${formatTokenAmount(portfolio.stakedAmount)} NEAR)</span></div>`
                 : '';
 
+            this.topSection.hidden = false;
             this.summaryEl.hidden = false;
             this.summaryEl.innerHTML = `
                 <div class="card-surface hero-card">

--- a/public_html/pricedata/pricedata.js
+++ b/public_html/pricedata/pricedata.js
@@ -189,6 +189,53 @@ export async function getEODPrice(currency, datestring, token = defaultToken) {
     return price ?? 0;
 }
 
+/**
+ * Whole EOD price history for a token in a currency, as a map { 'yyyy-MM-dd': price }.
+ * Mirrors getEODPrice's symbol resolution and stablecoin handling, but returns the
+ * full series in one call so callers that need many dates (e.g. the value-over-time
+ * chart) don't do one storage read per date. Triggers a single gateway fetch if the
+ * history isn't cached yet.
+ *
+ * For USD-pegged stablecoins valued in USD (which getEODPrice short-circuits to 1)
+ * the map has no dates; a sentinel { __constant: 1 } is returned instead so the
+ * caller can treat every date as 1.
+ *
+ * @param {string} currency - target currency (e.g. 'nok')
+ * @param {string} token - token symbol or contract id ('' / 'NEAR' for native NEAR)
+ * @returns {Promise<Object<string, number> & {__constant?: number}>}
+ */
+export async function getEODPriceMap(currency, token = defaultToken) {
+    if (token === "") {
+        token = defaultToken;
+    }
+
+    const hasIntentsPrefix = /^nep(141|245):/.test(token);
+    const hasNearSuffix = /\.(near|testnet)$/.test(token);
+    const isImplicitAccount = token.length === 64 && /^[a-f0-9]+$/.test(token);
+    if (hasIntentsPrefix || hasNearSuffix || isImplicitAccount) {
+        token = await resolveSymbol(token);
+    }
+
+    // USD-pegged stablecoins are ~1 USD - match getEODPrice's USD short-circuit.
+    if ((token.indexOf('USD') === 0 || token === 'USN') && currency.toUpperCase() === 'USD') {
+        return { __constant: 1 };
+    }
+
+    let pricedata = await getHistoricalPriceData(token, currency);
+    if (!pricedata || Object.keys(pricedata).length === 0) {
+        const coinGeckoId = symbolToCoinGeckoId[token.toUpperCase()] || token.toLowerCase();
+        if (!(await getNoPriceTokens()).has(coinGeckoId)) {
+            try {
+                await fetchHistoricalPricesFromArizGateway({ baseToken: token, currency });
+                pricedata = await getHistoricalPriceData(token, currency);
+            } catch (e) {
+                console.error(`Failed to fetch price history for ${token}/${currency} from Ariz Gateway`, e);
+            }
+        }
+    }
+    return pricedata || {};
+}
+
 export async function getCustomSellPrice(currency, datestring, token) {
     if (token && token !== 'near') {
         return await getEODPrice(currency, datestring, token);


### PR DESCRIPTION
Adds a zero-dependency stacked-area chart on the Portfolio page showing total value over time, split into staked (bottom) and liquid (top).

- Reuses the existing currency + from-month/year selectors; new control is only a day/week/month resolution toggle (default monthly).
- 50/50 layout: info boxes left, chart right; holdings full-width below. All existing labels/captions/footnotes preserved.
- Data derived from daily balances × EOD prices (carry-forward when a price is missing); final point anchored to the live totals.
- Known limit: CoinGecko free tier caps altcoin daily history at ~365 days, so older altcoin values carry forward the last known price.
- New unit tests for the sampling logic; full test suite passes locally.