### PR TITLE
Encryption key module: wallet-unlocked wrapped master key (DEK/KEK)

### DIFF
--- a/public_html/arizgateway/arizgatewayaccess.js
+++ b/public_html/arizgateway/arizgatewayaccess.js
@@ -67,6 +67,19 @@ export async function getAccountId() {
 }
 
 /**
+ * NEP-413 signMessage through the connected wallet (or the injected test
+ * wallet). Used for gateway auth tokens and for encryption-key derivation
+ * (encryptionkey.js) — the latter with its own fixed nonce and a recipient
+ * distinct from the auth recipient, so the two signatures can never stand in
+ * for each other.
+ */
+export async function signMessageWithWallet({ message, recipient, nonce }) {
+    const wallet = await currentWallet();
+    if (!wallet) throw new Error('Not signed in to the Ariz gateway');
+    return wallet.signMessage({ message, recipient, nonce });
+}
+
+/**
  * Sign and send a transaction through the connected wallet (NEAR Connect).
  * Prompts a login first if not connected. `actions` use the wallet-selector
  * shape, e.g. [{ type: 'FunctionCall', params: { methodName, args, gas, deposit } }].

--- a/public_html/arizgateway/encryptionkey.js
+++ b/public_html/arizgateway/encryptionkey.js
@@ -1,0 +1,225 @@
+import { arizgatewayhost, getAccessToken, signMessageWithWallet } from './arizgatewayaccess.js';
+
+// Wallet-unlocked master key for the encrypted repository store.
+// Design + threat model: docs/encrypted-storage.md ("Your key") and issue #76.
+//
+// The repo is encrypted with a random master key (DEK), never derived from any
+// signature. Each enrolled wallet key unlocks it:
+//
+//   fixed NEP-413 message ──wallet sign──> deterministic signature
+//     ──HKDF──> KEK (unwraps the DEK) + wrapId (where the wrap lives)
+//
+// The wrap — AES-256-GCM(KEK, DEK) — is stored at /store/me/keys/<wrapId>.
+// wrapId is derived from the signature, NOT the public key: access keys are
+// public on-chain, so pk-named blobs would let a bucket-level observer map
+// stores back to accounts. Only someone who can produce the signature can even
+// compute which blob to look for.
+//
+// Signatures and the DEK live in memory only; nothing key-related is persisted
+// in the browser. Wallets with non-deterministic (hedged) ed25519 can't serve
+// as a KEK source — enrollment signs twice and compares, and such devices use
+// the exported DEK instead.
+
+// Distinct from the auth recipient (arizportfolio.near) so a derivation
+// signature can never double as a gateway login token, and vice versa.
+const DERIVATION_RECIPIENT = 'encrypted-storage.arizportfolio.near';
+const DERIVATION_MESSAGE =
+    'Unlock your encrypted Ariz Portfolio storage.\n\n'
+    + 'Signing this message derives the key that protects your synced data. '
+    + 'Only sign it on arizportfolio.near.page or a client you trust.';
+// NEP-413 requires a 32-byte nonce; a FIXED one makes the signature (and thus
+// the derived KEK) reproducible across sessions and devices. 32 ASCII bytes:
+const DERIVATION_NONCE = new TextEncoder().encode('ariz-encrypted-storage-nonce-v1!');
+
+const HKDF_SALT = new TextEncoder().encode('ariz-egit-salt-v1');
+const INFO_KEK = 'ariz-egit-kek-v1';
+const INFO_WRAP_ID = 'ariz-egit-wrap-id-v1';
+
+export const DEK_BYTES = 32;
+const GCM_IV_BYTES = 12;
+
+/** Thrown when the store already has data but no wrap exists for this wallet
+ *  key (or the DEK it unwraps doesn't fit) — the caller must enroll this device
+ *  by importing the exported key (or unlocking via an already-enrolled wallet). */
+export class NeedsEnrollmentError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'NeedsEnrollmentError';
+    }
+}
+
+/** Thrown when the wallet's signatures over the same message differ — a
+ *  hedged/randomized ed25519 signer that can never re-derive its KEK. */
+export class NonDeterministicSignerError extends Error {
+    constructor() {
+        super('This wallet produces a different signature each time, so it cannot unlock the encrypted store by signing. Import your exported key on this device instead.');
+        this.name = 'NonDeterministicSignerError';
+    }
+}
+
+const b64ToBytes = (b64) => Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+export const bytesToHex = (bytes) => [...bytes].map(b => b.toString(16).padStart(2, '0')).join('');
+export const hexToBytes = (hex) => Uint8Array.from(hex.match(/../g) ?? [], h => parseInt(h, 16));
+
+async function hkdf(ikm, info, length) {
+    const key = await crypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits']);
+    const bits = await crypto.subtle.deriveBits(
+        { name: 'HKDF', hash: 'SHA-256', salt: HKDF_SALT, info: new TextEncoder().encode(info) },
+        key, length * 8);
+    return new Uint8Array(bits);
+}
+
+/**
+ * Sign the fixed derivation message and derive { kek, wrapId }. Signs TWICE and
+ * compares: RFC 8032 ed25519 is deterministic, but hedged implementations exist,
+ * and a non-deterministic signer would enroll fine and then never be able to
+ * unlock again.
+ */
+export async function deriveKeyMaterial() {
+    const sign = () => signMessageWithWallet({
+        message: DERIVATION_MESSAGE,
+        recipient: DERIVATION_RECIPIENT,
+        nonce: DERIVATION_NONCE,
+    });
+    const first = await sign();
+    const second = await sign();
+    if (first.signature !== second.signature || first.publicKey !== second.publicKey) {
+        throw new NonDeterministicSignerError();
+    }
+    const ikm = b64ToBytes(first.signature);
+    const kek = await hkdf(ikm, INFO_KEK, 32);
+    const wrapId = bytesToHex(await hkdf(ikm, INFO_WRAP_ID, 16));
+    return { kek, wrapId };
+}
+
+async function aesGcm(mode, keyBytes, iv, data) {
+    const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM' }, false, [mode]);
+    return new Uint8Array(await crypto.subtle[mode]({ name: 'AES-GCM', iv }, key, data));
+}
+
+/** AES-256-GCM wrap of the DEK: iv || ciphertext+tag. */
+export async function wrapDek(kek, dek) {
+    const iv = crypto.getRandomValues(new Uint8Array(GCM_IV_BYTES));
+    const ct = await aesGcm('encrypt', kek, iv, dek);
+    const out = new Uint8Array(iv.length + ct.length);
+    out.set(iv); out.set(ct, iv.length);
+    return out;
+}
+
+export async function unwrapDek(kek, blob) {
+    const bytes = new Uint8Array(blob);
+    return aesGcm('decrypt', kek, bytes.subarray(0, GCM_IV_BYTES), bytes.subarray(GCM_IV_BYTES));
+}
+
+// --- store access (wraps + repo-existence probe), NEP-413-authenticated -------
+
+async function storeFetch(path, init = {}) {
+    const token = await getAccessToken();
+    return fetch(`${arizgatewayhost}/store/me${path}`, {
+        ...init,
+        headers: { ...(init.headers ?? {}), authorization: `Bearer ${token}` },
+    });
+}
+
+async function fetchWrap(wrapId) {
+    const res = await storeFetch(`/keys/${wrapId}`);
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`fetching key wrap failed: ${res.status}`);
+    return new Uint8Array(await res.arrayBuffer());
+}
+
+async function putWrap(wrapId, blob) {
+    const res = await storeFetch(`/keys/${wrapId}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/octet-stream' },
+        body: blob,
+    });
+    if (res.status === 412) return false; // raced — a wrap now exists; caller re-fetches
+    if (!res.ok) throw new Error(`storing key wrap failed: ${res.status}`);
+    return true;
+}
+
+async function repoExists() {
+    const res = await storeFetch('/refs');
+    if (res.status === 404) return false;
+    if (!res.ok) throw new Error(`probing encrypted store failed: ${res.status}`);
+    return true;
+}
+
+// The DEK is held in memory only, for this session.
+let _dek = null;
+
+export function currentDek() {
+    return _dek;
+}
+
+export function currentDekHex() {
+    return _dek ? bytesToHex(_dek) : null;
+}
+
+export function __clearDekForTests() {
+    _dek = null;
+}
+
+/**
+ * Obtain the DEK for the encrypted store, walking the full enrollment flow:
+ *
+ *  1. wallet signature -> { kek, wrapId } (deterministic, verified)
+ *  2. wrap exists  -> unwrap -> DEK
+ *  3. no wrap, repo data exists -> NeedsEnrollmentError (this wallet key isn't
+ *     enrolled — import the exported key, or unlock with an enrolled wallet)
+ *  4. no wrap, empty store -> FIRST SETUP: mint a random DEK, store the wrap.
+ *     Create-only PUT means a concurrent first-setup on another device can't
+ *     mint a second DEK for the same wrapId (412 -> re-fetch + unwrap); a race
+ *     between DIFFERENT wallet keys is caught at the refs CAS and surfaces as a
+ *     manifest that won't decrypt -> NeedsEnrollmentError on the next call.
+ */
+export async function obtainDek() {
+    if (_dek) return _dek;
+    const { kek, wrapId } = await deriveKeyMaterial();
+
+    let wrap = await fetchWrap(wrapId);
+    if (!wrap) {
+        if (await repoExists()) {
+            throw new NeedsEnrollmentError(
+                'The encrypted store already contains data, but this wallet key is not enrolled. Import your exported key on this device (Storage page) to enroll it.');
+        }
+        const dek = crypto.getRandomValues(new Uint8Array(DEK_BYTES));
+        if (await putWrap(wrapId, await wrapDek(kek, dek))) {
+            _dek = dek;
+            return _dek;
+        }
+        wrap = await fetchWrap(wrapId); // lost the race; use the winner's wrap
+        if (!wrap) throw new Error('key wrap race lost but no wrap found — retry');
+    }
+    try {
+        _dek = await unwrapDek(kek, wrap);
+    } catch {
+        throw new NeedsEnrollmentError(
+            'The stored key wrap for this wallet could not be opened — enroll this device by importing your exported key (Storage page).');
+    }
+    return _dek;
+}
+
+/**
+ * Enroll this device/wallet key with an exported DEK (from another device's
+ * "export key"): verifies nothing about the DEK itself here — the first
+ * decrypt of the refs manifest is the proof — but stores a wrap so this wallet
+ * can unlock by signing from now on.
+ */
+export async function enrollWithExportedKey(dekHex) {
+    const dek = hexToBytes(dekHex.trim());
+    if (dek.length !== DEK_BYTES) throw new Error(`the exported key must be ${DEK_BYTES * 2} hex characters`);
+    const { kek, wrapId } = await deriveKeyMaterial();
+    const stored = await putWrap(wrapId, await wrapDek(kek, dek));
+    if (!stored) {
+        // A wrap already exists for this wallet key — sanity-check it opens to
+        // the same DEK (otherwise the imported key is wrong for this store).
+        const existing = await unwrapDek(kek, await fetchWrap(wrapId)).catch(() => null);
+        if (!existing || bytesToHex(existing) !== bytesToHex(dek)) {
+            throw new Error('a different key is already enrolled for this wallet — the imported key does not match this store');
+        }
+    }
+    _dek = dek;
+    return _dek;
+}

--- a/public_html/arizgateway/encryptionkey.spec.js
+++ b/public_html/arizgateway/encryptionkey.spec.js
@@ -1,0 +1,184 @@
+import {
+    ACCESS_TOKEN_SESSION_STORAGE_KEY,
+    __setTestWallet,
+    arizgatewayhost,
+} from './arizgatewayaccess.js';
+import {
+    obtainDek, enrollWithExportedKey, deriveKeyMaterial,
+    wrapDek, unwrapDek, currentDekHex, __clearDekForTests,
+    bytesToHex, hexToBytes,
+    NeedsEnrollmentError, NonDeterministicSignerError, DEK_BYTES,
+} from './encryptionkey.js';
+
+// Deterministic fake wallet: a fixed fake "signature" per (accountId, message,
+// recipient) — enough for derivation, which never verifies signatures.
+function fakeWallet(accountId, { hedged = false } = {}) {
+    let counter = 0;
+    __setTestWallet({
+        accountId,
+        async getAccounts() { return [{ accountId }]; },
+        async signMessage({ message, recipient }) {
+            const seed = `${accountId}|${recipient}|${message}${hedged ? `|${counter++}` : ''}`;
+            const bytes = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed)));
+            const sig = new Uint8Array(64);
+            sig.set(bytes); sig.set(bytes, 32);
+            return {
+                accountId,
+                publicKey: 'ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi',
+                signature: btoa(String.fromCharCode(...sig)),
+            };
+        },
+        async signOut() {},
+    });
+}
+
+// In-memory mock of the gateway's /store/me wraps + refs-probe endpoints.
+function mockStore() {
+    const state = { wraps: new Map(), refsExists: false, unauthorized: false };
+    const realFetch = window.fetch;
+    window.fetch = async (url, init = {}) => {
+        const u = String(url);
+        if (!u.startsWith(`${arizgatewayhost}/store/me`)) return realFetch(url, init);
+        if (state.unauthorized) return new Response('failed to parse token', { status: 401 });
+        const path = u.slice(`${arizgatewayhost}/store/me`.length);
+        if (path === '/refs') {
+            return state.refsExists
+                ? new Response(new Uint8Array([1]), { status: 200 })
+                : new Response('{"error":"not found"}', { status: 404 });
+        }
+        const wrapMatch = path.match(/^\/keys\/([0-9a-f]{32})$/);
+        if (wrapMatch) {
+            const id = wrapMatch[1];
+            if ((init.method ?? 'GET') === 'GET') {
+                const wrap = state.wraps.get(id);
+                return wrap
+                    ? new Response(wrap, { status: 200 })
+                    : new Response('{"error":"not found"}', { status: 404 });
+            }
+            if (init.method === 'PUT') {
+                if (state.wraps.has(id)) return new Response('{"error":"wrap already exists"}', { status: 412 });
+                state.wraps.set(id, new Uint8Array(await new Response(init.body).arrayBuffer()));
+                return new Response(null, { status: 204 });
+            }
+        }
+        return new Response('unexpected', { status: 500 });
+    };
+    state.restore = () => { window.fetch = realFetch; };
+    return state;
+}
+
+describe('encryptionkey (wrapped-DEK wallet unlock)', () => {
+    let store;
+
+    beforeEach(() => {
+        __clearDekForTests();
+        // Seed a fresh cached auth token so getAccessToken never re-signs (keeps
+        // the signature counting in these specs to derivation signatures only).
+        localStorage.setItem(ACCESS_TOKEN_SESSION_STORAGE_KEY,
+            JSON.stringify({ token: 'test-token', accountId: 'alice.near', issuedAt: Date.now() }));
+        store = mockStore();
+    });
+
+    afterEach(() => {
+        store.restore();
+        __setTestWallet(null);
+        localStorage.removeItem(ACCESS_TOKEN_SESSION_STORAGE_KEY);
+    });
+
+    it('derivation is deterministic and account/recipient-scoped', async () => {
+        fakeWallet('alice.near');
+        const a = await deriveKeyMaterial();
+        const b = await deriveKeyMaterial();
+        expect(bytesToHex(a.kek)).to.equal(bytesToHex(b.kek));
+        expect(a.wrapId).to.equal(b.wrapId);
+        expect(a.wrapId).to.match(/^[0-9a-f]{32}$/);
+        // KEK and wrapId must not be trivially related.
+        expect(bytesToHex(a.kek)).to.not.contain(a.wrapId);
+
+        fakeWallet('bob.near');
+        const c = await deriveKeyMaterial();
+        expect(c.wrapId).to.not.equal(a.wrapId);
+    });
+
+    it('rejects a non-deterministic (hedged) signer', async () => {
+        fakeWallet('alice.near', { hedged: true });
+        try {
+            await deriveKeyMaterial();
+            expect.fail('should have thrown');
+        } catch (e) {
+            expect(e).to.be.instanceOf(NonDeterministicSignerError);
+        }
+    });
+
+    it('wrap/unwrap round-trips and rejects a wrong KEK', async () => {
+        const kek = crypto.getRandomValues(new Uint8Array(32));
+        const dek = crypto.getRandomValues(new Uint8Array(DEK_BYTES));
+        const wrap = await wrapDek(kek, dek);
+        expect(bytesToHex(await unwrapDek(kek, wrap))).to.equal(bytesToHex(dek));
+        let failed = false;
+        await unwrapDek(crypto.getRandomValues(new Uint8Array(32)), wrap).catch(() => { failed = true; });
+        expect(failed).to.equal(true);
+    });
+
+    it('first setup: mints a DEK and stores a wrap; second session unlocks the same DEK', async () => {
+        fakeWallet('alice.near');
+        const dek1 = await obtainDek();
+        expect(dek1.length).to.equal(DEK_BYTES);
+        expect(store.wraps.size).to.equal(1);
+
+        __clearDekForTests(); // "new session", same wallet
+        const dek2 = await obtainDek();
+        expect(bytesToHex(dek2)).to.equal(bytesToHex(dek1));
+        expect(store.wraps.size).to.equal(1);
+    });
+
+    it('a second wallet key on an existing store needs enrollment, then unlocks by signing', async () => {
+        fakeWallet('alice.near');
+        const dek = await obtainDek();
+        store.refsExists = true; // the first device has pushed data
+
+        __clearDekForTests();
+        fakeWallet('alice-ledger.near'); // different signer -> different KEK/wrapId
+        try {
+            await obtainDek();
+            expect.fail('should have required enrollment');
+        } catch (e) {
+            expect(e).to.be.instanceOf(NeedsEnrollmentError);
+        }
+
+        // Enroll with the exported key -> a second wrap; from now on signing works.
+        await enrollWithExportedKey(bytesToHex(dek));
+        expect(store.wraps.size).to.equal(2);
+
+        __clearDekForTests();
+        expect(bytesToHex(await obtainDek())).to.equal(bytesToHex(dek));
+        expect(currentDekHex()).to.equal(bytesToHex(dek));
+    });
+
+    it('first-setup race: the losing PUT re-fetches and unwraps the winner\'s DEK', async () => {
+        fakeWallet('alice.near');
+        // Pre-store a wrap for alice's wrapId as if another tab/device just won.
+        const { kek, wrapId } = await deriveKeyMaterial();
+        const winnerDek = crypto.getRandomValues(new Uint8Array(DEK_BYTES));
+        store.wraps.set(wrapId, await wrapDek(kek, winnerDek));
+
+        const dek = await obtainDek();
+        expect(bytesToHex(dek)).to.equal(bytesToHex(winnerDek));
+        expect(store.wraps.size).to.equal(1);
+    });
+
+    it('enrolling a mismatched exported key against an existing wrap is rejected', async () => {
+        fakeWallet('alice.near');
+        await obtainDek(); // creates alice's wrap
+        __clearDekForTests();
+        let message = '';
+        await enrollWithExportedKey(bytesToHex(crypto.getRandomValues(new Uint8Array(DEK_BYTES))))
+            .catch((e) => { message = e.message; });
+        expect(message).to.contain('does not match');
+    });
+
+    it('hexToBytes/bytesToHex round-trip', () => {
+        const bytes = crypto.getRandomValues(new Uint8Array(32));
+        expect(bytesToHex(hexToBytes(bytesToHex(bytes)))).to.equal(bytesToHex(bytes));
+    });
+});


### PR DESCRIPTION
First frontend slice of #76 — the key model, exactly as settled in the design reviews.

- **Random master DEK** (never derived from a signature) encrypts the store; wallet keys unlock it: fixed NEP-413 message → deterministic signature → HKDF → **KEK + wrapId**; the AES-256-GCM **wrap** lives at `/store/me/keys/<wrapId>` (gateway PR arizas/ariz-gateway#42).
- Design-review findings implemented: domain-separated recipient (`encrypted-storage.arizportfolio.near`); wrapId from the signature, **not** the pk (de-blinding); **sign-twice determinism check** (hedged ed25519 → `NonDeterministicSignerError`, exported-key path instead); first-setup race via create-only PUT (412 → unwrap winner's DEK); `NeedsEnrollmentError` + `enrollWithExportedKey` for second wallets (Ledger + phone case); DEK/signatures in memory only.
- `signMessageWithWallet` exposed from arizgatewayaccess (near-connect + existing test hook).

**Tests:** 8 hermetic specs (fake wallet + mocked store endpoints) covering determinism/scoping, hedged rejection, wrap round-trip + wrong-KEK, first setup → re-unlock, second-wallet enrollment, setup race, mismatch rejection. Full suite: **158 passing**.

Next slices: SW registration + `egit-set-key` wiring, git-worker remote switch, Storage-page UI (enable/export/CLI), then migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)