### PR TITLE
docs + landing: data custody model (convenience sync, reads free on lapsed billing)

### DIFF
--- a/docs/encrypted-storage.md
+++ b/docs/encrypted-storage.md
@@ -136,6 +136,29 @@ git clone egit::https://arizgateway.fly.dev/store/me
 `me` resolves to your blinded store server-side — you never need to know the
 actual storage path.
 
+## Your data, your custody
+
+The gateway's storage is a **convenience service** — it exists so you can sync
+and restore your repository across devices. It is not the system of record:
+**you are the custodian of your data.** Keep your own copy (the local repository
+in your browser counts; a clone on another device or an exported archive is
+better) and keep your encryption key exported somewhere safe.
+
+This is a deliberate departure from traditional cloud services, where the
+operator can see, inspect, and usually recover your data for you. Here the
+operator can do none of those things — which means more privacy and control for
+you, and also more responsibility: **nobody can reset a lost key.**
+
+Two commitments follow from this model:
+
+- **Getting your data out is always free.** If your ARIZ balance lapses, writes
+  to the store are paused, but reading/cloning your own data remains available —
+  a backup is never held hostage to billing.
+- Even so, do not treat the server as your only copy — especially for a lapsed
+  account. The store guarantees the operator *cannot read* your data; it cannot
+  guarantee eternal availability of any single replica. Your key + any clone is
+  full recovery.
+
 ## Honest limitations
 
 - **Traffic metadata**: the gateway (not the public) can see that your account

--- a/public_html/app.html.js
+++ b/public_html/app.html.js
@@ -96,6 +96,9 @@ export default /*html*/ `
         configuration and the calculations of the software. Users should verify the correctness of
         the calculations and ensure that all relevant data is collected — the software does not
         guarantee correctness in calculations or accuracy and completeness in the underlying data.
+        Your data stays in your custody: server-side storage is a convenience for syncing between
+        devices, and encrypted data can never be read or recovered by the operator — keep your own
+        copy of your data and your encryption key.
         The source code is open and available at
         <a href="https://github.com/arizas/Ariz-Portfolio" target="_blank" rel="noopener noreferrer">
             <i class="bi bi-github"></i> github.com/arizas/Ariz-Portfolio</a>.


### PR DESCRIPTION
Companion to arizas/ariz-gateway#41 (reads stay available to lapsed-billing accounts).

- **docs/encrypted-storage.md**: new "Your data, your custody" section — the store is a convenience sync service, the user is the custodian; getting data out is always free, but don't treat the server as the only copy; contrast with traditional cloud (operator can't see, inspect, or recover).
- **Landing disclaimer**: one added sentence advising users to keep their own copy of data + key, since the operator can never read or recover encrypted data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)