### PR TITLE
Encrypted sync SW wiring: registration with retry + egit-set-key (#76)

### DIFF
--- a/public_html/arizgateway/encryptedsync.js
+++ b/public_html/arizgateway/encryptedsync.js
@@ -1,0 +1,110 @@
+import { arizgatewayhost, getAccessToken, getAccountId } from './arizgatewayaccess.js';
+import { obtainDek, bytesToHex } from './encryptionkey.js';
+
+// Encrypted gateway sync plumbing (issue #76).
+//
+// The egit service worker (from the encrypted-git-storage library, served at
+// /sw.js by the gateway and by the arizportfolio.near web4 contract) is the
+// browser's git-remote-egit: it intercepts wasm-git's smart-HTTP requests to
+// <origin>/egit/<account>/… and answers them from the encrypted object store at
+// <gateway>/store/me — encrypting/decrypting with the wallet-unlocked master
+// key (encryptionkey.js), so the gateway only ever sees ciphertext.
+//
+// This module registers that service worker and hands it the key + auth via
+// the library's `egit-set-key` message. The SW keeps its config in memory
+// only, and the NEP-413 bearer token expires — so configureEgitKey() must be
+// called before every encrypted sync (it re-sends the current key + a fresh
+// token; re-sending replaces the SW-side config).
+
+const SW_URL = '/sw.js';
+// near.page intermittently answers transient 400s, which fails the initial
+// register() fetch of /sw.js — retry. Already-installed SWs are unaffected.
+const REGISTER_ATTEMPTS = 5;
+const REGISTER_RETRY_DELAY_MS = 2000;
+const ACK_TIMEOUT_MS = 15000;
+
+let _testContainer = null;
+/** Test hook: inject a fake ServiceWorkerContainer. Pass null to clear. */
+export function __setTestServiceWorkerContainer(container) {
+    _testContainer = container;
+}
+const swContainer = () => _testContainer ?? navigator.serviceWorker;
+
+/**
+ * The git remote URL wasm-git should use for encrypted sync: virtual smart-HTTP
+ * under this origin, answered by the service worker. The repoId path segment
+ * must match the repoId sent in egit-set-key (the signed-in account).
+ */
+export const encryptedRemoteUrl = (accountId) => `${location.origin}/egit/${accountId}`;
+
+/**
+ * Whether this page has been service-worker controlled from the start. After a
+ * FIRST-TIME registration the SW claims the page, but workers that already
+ * existed (the wasm-git worker is created at module load) stay uncontrolled —
+ * their /egit requests would bypass the SW. Callers enabling encrypted sync
+ * for the first time should reload the page when this is false.
+ */
+export function pageIsControlled() {
+    return !!swContainer()?.controller;
+}
+
+/**
+ * Register /sw.js (module SW, scope '/'), retrying transient failures, and
+ * resolve with the ready registration (an active service worker). Safe to call
+ * repeatedly — re-registering an installed SW is a no-op.
+ */
+export async function registerEgitServiceWorker({ attempts = REGISTER_ATTEMPTS, retryDelayMs = REGISTER_RETRY_DELAY_MS } = {}) {
+    const sw = swContainer();
+    if (!sw) {
+        throw new Error('This browser does not support service workers, which encrypted sync requires');
+    }
+    let lastError;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        try {
+            await sw.register(SW_URL, { type: 'module', scope: '/' });
+            return await sw.ready;
+        } catch (e) {
+            lastError = e;
+            if (attempt < attempts) {
+                await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+            }
+        }
+    }
+    throw new Error(`Could not install the encrypted sync service worker (${attempts} attempts): ${lastError}`);
+}
+
+/**
+ * Ensure the service worker is registered and configured for the signed-in
+ * account: obtain the master key (obtainDek — may throw NeedsEnrollmentError
+ * for an unenrolled wallet key), then send `egit-set-key` with the key, the
+ * store base URL and a fresh bearer token, and await the SW's ack.
+ *
+ * Call before every encrypted sync: this refreshes the token and survives
+ * service-worker restarts (the SW's config is in-memory only).
+ */
+export async function configureEgitKey({ attempts, retryDelayMs } = {}) {
+    const registration = await registerEgitServiceWorker({ attempts, retryDelayMs });
+    const accountId = await getAccountId();
+    if (!accountId) {
+        throw new Error('Not signed in — sign in with your NEAR account to use encrypted sync');
+    }
+    const dek = await obtainDek();
+    const token = await getAccessToken();
+
+    const channel = new MessageChannel();
+    const ack = new Promise((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error('The encrypted sync service worker did not acknowledge the key')),
+            ACK_TIMEOUT_MS);
+        channel.port1.onmessage = (event) => { clearTimeout(timer); resolve(event.data); };
+    });
+    registration.active.postMessage({
+        type: 'egit-set-key',
+        repoId: accountId,
+        keyHex: bytesToHex(dek),
+        storeBaseUrl: `${arizgatewayhost}/store/me`,
+        headers: { Authorization: `Bearer ${token}` },
+    }, [channel.port2]);
+    await ack;
+    return { repoId: accountId, remoteUrl: encryptedRemoteUrl(accountId) };
+}

--- a/public_html/arizgateway/encryptedsync.spec.js
+++ b/public_html/arizgateway/encryptedsync.spec.js
@@ -1,0 +1,126 @@
+import {
+    ACCESS_TOKEN_SESSION_STORAGE_KEY,
+    __setTestWallet,
+    arizgatewayhost,
+} from './arizgatewayaccess.js';
+import { __clearDekForTests, currentDekHex, NeedsEnrollmentError } from './encryptionkey.js';
+import { fakeWallet, mockStore } from './encryptionkey.mock.js';
+import {
+    registerEgitServiceWorker, configureEgitKey, encryptedRemoteUrl,
+    __setTestServiceWorkerContainer,
+} from './encryptedsync.js';
+
+// Fake ServiceWorkerContainer: register() fails `failures` times before
+// succeeding (near.page's transient 400s), and the active worker records
+// egit-set-key messages and acks on the transferred port like the real SW.
+function fakeSwContainer({ failures = 0, ack = true } = {}) {
+    const active = {
+        messages: [],
+        postMessage(message, transfer) {
+            this.messages.push(message);
+            if (ack) transfer?.[0]?.postMessage({ type: 'egit-key-set', repoId: message.repoId });
+        },
+    };
+    return {
+        active,
+        registerCalls: [],
+        async register(url, options) {
+            this.registerCalls.push({ url, options });
+            if (this.registerCalls.length <= failures) {
+                throw new TypeError('Failed to register a ServiceWorker: bad HTTP response code (400)');
+            }
+            return {};
+        },
+        get ready() { return Promise.resolve({ active }); },
+        controller: active,
+    };
+}
+
+describe('encryptedsync (service worker registration + egit-set-key wiring)', () => {
+    let store;
+    let sw;
+
+    const seedToken = (token) => localStorage.setItem(ACCESS_TOKEN_SESSION_STORAGE_KEY,
+        JSON.stringify({ token, accountId: 'alice.near', issuedAt: Date.now() }));
+
+    beforeEach(() => {
+        __clearDekForTests();
+        seedToken('test-token');
+        store = mockStore();
+        sw = fakeSwContainer();
+        __setTestServiceWorkerContainer(sw);
+        fakeWallet('alice.near');
+    });
+
+    afterEach(() => {
+        store.restore();
+        __setTestWallet(null);
+        __setTestServiceWorkerContainer(null);
+        localStorage.removeItem(ACCESS_TOKEN_SESSION_STORAGE_KEY);
+    });
+
+    it('registers /sw.js as a module service worker at scope /', async () => {
+        await registerEgitServiceWorker();
+        expect(sw.registerCalls.length).to.equal(1);
+        expect(sw.registerCalls[0].url).to.equal('/sw.js');
+        expect(sw.registerCalls[0].options).to.deep.equal({ type: 'module', scope: '/' });
+    });
+
+    it('retries registration through transient failures (near.page 400s)', async () => {
+        sw = fakeSwContainer({ failures: 2 });
+        __setTestServiceWorkerContainer(sw);
+        const registration = await registerEgitServiceWorker({ retryDelayMs: 1 });
+        expect(sw.registerCalls.length).to.equal(3);
+        expect(registration.active).to.equal(sw.active);
+    });
+
+    it('gives up after the configured attempts and reports the last error', async () => {
+        sw = fakeSwContainer({ failures: Infinity });
+        __setTestServiceWorkerContainer(sw);
+        let message = '';
+        await registerEgitServiceWorker({ attempts: 2, retryDelayMs: 1 }).catch((e) => { message = e.message; });
+        expect(sw.registerCalls.length).to.equal(2);
+        expect(message).to.contain('2 attempts');
+        expect(message).to.contain('400');
+    });
+
+    it('configureEgitKey sends the key, store URL and bearer token, and awaits the ack', async () => {
+        const { repoId, remoteUrl } = await configureEgitKey();
+        expect(repoId).to.equal('alice.near');
+        expect(remoteUrl).to.equal(`${location.origin}/egit/alice.near`);
+
+        expect(sw.active.messages.length).to.equal(1);
+        const msg = sw.active.messages[0];
+        expect(msg.type).to.equal('egit-set-key');
+        expect(msg.repoId).to.equal('alice.near');
+        expect(msg.keyHex).to.match(/^[0-9a-f]{64}$/);
+        expect(msg.keyHex).to.equal(currentDekHex());
+        expect(msg.storeBaseUrl).to.equal(`${arizgatewayhost}/store/me`);
+        expect(msg.headers).to.deep.equal({ Authorization: 'Bearer test-token' });
+    });
+
+    it('re-sending picks up a refreshed token but keeps the same key', async () => {
+        await configureEgitKey();
+        seedToken('refreshed-token');
+        await configureEgitKey();
+
+        expect(sw.active.messages.length).to.equal(2);
+        const [first, second] = sw.active.messages;
+        expect(second.headers).to.deep.equal({ Authorization: 'Bearer refreshed-token' });
+        expect(second.keyHex).to.equal(first.keyHex);
+        // still only the one wrap from first setup — no new DEK was minted
+        expect(store.wraps.size).to.equal(1);
+    });
+
+    it('propagates NeedsEnrollmentError without configuring the service worker', async () => {
+        store.refsExists = true; // data exists, but this wallet key has no wrap
+        let error = null;
+        await configureEgitKey().catch((e) => { error = e; });
+        expect(error).to.be.instanceOf(NeedsEnrollmentError);
+        expect(sw.active.messages.length).to.equal(0);
+    });
+
+    it('encryptedRemoteUrl targets /egit/<account> on this origin', () => {
+        expect(encryptedRemoteUrl('bob.near')).to.equal(`${location.origin}/egit/bob.near`);
+    });
+});

--- a/public_html/arizgateway/encryptionkey.mock.js
+++ b/public_html/arizgateway/encryptionkey.mock.js
@@ -1,0 +1,61 @@
+import { __setTestWallet, arizgatewayhost } from './arizgatewayaccess.js';
+
+// Shared test doubles for the encryption-key/encrypted-sync specs (not a spec
+// file itself — wtr only runs *.spec.js).
+
+// Deterministic fake wallet: a fixed fake "signature" per (accountId, message,
+// recipient) — enough for derivation, which never verifies signatures.
+export function fakeWallet(accountId, { hedged = false } = {}) {
+    let counter = 0;
+    __setTestWallet({
+        accountId,
+        async getAccounts() { return [{ accountId }]; },
+        async signMessage({ message, recipient }) {
+            const seed = `${accountId}|${recipient}|${message}${hedged ? `|${counter++}` : ''}`;
+            const bytes = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed)));
+            const sig = new Uint8Array(64);
+            sig.set(bytes); sig.set(bytes, 32);
+            return {
+                accountId,
+                publicKey: 'ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi',
+                signature: btoa(String.fromCharCode(...sig)),
+            };
+        },
+        async signOut() {},
+    });
+}
+
+// In-memory mock of the gateway's /store/me wraps + refs-probe endpoints.
+export function mockStore() {
+    const state = { wraps: new Map(), refsExists: false, unauthorized: false };
+    const realFetch = window.fetch;
+    window.fetch = async (url, init = {}) => {
+        const u = String(url);
+        if (!u.startsWith(`${arizgatewayhost}/store/me`)) return realFetch(url, init);
+        if (state.unauthorized) return new Response('failed to parse token', { status: 401 });
+        const path = u.slice(`${arizgatewayhost}/store/me`.length);
+        if (path === '/refs') {
+            return state.refsExists
+                ? new Response(new Uint8Array([1]), { status: 200 })
+                : new Response('{"error":"not found"}', { status: 404 });
+        }
+        const wrapMatch = path.match(/^\/keys\/([0-9a-f]{32})$/);
+        if (wrapMatch) {
+            const id = wrapMatch[1];
+            if ((init.method ?? 'GET') === 'GET') {
+                const wrap = state.wraps.get(id);
+                return wrap
+                    ? new Response(wrap, { status: 200 })
+                    : new Response('{"error":"not found"}', { status: 404 });
+            }
+            if (init.method === 'PUT') {
+                if (state.wraps.has(id)) return new Response('{"error":"wrap already exists"}', { status: 412 });
+                state.wraps.set(id, new Uint8Array(await new Response(init.body).arrayBuffer()));
+                return new Response(null, { status: 204 });
+            }
+        }
+        return new Response('unexpected', { status: 500 });
+    };
+    state.restore = () => { window.fetch = realFetch; };
+    return state;
+}

--- a/public_html/arizgateway/encryptionkey.spec.js
+++ b/public_html/arizgateway/encryptionkey.spec.js
@@ -1,7 +1,6 @@
 import {
     ACCESS_TOKEN_SESSION_STORAGE_KEY,
     __setTestWallet,
-    arizgatewayhost,
 } from './arizgatewayaccess.js';
 import {
     obtainDek, enrollWithExportedKey, deriveKeyMaterial,
@@ -9,63 +8,7 @@ import {
     bytesToHex, hexToBytes,
     NeedsEnrollmentError, NonDeterministicSignerError, DEK_BYTES,
 } from './encryptionkey.js';
-
-// Deterministic fake wallet: a fixed fake "signature" per (accountId, message,
-// recipient) — enough for derivation, which never verifies signatures.
-function fakeWallet(accountId, { hedged = false } = {}) {
-    let counter = 0;
-    __setTestWallet({
-        accountId,
-        async getAccounts() { return [{ accountId }]; },
-        async signMessage({ message, recipient }) {
-            const seed = `${accountId}|${recipient}|${message}${hedged ? `|${counter++}` : ''}`;
-            const bytes = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(seed)));
-            const sig = new Uint8Array(64);
-            sig.set(bytes); sig.set(bytes, 32);
-            return {
-                accountId,
-                publicKey: 'ed25519:CziSGowWUKiP5N5pqGUgXCJXtqpySAk29YAU6zEs5RAi',
-                signature: btoa(String.fromCharCode(...sig)),
-            };
-        },
-        async signOut() {},
-    });
-}
-
-// In-memory mock of the gateway's /store/me wraps + refs-probe endpoints.
-function mockStore() {
-    const state = { wraps: new Map(), refsExists: false, unauthorized: false };
-    const realFetch = window.fetch;
-    window.fetch = async (url, init = {}) => {
-        const u = String(url);
-        if (!u.startsWith(`${arizgatewayhost}/store/me`)) return realFetch(url, init);
-        if (state.unauthorized) return new Response('failed to parse token', { status: 401 });
-        const path = u.slice(`${arizgatewayhost}/store/me`.length);
-        if (path === '/refs') {
-            return state.refsExists
-                ? new Response(new Uint8Array([1]), { status: 200 })
-                : new Response('{"error":"not found"}', { status: 404 });
-        }
-        const wrapMatch = path.match(/^\/keys\/([0-9a-f]{32})$/);
-        if (wrapMatch) {
-            const id = wrapMatch[1];
-            if ((init.method ?? 'GET') === 'GET') {
-                const wrap = state.wraps.get(id);
-                return wrap
-                    ? new Response(wrap, { status: 200 })
-                    : new Response('{"error":"not found"}', { status: 404 });
-            }
-            if (init.method === 'PUT') {
-                if (state.wraps.has(id)) return new Response('{"error":"wrap already exists"}', { status: 412 });
-                state.wraps.set(id, new Uint8Array(await new Response(init.body).arrayBuffer()));
-                return new Response(null, { status: 204 });
-            }
-        }
-        return new Response('unexpected', { status: 500 });
-    };
-    state.restore = () => { window.fetch = realFetch; };
-    return state;
-}
+import { fakeWallet, mockStore } from './encryptionkey.mock.js';
 
 describe('encryptionkey (wrapped-DEK wallet unlock)', () => {
     let store;


### PR DESCRIPTION
## Slice 1 of the #76 frontend integration

Adds `public_html/arizgateway/encryptedsync.js` — the plumbing between the app and the egit service worker (from [encrypted-git-storage](https://github.com/petersalomonsen/encrypted-git-storage), served at `/sw.js` by the gateway and the web4 contract):

- **`registerEgitServiceWorker()`** — registers `/sw.js` as a module SW at scope `/`, retrying through near.page's intermittent transient 400s (installed SWs are unaffected; only the initial registration fetch is at risk).
- **`configureEgitKey()`** — obtains the wallet-unlocked master key via `obtainDek()` (#82), then sends the library's `egit-set-key` message to the active SW — `{repoId: <account>, keyHex: <DEK>, storeBaseUrl: <gateway>/store/me, headers: {Authorization: Bearer <NEP-413 token>}}` — and awaits the ack on a MessageChannel. Designed to be called before **every** encrypted sync: it re-sends a fresh bearer token and survives SW restarts (the SW keeps config in memory only). `NeedsEnrollmentError` propagates untouched for the Storage-page enrollment flow (slice 3).
- **`encryptedRemoteUrl(account)`** / **`pageIsControlled()`** — helpers for slice 2: the wasm-git remote URL under `<origin>/egit/<account>`, and detection of the first-registration case where the already-running git worker is uncontrolled and a reload is needed.

Also extracts the fake wallet + in-memory store mocks from `encryptionkey.spec.js` into `encryptionkey.mock.js` so the new spec reuses them without re-running that suite.

**Tests:** 7 new hermetic wtr specs (registration options, retry/give-up behavior, full egit-set-key payload incl. token refresh re-send, NeedsEnrollmentError propagation, remote URL shape).

Next slices: opt-in encrypted remote in the git sync flow (2), Storage-page UI for enable/export/enroll + CLI instructions (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)