### PR TITLE
Fix mobile hamburger menu: wire navbar toggler inside shadow DOM

### DIFF
--- a/public_html/app.js
+++ b/public_html/app.js
@@ -20,20 +20,6 @@ import { isSignedIn, loginToArizGateway, logout } from './arizgateway/arizgatewa
 const baseurl = import.meta.url.substring(0, import.meta.url.lastIndexOf('/') + 1);
 const basepath = baseurl.substring(location.origin.length);
 
-const navbarmenu = document.querySelector('#navbarNavAltMarkup');
-Array.from(document.getElementsByClassName('nav-link')).forEach(navLink => {
-    const targetPage = navLink.dataset.page;
-
-    navLink.onclick = () => {
-        goToPage(targetPage);
-        if (navbarmenu.classList.contains('navbar-collapse')) {
-            const collapse = new bootstrap.Collapse(navbarmenu);
-            collapse.hide();
-        }
-        return false;
-    }
-});
-
 class AppNearNumbersComponent extends HTMLElement {
     constructor() {
         super();
@@ -63,11 +49,22 @@ class AppNearNumbersComponent extends HTMLElement {
             }
         }
 
+        // The navbar lives in this component's shadow DOM, so Bootstrap's
+        // data-bs-toggle collapse handler (delegated on document) never reaches
+        // the hamburger toggler. Wire it up manually against the shadow-DOM
+        // element instead, otherwise the menu can't be opened on mobile widths.
+        const navbarCollapse = this.shadowRoot.querySelector('#navbarNavAltMarkup');
+        const navbarToggler = this.shadowRoot.querySelector('.navbar-toggler');
+        const navbarCollapseInstance = bootstrap.Collapse.getOrCreateInstance(navbarCollapse, { toggle: false });
+        navbarToggler.addEventListener('click', () => navbarCollapseInstance.toggle());
+
         this.shadowRoot.querySelectorAll('a').forEach(a => {
             if (a.dataset['page']) {
                 a.onclick = (evt) => {
                     evt.preventDefault();
                     window.goToPage(a.dataset['page']);
+                    // Collapse the mobile menu after navigating.
+                    navbarCollapseInstance.hide();
                 }
             }
         });


### PR DESCRIPTION
The navbar is rendered inside the `app-near-account-report` shadow DOM, so Bootstrap's `data-bs-toggle="collapse"` handler (delegated on `document`) never reached the toggler — the hamburger button did nothing at mobile widths (below the `md` breakpoint).

Fix: wire the toggler to a `bootstrap.Collapse` instance directly against the shadow-DOM element, and collapse the menu after a nav link is clicked. Also removes dead top-level code that queried the light DOM (it returned null because the navbar lives in the shadow root).

Verified in the browser: a real click on the toggler now adds the `show` class and opens the menu, and clicking a nav link closes it again.