### PR TITLE
Staking: stop booking deposits as rewards (re-derive earnings from balances)

### DIFF
--- a/public_html/near/accounting-export.js
+++ b/public_html/near/accounting-export.js
@@ -744,6 +744,71 @@ export function mergeFungibleTokenTransactions(existingFtTx, newFtTx) {
 }
 
 /**
+ * Recompute staking earnings for one pool's entries from the balance series and the
+ * principal moves, overriding any per-entry `earnings` from the source data.
+ *
+ * A pool balance only changes two ways: you move principal in/out (a transaction, so
+ * the entry carries a `hash`), or the pool accrues a reward (a plain snapshot with no
+ * hash). So, walking the entries oldest-first:
+ *   - an entry WITH a hash is a principal move -> its balance jump is a deposit (up)
+ *     or withdrawal (down), and earnings = 0;
+ *   - an entry WITHOUT a hash is reward accrual -> earnings = the balance increase.
+ *
+ * Summed, this yields earnings = finalBalance + withdrawals - deposits (true yield).
+ * It is robust to the two things that previously booked deposits as rewards: the
+ * accounting-export format carries no `method_name` (so deposit detection failed),
+ * and mergeStakingEntries kept stale RPC-path entries whose `earnings` equalled the
+ * deposit. The first known entry is treated as an opening baseline (earnings = 0) so
+ * a data window that starts mid-history can't report its opening balance as reward.
+ *
+ * @param {Array<Object>} entries - staking entries for a single pool
+ * @returns {Array<Object>} the same entries, block-height descending, earnings fixed
+ */
+export function recomputeStakingEarnings(entries) {
+    const sorted = [...entries].sort((a, b) => a.block_height - b.block_height);
+    let prevBalance = null;
+    for (const e of sorted) {
+        const balance = Number(e.balance) || 0;
+        const explicitDep = Number(e.deposit) || 0;
+        const explicitWd = Number(e.withdrawal) || 0;
+        // A principal move is anything with a transaction hash or an explicit
+        // deposit/withdrawal already recorded by the extractor.
+        const isPrincipalMove = !!e.hash || explicitDep > 0 || explicitWd > 0;
+        if (prevBalance === null) {
+            // Opening baseline: never book the first known balance as reward.
+            e.deposit = explicitDep || (e.hash ? balance : 0);
+            e.withdrawal = explicitWd;
+            e.earnings = 0;
+        } else {
+            const delta = balance - prevBalance;
+            if (e.hash) {
+                // A real transaction: its whole balance effect is the principal move
+                // (deposit up / withdrawal down), earnings 0. Inferring from the actual
+                // balance change - rather than a recorded `deposit` amount - is robust
+                // to transient/incorrect balance snapshots (e.g. a re-stake that briefly
+                // reads 0) that would otherwise leave the balance jump booked as reward.
+                e.deposit = delta > 0 ? delta : 0;
+                e.withdrawal = delta < 0 ? -delta : 0;
+                e.earnings = 0;
+            } else if (isPrincipalMove) {
+                // A principal move recorded without a tx hash: trust the explicit
+                // deposit/withdrawal; any remaining balance change is accrued reward.
+                e.deposit = explicitDep;
+                e.withdrawal = explicitWd;
+                e.earnings = Math.max(0, delta - explicitDep + explicitWd);
+            } else {
+                // Plain snapshot: a balance increase is accrued reward.
+                e.deposit = 0;
+                e.withdrawal = 0;
+                e.earnings = delta > 0 ? delta : 0;
+            }
+        }
+        prevBalance = balance;
+    }
+    return sorted.sort((a, b) => b.block_height - a.block_height);
+}
+
+/**
  * Merge staking data entries for a single pool
  * @param {Array<Object>} existingEntries - Existing staking entries
  * @param {Array<Object>} newEntries - New staking entries from accounting export
@@ -764,10 +829,11 @@ export function mergeStakingEntries(existingEntries, newEntries) {
 
     // Convert back to array and sort by block height descending
     const merged = Array.from(entriesByBlock.values());
-    merged.sort((a, b) => b.block_height - a.block_height);
 
-    // Earnings are already set from API - no recalculation needed
-    // New entries (with correct earnings from API) take precedence over existing entries
-
-    return merged;
+    // Recompute earnings from the merged balance series + principal moves. The old
+    // per-entry `earnings` cannot be trusted: the accounting-export format has no
+    // method_name (deposit detection failed) and merging two source paths keyed by
+    // block_height left stale RPC-path entries whose earnings equalled the deposit,
+    // so principal was booked as reward. Deriving from balance changes fixes both.
+    return recomputeStakingEarnings(merged);
 }

--- a/public_html/near/accounting-export.spec.js
+++ b/public_html/near/accounting-export.spec.js
@@ -397,10 +397,13 @@ describe('accounting-export (JSON)', () => {
             expect(totalEarnings / 1e24, 'Total earnings after merge should be ~0.15 NEAR').to.be.closeTo(0.15, 0.1);
             expect(totalEarnings / 1e24, 'Total earnings should NOT be ~1000 NEAR').to.be.lessThan(10);
 
-            // Verify individual earnings from new entries were preserved
+            // Earnings are re-derived from the balance series: the deposit itself is
+            // never reward (the 1000 NEAR jump is principal), and the small reward that
+            // accrued in the interval is attributed to the deposit block. The oldest
+            // entry is the opening baseline (no reward booked for a starting balance).
             expect(merged[0].earnings / 1e24).to.be.closeTo(0.118, 0.01);
-            expect(merged[1].earnings).to.equal(0); // Deposit entry, no staking reward
-            expect(merged[2].earnings / 1e24).to.be.closeTo(0.036, 0.01);
+            expect(merged[1].earnings / 1e24).to.be.closeTo(0.036, 0.01);
+            expect(merged[2].earnings).to.equal(0);
         });
     });
 

--- a/public_html/near/staking-earnings.spec.js
+++ b/public_html/near/staking-earnings.spec.js
@@ -1,0 +1,75 @@
+import { recomputeStakingEarnings } from './accounting-export.js';
+
+const N = (near) => near * 1e24; // NEAR -> raw yocto
+
+// A pool balance changes only two ways: principal moves (a transaction -> the entry
+// has a `hash`) or reward accrual (a plain snapshot, no `hash`). recomputeStakingEarnings
+// must book the former as deposit/withdrawal (earnings 0) and only the latter as reward.
+describe('recomputeStakingEarnings', () => {
+    const sum = (entries, k) => entries.reduce((t, e) => t + e[k], 0);
+
+    it('books deposits as principal, not reward (the npro bug)', () => {
+        // Every balance jump is a deposit (has a hash) -> zero real reward.
+        const entries = [
+            { block_height: 1, balance: N(150), hash: 'a' },
+            { block_height: 2, balance: N(5350), hash: 'b' },   // +5200 deposit
+            { block_height: 3, balance: N(11988), hash: 'c' },  // +6638 deposit
+        ];
+        const out = recomputeStakingEarnings(entries);
+        expect(sum(out, 'earnings')).to.equal(0);
+        expect(sum(out, 'deposit')).to.equal(N(11988));
+    });
+
+    it('books balance creep on snapshots (no hash) as reward', () => {
+        const entries = [
+            { block_height: 1, balance: N(1000), hash: 'dep' }, // opening deposit
+            { block_height: 2, balance: N(1002) },              // +2 reward (snapshot)
+            { block_height: 3, balance: N(1005) },              // +3 reward (snapshot)
+        ];
+        const out = recomputeStakingEarnings(entries);
+        expect(sum(out, 'earnings')).to.be.closeTo(N(5), 1e15);
+    });
+
+    it('satisfies earnings = finalBalance + withdrawals - deposits', () => {
+        const entries = [
+            { block_height: 1, balance: N(1000), hash: 'dep1' }, // deposit 1000
+            { block_height: 2, balance: N(1010) },               // +10 reward
+            { block_height: 3, balance: N(510), hash: 'wd1' },   // withdraw 500
+            { block_height: 4, balance: N(515) },                // +5 reward
+        ];
+        const out = recomputeStakingEarnings(entries);
+        const final = N(515), deposits = sum(out, 'deposit'), withdrawals = sum(out, 'withdrawal');
+        expect(sum(out, 'earnings')).to.be.closeTo(final + withdrawals - deposits, 1e15);
+        expect(sum(out, 'earnings')).to.be.closeTo(N(15), 1e15);
+    });
+
+    it('treats a mid-history opening balance as baseline, not reward', () => {
+        // First entry is a snapshot with an existing balance -> must not be booked as reward.
+        const entries = [
+            { block_height: 1, balance: N(5000) },   // opening snapshot, no hash
+            { block_height: 2, balance: N(5003) },   // +3 reward
+        ];
+        const out = recomputeStakingEarnings(entries);
+        expect(sum(out, 'earnings')).to.be.closeTo(N(3), 1e15);
+    });
+
+    it('ignores a spurious balance=0 blip between real balances (re-stake)', () => {
+        // 10000 -> 0 (blip, has hash) -> 11988 (has hash): no reward, just principal.
+        const entries = [
+            { block_height: 1, balance: N(10000), hash: 'x' },
+            { block_height: 2, balance: N(0), hash: 'y' },
+            { block_height: 3, balance: N(11988), hash: 'z' },
+        ];
+        const out = recomputeStakingEarnings(entries);
+        expect(sum(out, 'earnings')).to.equal(0);
+    });
+
+    it('returns entries block-height descending', () => {
+        const out = recomputeStakingEarnings([
+            { block_height: 1, balance: N(1), hash: 'a' },
+            { block_height: 3, balance: N(3), hash: 'c' },
+            { block_height: 2, balance: N(2), hash: 'b' },
+        ]);
+        expect(out.map(e => e.block_height)).to.deep.equal([3, 2, 1]);
+    });
+});

--- a/public_html/yearreport/yearreportdata.js
+++ b/public_html/yearreport/yearreportdata.js
@@ -1,5 +1,6 @@
 import { getAccounts, getTransactionsForAccount, getStakingRewardsForAccountAndPool, getAllFungibleTokenTransactionsByTxHash, getReceivedAccounts, getExpenseAccounts, getCustomRealizationRates } from "../storage/domainobjectstore.js";
 import { getStakingAccounts } from "../near/stakingpool.js";
+import { recomputeStakingEarnings } from "../near/accounting-export.js";
 import { getEODPrice, getCustomSellPrice, getCustomBuyPrice } from '../pricedata/pricedata.js';
 import { resolveDecimals } from '../near/intents-tokens.js';
 
@@ -107,7 +108,11 @@ export async function calculateYearReportData(fungibleTokenSymbol) {
 
         for (let stakingAccount of stakingAccounts) {
             allStakingAccounts[stakingAccount] = true;
-            const stakingRewards = await getStakingRewardsForAccountAndPool(account, stakingAccount, fungibleTokenSymbol);
+            // Re-derive earnings from the balance series + principal moves so stored
+            // data collected before the earnings fix (which booked deposits as
+            // rewards) is corrected on read, without needing a re-import.
+            const stakingRewards = recomputeStakingEarnings(
+                await getStakingRewardsForAccountAndPool(account, stakingAccount, fungibleTokenSymbol));
             for (let stakingReward of stakingRewards) {
                 const ts = stakingReward.timestamp.substr(0, 'yyyy-MM-dd'.length);
                 const stakingBalances = accountTransactions[account].stakingBalances;


### PR DESCRIPTION
Fixes #68.

Staking earnings were massively overstated because stake **deposits** were counted as **rewards**. On an affected account the year report showed **11,989 NEAR of "reward" on 2 May 2026** (actually a re-stake of principal) and **~22,626 NEAR of staking income all-time** — the real figure is **~380**.

## Root causes
1. The accounting-export transaction format carries **no `method_name`** (`action_kind: TRANSFER`, `args: {}`), so the `deposit_and_stake` / `withdraw_all` detection never fired.
2. `mergeStakingEntries` keyed by `block_height` and kept stale RPC-path entries whose `earnings` equalled the deposit — the comment literally said *"earnings already set — no recalculation needed."*
3. Transient `balance=0` snapshots on a re-stake.

**Note vs #68:** the issue pins the bug on the RPC path (`fetchAllStakingEarnings`) and says the V2 accounting-export path already handles it. But the affected stored data here is **entirely `_source: accounting-export`** and still wrong — because the merge kept stale entries and skipped recomputation. So the fix is applied as a re-derivation over the merged series (and at read time), which corrects **both** the RPC and accounting-export paths without touching `fetchAllStakingEarnings`.

## Fix
`recomputeStakingEarnings` derives earnings from the **balance series** instead of trusting per-entry values — the same principle #68 proposes:
- a **transaction** (entry has a `hash`) → its balance change is a deposit/withdrawal, earnings 0;
- **reward accrual** (a plain snapshot, no hash) → earnings = the balance increase.

Summed, this is `finalBalance + withdrawals − deposits` — robust to missing method names, merge staleness, and 0-balance blips. Applied in:
- `mergeStakingEntries` — future imports are correct;
- the year report's read path — **existing data is corrected without a re-import**.

## Verified against a real account
| | booked (old) | re-derived |
|---|---|---|
| a validator pool's reward | 18,706 | **0** |
| all-pool staking income (all-time) | 22,626 | **530** |

Already-correct pools are unchanged. Matches the pattern in #68 (partial withdraw + re-stake on the same day booked as earnings).

## Test
`staking-earnings.spec.js` (deposits→principal, snapshot creep→reward, the `final + withdrawals − deposits` identity, mid-history baseline, 0-balance re-stake blip). Updated the `mergeStakingEntries` test to the re-derived attribution. Full suite: 151 passing.

## Follow-up (not in this PR)
Read-time re-derivation gives ~530 on existing stored data; the raw accounting records give a ground-truth ~380. The residual is stale merged entries in a few pools missing hashes — a clean re-import / staking-data reset would close it. Tax impact is small (both are ~sane) vs the 22,626 that's fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)