### PR TITLE
web4: path-aware bodyUrl (same-origin /sw.js for encrypted git sync)

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -36,14 +36,17 @@ IMPORTANT: pushing to `ariz-gateway` `main` auto-deploys to production via Fly �
 
 ## Contract (rare)
 
-`arizportfolio.near` runs a minimal 126-byte WAT contract whose `web4_get` returns
-the `bodyUrl` (it replaced the old 123 KB Rust contract, freeing ~1.2 NEAR). You
-only need to redeploy it to repoint the gateway URL.
+`arizportfolio.near` runs a minimal ~450-byte WAT contract whose `web4_get` returns
+a **path-aware** `bodyUrl` (`https://arizgateway.fly.dev<path>`), so per-path assets
+like `/sw.js` are served same-origin with the right MIME type while SPA routes hit
+the gateway's index.html fallback (it replaced the old 123 KB Rust contract, freeing
+~1.2 NEAR). You only need to redeploy it to repoint the gateway URL.
 
 1. Rebuild — regenerates `web4contract/web4contract.wat` + `.wasm` (both gitignored;
    `web4contract.wat.js` is the source). Override the URL with `WEB4_BODY_URL`:
    ```
    node web4contract/web4contract.wat.js
+   node --test web4contract/web4contract.test.mjs   # mocked NEAR host — must pass before deploying
    ```
 2. Deploy (confirm the wasm size and the mainnet deploy first):
    ```

--- a/web4contract/web4contract.test.mjs
+++ b/web4contract/web4contract.test.mjs
@@ -1,0 +1,81 @@
+// Local harness for the path-aware web4 WAT contract: instantiates the wasm with
+// mocked NEAR host functions (input register + value_return) and asserts the
+// bodyUrl for the request shapes the web4 gateway sends. Run before any deploy:
+//   node web4contract/web4contract.wat.js && node --test web4contract/web4contract.test.mjs
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const wasmBytes = await readFile(new URL('./web4contract.wasm', import.meta.url));
+const GATEWAY = 'https://arizgateway.fly.dev';
+
+// One fresh instance per call (the contract is stateless, but keep tests isolated).
+async function web4Get(argsJson) {
+    let inputBytes = new TextEncoder().encode(argsJson);
+    let returned = null;
+    let memory; // assigned after instantiate; host fns run only during the call
+    const env = {
+        input: (_registerId) => {},
+        register_len: (_registerId) => BigInt(inputBytes.length),
+        read_register: (_registerId, ptr) => {
+            new Uint8Array(memory.buffer).set(inputBytes, Number(ptr));
+        },
+        value_return: (len, ptr) => {
+            returned = new TextDecoder().decode(
+                new Uint8Array(memory.buffer).slice(Number(ptr), Number(ptr) + Number(len)));
+        },
+    };
+    const { instance } = await WebAssembly.instantiate(wasmBytes, { env });
+    memory = instance.exports.memory;
+    instance.exports.web4_get();
+    return returned;
+}
+
+// The request shape the web4 gateway sends (per the web4 spec / observed panics
+// from the previous Rust contract wanting a `request` wrapper).
+const gatewayArgs = (path) => JSON.stringify({
+    request: { accountId: null, path, params: {}, query: {}, preloads: null },
+});
+
+describe('path-aware web4 contract', () => {
+    test('root', async () => {
+        assert.equal(await web4Get(gatewayArgs('/')), `{"bodyUrl":"${GATEWAY}/"}`);
+    });
+
+    test('service worker path (the reason for this contract)', async () => {
+        assert.equal(await web4Get(gatewayArgs('/sw.js')), `{"bodyUrl":"${GATEWAY}/sw.js"}`);
+    });
+
+    test('SPA route', async () => {
+        assert.equal(await web4Get(gatewayArgs('/portfolio')), `{"bodyUrl":"${GATEWAY}/portfolio"}`);
+    });
+
+    test('nested path with extension', async () => {
+        assert.equal(await web4Get(gatewayArgs('/assets/app.css')), `{"bodyUrl":"${GATEWAY}/assets/app.css"}`);
+    });
+
+    test('key order does not matter (path last)', async () => {
+        const args = JSON.stringify({ request: { query: {}, path: '/x.js' } });
+        assert.equal(await web4Get(args), `{"bodyUrl":"${GATEWAY}/x.js"}`);
+    });
+
+    test('no path -> falls back to /', async () => {
+        assert.equal(await web4Get('{}'), `{"bodyUrl":"${GATEWAY}/"}`);
+    });
+
+    test('empty input -> falls back to /', async () => {
+        assert.equal(await web4Get(''), `{"bodyUrl":"${GATEWAY}/"}`);
+    });
+
+    test('oversized path is truncated, output stays valid JSON', async () => {
+        const out = await web4Get(gatewayArgs('/' + 'a'.repeat(10_000)));
+        const parsed = JSON.parse(out); // must not corrupt framing
+        assert.ok(parsed.bodyUrl.startsWith(`${GATEWAY}/aaa`));
+        assert.ok(out.length < 3000, 'output capped before the pattern region');
+    });
+
+    test('oversized input (register bigger than memory headroom) -> falls back to /', async () => {
+        const big = JSON.stringify({ request: { path: '/x', pad: 'p'.repeat(70_000) } });
+        assert.equal(await web4Get(big), `{"bodyUrl":"${GATEWAY}/"}`);
+    });
+});

--- a/web4contract/web4contract.wat.js
+++ b/web4contract/web4contract.wat.js
@@ -2,40 +2,114 @@ import { writeFile } from 'fs/promises';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
-// Minimal web4 contract for arizportfolio.near.
+// Minimal web4 contract for arizportfolio.near — PATH-AWARE bodyUrl.
 //
-// web4_get returns a fixed `bodyUrl`, so the NEAR web4 gateway (*.near.page)
-// fetches the frontend bundle from the Ariz gateway server-side and serves it
-// under the arizportfolio.near.page origin. That keeps the app on .near.page
-// (URL unchanged, OPFS/IndexedDB data preserved) - it is NOT a client-side
-// redirect to fly.dev.
+// web4_get extracts `path` from the request JSON and returns
+//   {"bodyUrl":"<GATEWAY><path>"}
+// so the NEAR web4 gateway (*.near.page) fetches each path from the Ariz gateway
+// server-side and serves it under the arizportfolio.near.page origin:
+//   /            -> gateway /            -> index.html (the app bundle)
+//   /portfolio   -> gateway /portfolio   -> index.html (gateway SPA fallback)
+//   /sw.js       -> gateway /sw.js       -> the service worker, served as
+//                                           application/javascript (required for
+//                                           navigator.serviceWorker.register)
 //
-// This replaces the previous ~123 KB Rust contract (whose token-registry methods
-// are unused) with a ~0.6 KB wasm that does the one thing still needed, freeing
-// ~1.2 NEAR of storage staking. The contract reads no input, so web4_get can
-// never panic on a malformed request.
+// The per-path bodyUrl is what makes same-origin assets like the encrypted-git
+// service worker possible (a SW must be same-origin with a JS MIME type); the
+// previous fixed-bodyUrl contract served index.html for every path.
 //
-// Override the target with WEB4_BODY_URL when building for a different gateway.
-const BODY_URL = process.env.WEB4_BODY_URL || 'https://arizgateway.fly.dev/';
+// Implementation: scan the input JSON for the first `"path":"` and copy the
+// string value (up to the next '"') onto the URL prefix. If no path is found,
+// fall back to "/". Written as raw WAT (~0.6 KB wasm) to keep storage staking
+// minimal. Memory layout:
+//   0..     output buffer (starts with the URL prefix from the data segment)
+//   3000..  the 8-byte pattern `"path":"`
+//   4096..  the request JSON (copied from the input register)
+//
+// Override the target with WEB4_BODY_URL when building for a different gateway
+// (no trailing slash — the request path always starts with one).
+const BODY_URL = (process.env.WEB4_BODY_URL || 'https://arizgateway.fly.dev').replace(/\/$/, '');
 
-const web4jsonstring = JSON.stringify({ bodyUrl: BODY_URL });
+const PREFIX = `{"bodyUrl":"${BODY_URL}`;
+const PREFIX_LEN = PREFIX.length;
+const PATTERN = '"path":"';
+const OUT_BASE = 0;
+const PATTERN_BASE = 3000;
+const INPUT_BASE = 4096;
+// Stop copying before the pattern/input areas so a pathological path can't
+// overwrite the region we're still reading from.
+const OUT_MAX = PATTERN_BASE - 8;
 
-// Each wasm memory page is 64 KiB; the body is tiny but keep the math general.
-const memoryPages = Math.max(1, Math.ceil(web4jsonstring.length / 65536));
+const esc = (s) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
-// Escape for a wat data-string literal (backslash and double-quote only).
-const escaped = web4jsonstring.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-
-// value_return(value_len, value_ptr): return memory[0 .. len] as the view result.
 const wat = `(module
+    (import "env" "input" (func $input (param i64)))
+    (import "env" "register_len" (func $register_len (param i64) (result i64)))
+    (import "env" "read_register" (func $read_register (param i64 i64)))
     (import "env" "value_return" (func $value_return (param i64 i64)))
+    (memory (export "memory") 1)
+    (data (i32.const ${OUT_BASE}) "${esc(PREFIX)}")
+    (data (i32.const ${PATTERN_BASE}) "${esc(PATTERN)}")
     (func (export "web4_get")
-      i64.const ${web4jsonstring.length}
-      i64.const 0
-      call $value_return
+        (local $inLen i32) (local $i i32) (local $j i32) (local $out i32) (local $c i32)
+
+        ;; Copy the request JSON from the input register into memory at INPUT_BASE.
+        (call $input (i64.const 0))
+        (local.set $inLen (i32.wrap_i64 (call $register_len (i64.const 0))))
+        ;; Cap absurd inputs so read_register can never write past the memory page
+        ;; (the web4 gateway sends small JSON; anything bigger just gets "/").
+        (if (i32.gt_s (local.get $inLen) (i32.const ${65536 - INPUT_BASE}))
+            (then (local.set $inLen (i32.const 0)))
+            (else (call $read_register (i64.const 0) (i64.const ${INPUT_BASE}))))
+
+        (local.set $out (i32.const ${PREFIX_LEN}))
+        (local.set $i (i32.const 0))
+
+        (block $notfound
+            (loop $scan
+                (br_if $notfound (i32.gt_s (i32.add (local.get $i) (i32.const ${PATTERN.length})) (local.get $inLen)))
+                (block $nomatch
+                    ;; compare PATTERN.length bytes at INPUT_BASE+i with the pattern
+                    (local.set $j (i32.const 0))
+                    (loop $cmp
+                        (br_if $nomatch (i32.ne
+                            (i32.load8_u (i32.add (i32.add (i32.const ${INPUT_BASE}) (local.get $i)) (local.get $j)))
+                            (i32.load8_u (i32.add (i32.const ${PATTERN_BASE}) (local.get $j)))))
+                        (local.set $j (i32.add (local.get $j) (i32.const 1)))
+                        (br_if $cmp (i32.lt_s (local.get $j) (i32.const ${PATTERN.length})))
+                    )
+                    ;; matched: copy the path value until the closing quote
+                    (local.set $i (i32.add (local.get $i) (i32.const ${PATTERN.length})))
+                    (block $donecopy
+                        (loop $copy
+                            (br_if $donecopy (i32.ge_s (local.get $i) (local.get $inLen)))
+                            (local.set $c (i32.load8_u (i32.add (i32.const ${INPUT_BASE}) (local.get $i))))
+                            (br_if $donecopy (i32.eq (local.get $c) (i32.const 34))) ;; '"'
+                            (br_if $donecopy (i32.ge_s (local.get $out) (i32.const ${OUT_MAX})))
+                            (i32.store8 (local.get $out) (local.get $c))
+                            (local.set $out (i32.add (local.get $out) (i32.const 1)))
+                            (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                            (br $copy)
+                        )
+                    )
+                    ;; close the JSON: '"' '}' and return
+                    (i32.store8 (local.get $out) (i32.const 34))
+                    (i32.store8 (i32.add (local.get $out) (i32.const 1)) (i32.const 125))
+                    (call $value_return
+                        (i64.extend_i32_u (i32.add (local.get $out) (i32.const 2)))
+                        (i64.const ${OUT_BASE}))
+                    (return)
+                )
+                (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                (br $scan)
+            )
+        )
+        ;; no "path":" found — default to "/"
+        (i32.store8 (i32.const ${PREFIX_LEN}) (i32.const 47))      ;; '/'
+        (i32.store8 (i32.const ${PREFIX_LEN + 1}) (i32.const 34))  ;; '"'
+        (i32.store8 (i32.const ${PREFIX_LEN + 2}) (i32.const 125)) ;; '}'
+        (call $value_return (i64.const ${PREFIX_LEN + 3}) (i64.const ${OUT_BASE}))
     )
-    (memory ${memoryPages})
-    (data (i32.const 0) "${escaped}")
 )
 `;
 
@@ -45,5 +119,5 @@ const wasmPath = fileURLToPath(new URL('web4contract.wasm', import.meta.url));
 await writeFile(watPath, wat);
 execFileSync('wat2wasm', [watPath, '-o', wasmPath]);
 
-console.log(`web4_get -> ${web4jsonstring} (${web4jsonstring.length} bytes)`);
+console.log(`web4_get -> {"bodyUrl":"${BODY_URL}<path>"} (path-aware)`);
 console.log(`built ${wasmPath}`);


### PR DESCRIPTION
Part of #76. A service worker must be served **same-origin with a JS MIME type** — but the fixed-bodyUrl web4 contract returned index.html for every path, so `arizportfolio.near.page/sw.js` could never work.

## Change
- `web4_get` now extracts `path` from the request JSON and returns `{"bodyUrl":"https://arizgateway.fly.dev<path>"}` (444-byte WAT). Falls back to `/` when no path is present; output is capped and input length-guarded.
- `/sw.js` → the gateway's real file (`application/javascript`, served statically); SPA routes → the gateway's index.html fallback, unchanged behavior.
- New `web4contract.test.mjs`: runs the wasm against **mocked NEAR host functions** (9 tests: gateway request shapes, key order, fallbacks, oversized path/input guards). Wired into the `/deploy` skill docs as a pre-deploy gate.
- Gateway side (already pushed to ariz-gateway): serve `sw.js` (encrypted-git-storage v0.1.0 `dist/sw.js`) from `server/public`.

## Deployed + verified
- Mainnet tx `CKqcjQ1YZ28L6YJwEz3j3s3m2Y32J5qPk9iS4djKhDE9`; on-chain `web4_get` returns per-path bodyUrls.
- `arizportfolio.near.page`: `/`, `/portfolio(/)`, `/year-report`, `/storage`, `/transactions` all 200 `text/html`; **`/sw.js` 200 `application/javascript`**, byte-identical to the gateway copy. Stable over repeated sweeps (brief 400 flapping right after deploy was the web4 gateway's per-path cache expiring, max-age=60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)