### PR TITLE
Fix NEAR liquid/staked double-count (real on-chain split)

### DIFF
--- a/public_html/portfolio/portfolio-data.js
+++ b/public_html/portfolio/portfolio-data.js
@@ -66,6 +66,31 @@ function summarizeOpenPositions(openPositions) {
     return { remainingRaw, costBasis };
 }
 
+// On-chain liquid/staked NEAR split at a point in time.
+//
+// Transfers to/from staking pools are invisible to the FIFO (excluded in
+// calculateYearReportData at the deposit/withdrawal step), so the FIFO "remaining"
+// lumps liquid + staked NEAR together - which is why the liquid row looked ~40x too
+// high and the staked balance was double-counted. The real split lives in the daily
+// balances: `accountBalance` is the summed on-chain (liquid) balance and
+// `stakingBalance` is the staked balance (both raw yocto). Pass `before`
+// (yyyy-MM-dd, exclusive) for an IB snapshot day; omit it for the latest day.
+export function nearLiquidStakedRaw(dailyBalances, before) {
+    const dates = Object.keys(dailyBalances); // chronological (yyyy-MM-dd insertion order)
+    let day;
+    if (before) {
+        for (const ds of dates) {
+            if (ds < before) day = dailyBalances[ds];
+            else break;
+        }
+    } else {
+        day = dailyBalances[dates[dates.length - 1]];
+    }
+    const liquidRaw = Number(day?.accountBalance ?? 0n);
+    const stakedRaw = day?.stakingBalance ?? 0;
+    return { liquidRaw, stakedRaw, totalRaw: liquidRaw + stakedRaw };
+}
+
 /**
  * Heavy per-currency computation, cached. Runs the full-history FIFO for every
  * token to get current holdings, cost basis, the per-day realized series, current
@@ -78,6 +103,7 @@ async function computeBase(currency, onProgress, force) {
 
     const tokens = await getTokenList();
     const holdings = [];
+    let nearStakedCostBasis = 0; // staked share of NEAR's FIFO cost basis (see below)
 
     for (let i = 0; i < tokens.length; i++) {
         const t = tokens[i];
@@ -93,7 +119,21 @@ async function computeBase(currency, onProgress, force) {
             : Math.pow(10, -24);
 
         const { remainingRaw, costBasis } = summarizeOpenPositions(openPositions);
-        const amount = remainingRaw * decimalConversionValue;
+        let amount = remainingRaw * decimalConversionValue;
+        let holdingCostBasis = costBasis;
+
+        // Re-split NEAR into its real on-chain liquid vs staked buckets. The liquid
+        // holding row must reflect actual liquid NEAR (accountBalance), not the FIFO
+        // total (which still counts everything ever staked); the staked share of the
+        // cost basis is carried out via base.stakedCostBasis for the staked row.
+        if (t.token === NEAR_TOKEN) {
+            const { liquidRaw, totalRaw } = nearLiquidStakedRaw(dailyBalances);
+            if (totalRaw > 0) {
+                amount = liquidRaw * decimalConversionValue;
+                holdingCostBasis = costBasis * (liquidRaw / totalRaw);
+                nearStakedCostBasis = costBasis - holdingCostBasis;
+            }
+        }
 
         // Per-day realized net P/L (gain - loss) from FIFO disposals. FIFO is
         // prefix-consistent, so a later truncated pass won't change these days.
@@ -111,8 +151,8 @@ async function computeBase(currency, onProgress, force) {
             displaySymbol: t.displaySymbol,
             excluded,
             amount,
-            costBasis,
-            missingCostBasis: amount > DUST_THRESHOLD && !(costBasis > 0),
+            costBasis: holdingCostBasis,
+            missingCostBasis: amount > DUST_THRESHOLD && !(holdingCostBasis > 0),
             realizationsByDate,
             decimalConversionValue,
             dailyBalances
@@ -169,6 +209,7 @@ async function computeBase(currency, onProgress, force) {
     const base = {
         currency, holdings, totalValue, totalCost, excludedValue,
         stakedRawByDate,
+        stakedCostBasis: nearStakedCostBasis,
         pricesUnavailable,
         nearPrice: currentPrices['NEAR'] ?? null,
         nearDecimal: Math.pow(10, -24)
@@ -197,7 +238,18 @@ async function computeIbSnapshot(base, currency, fromDate, onProgress) {
         }
         const { openPositions } = await calculateProfitLoss(truncated, currency, h.token);
         const { remainingRaw, costBasis } = summarizeOpenPositions(openPositions);
-        const ibAmount = remainingRaw * h.decimalConversionValue;
+        let ibAmount = remainingRaw * h.decimalConversionValue;
+        let ibCostBasis = costBasis;
+
+        // Same liquid/staked split as the UB pass, but at the IB date - so the
+        // opening liquid NEAR row is consistent with the current liquid row.
+        if (h.token === NEAR_TOKEN) {
+            const { liquidRaw, totalRaw } = nearLiquidStakedRaw(h.dailyBalances, fromDate);
+            if (totalRaw > 0) {
+                ibAmount = liquidRaw * h.decimalConversionValue;
+                ibCostBasis = costBasis * (liquidRaw / totalRaw);
+            }
+        }
 
         let ibValue = null;
         if (ibAmount > DUST_THRESHOLD) {
@@ -207,7 +259,7 @@ async function computeIbSnapshot(base, currency, fromDate, onProgress) {
             ibValue = 0;
         }
 
-        snapshot.set(h.token, { ibAmount, ibCostBasis: costBasis, ibValue });
+        snapshot.set(h.token, { ibAmount, ibCostBasis, ibValue });
     }
 
     ibCache.set(cacheKey, snapshot);
@@ -282,6 +334,10 @@ export async function calculatePortfolio(currency, fromDate, onProgress = () => 
     const stakedValue = base.nearPrice != null ? stakedAmount * base.nearPrice : null;
     const ibNearPrice = ibStakedAmount > DUST_THRESHOLD ? await getEODPrice(currency, fromDate, NEAR_TOKEN) : 0;
     const ibStakedValue = ibStakedAmount > DUST_THRESHOLD ? ibStakedAmount * ibNearPrice : 0;
+    // Staked NEAR's share of the FIFO cost basis (see computeBase), so the staked
+    // row shows real unrealized P/L instead of pure market value.
+    const stakedCostBasis = base.stakedCostBasis || 0;
+    const stakedUnrealized = stakedValue != null && stakedCostBasis > 0 ? stakedValue - stakedCostBasis : null;
 
     return {
         currency,
@@ -303,6 +359,8 @@ export async function calculatePortfolio(currency, fromDate, onProgress = () => 
         // Staking (NEAR), shown separately
         stakedAmount,
         stakedValue,
+        stakedCostBasis,
+        stakedUnrealized,
         ibStakedAmount,
         ibStakedValue,
         // Complete asset picture

--- a/public_html/portfolio/portfolio-data.spec.js
+++ b/public_html/portfolio/portfolio-data.spec.js
@@ -1,0 +1,48 @@
+import { nearLiquidStakedRaw } from './portfolio-data.js';
+
+// Daily balances as produced by calculateYearReportData: chronological yyyy-MM-dd
+// keys, each with accountBalance (raw yocto BigInt, on-chain liquid) and
+// stakingBalance (raw yocto number, staked).
+function dailyBalances() {
+    return {
+        '2025-01-01': { accountBalance: 100n * 10n ** 24n, stakingBalance: 0 },
+        // staked a chunk: liquid drops, staked rises (FIFO can't see this move)
+        '2025-06-01': { accountBalance: 10n * 10n ** 24n, stakingBalance: 90 * 1e24 },
+        '2025-12-31': { accountBalance: 4n * 10n ** 24n, stakingBalance: 96 * 1e24 },
+    };
+}
+
+describe('nearLiquidStakedRaw', () => {
+    it('reads the latest day when no date is given', () => {
+        const { liquidRaw, stakedRaw, totalRaw } = nearLiquidStakedRaw(dailyBalances());
+        expect(liquidRaw).to.equal(4e24);
+        expect(stakedRaw).to.equal(96e24);
+        expect(totalRaw).to.equal(100e24);
+    });
+
+    it('reads the last day strictly before an IB date', () => {
+        // before 2025-06-01 -> the 2025-01-01 snapshot (100 liquid, 0 staked)
+        const ib = nearLiquidStakedRaw(dailyBalances(), '2025-06-01');
+        expect(ib.liquidRaw).to.equal(100e24);
+        expect(ib.stakedRaw).to.equal(0);
+    });
+
+    it('splits a FIFO cost basis by the on-chain weight', () => {
+        // The FIFO lumps liquid+staked: 100 NEAR remaining at cost 1000.
+        // On-chain it is 4 liquid / 96 staked, so the liquid row should carry 4% of
+        // the basis and the staked row 96% - exactly the double-count fix.
+        const fifoCostBasis = 1000;
+        const { liquidRaw, totalRaw } = nearLiquidStakedRaw(dailyBalances());
+        const liquidCostBasis = fifoCostBasis * (liquidRaw / totalRaw);
+        const stakedCostBasis = fifoCostBasis - liquidCostBasis;
+        expect(liquidCostBasis).to.be.closeTo(40, 1e-9);
+        expect(stakedCostBasis).to.be.closeTo(960, 1e-9);
+    });
+
+    it('is safe on empty input', () => {
+        const { liquidRaw, stakedRaw, totalRaw } = nearLiquidStakedRaw({});
+        expect(liquidRaw).to.equal(0);
+        expect(stakedRaw).to.equal(0);
+        expect(totalRaw).to.equal(0);
+    });
+});

--- a/public_html/portfolio/portfolio-page.component.js
+++ b/public_html/portfolio/portfolio-page.component.js
@@ -178,6 +178,9 @@ customElements.define('portfolio-page',
             // Holdings (liquid), with a dedicated staked row on top when present.
             this.holdingsSection.hidden = false;
             const maxValue = Math.max(1, ...portfolio.holdings.map(h => h.value ?? 0));
+            const stakedUnrealizedHtml = portfolio.stakedUnrealized != null
+                ? `<span class="${portfolio.stakedUnrealized >= 0 ? 'gain' : 'loss'}">${formatSigned(portfolio.stakedUnrealized, money)}</span>`
+                : '<span class="muted">not realized</span>';
             const stakedRow = hasStaking ? `
                 <div class="holding-card">
                     <div>
@@ -186,10 +189,11 @@ customElements.define('portfolio-page',
                             <span class="flag">staking</span>
                         </div>
                         <div class="holding-amount">${formatTokenAmount(portfolio.stakedAmount)} NEAR ${portfolio.stakedValue != null ? `@ ${money(portfolio.stakedValue / portfolio.stakedAmount)}` : ''}</div>
+                        ${portfolio.stakedCostBasis > 0 ? `<div class="holding-amount">Cost basis: ${money(portfolio.stakedCostBasis)}</div>` : ''}
                     </div>
                     <div class="holding-values">
                         <div class="holding-value">${portfolio.stakedValue != null ? money(portfolio.stakedValue) : '<span class="muted">value unknown</span>'}</div>
-                        <div class="holding-pl"><span class="muted">not realized</span></div>
+                        <div class="holding-pl">${stakedUnrealizedHtml}</div>
                     </div>
                 </div>
             ` : '';


### PR DESCRIPTION
Reopens #65 (auto-closed when its stacked base #64 was merged + branch-deleted). Rebased onto main; #64 is now merged.

## Problem
Transfers to/from staking pools are invisible to the FIFO ([yearreportdata.js:198](public_html/yearreport/yearreportdata.js#L198) excludes them from deposit/withdrawal), so the FIFO "remaining" lumps liquid + staked NEAR together. The portfolio then:
- showed that lump as the **liquid** NEAR row — **16,391** vs **~381** actually liquid, and
- showed the staked NEAR **again** via the staking API (**18,785**),

double-counting it and inflating the **total ~1.8×**.

## Fix (display/derivation only — FIFO untouched, tax numbers unchanged)
- Liquid NEAR row now uses the real on-chain balance (`accountBalance`), verified to reconcile with RPC (**380.98 NEAR**) to 4 decimals.
- Staked NEAR row keeps the staking-API balance and now carries its **share of the FIFO cost basis** (split by on-chain weight) → real unrealized P/L.
- Applied to both UB and IB passes for consistency.
- Year-report realized P/L is **unchanged** — the FIFO engine is not modified.

## Test
- `portfolio-data.spec.js` covers `nearLiquidStakedRaw` (latest day, IB date, proportional split, empty input).
- Full suite 134 passing locally.

## Follow-up (separate)
- **stNEAR** is overstated too (542 vs 254 on-chain) via a different cause — FT redemptions not captured in the token FIFO. PR #67's chart independently uses on-chain FT balances, reinforcing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)