### PR TITLE
Storage page: encrypted sync UI — enable, export/import key, CLI (#76)

### DIFF
--- a/playwright_tests/tests/wasmgit.spec.js
+++ b/playwright_tests/tests/wasmgit.spec.js
@@ -19,6 +19,13 @@ test("storage page shows the gateway git UI (no legacy key/url inputs)", async (
   await expect(page.locator('#gatewayaccountspan')).toBeVisible();
   await expect(page.locator('#downloadzipbutton')).toBeVisible();
 
+  // Encrypted sync controls (issue #76) are present; the opt-in defaults to off.
+  await expect(page.locator('#enableencryptedsyncbutton')).toBeVisible();
+  await expect(page.locator('#exportkeybutton')).toBeVisible();
+  await expect(page.locator('#importkeybutton')).toBeVisible();
+  await expect(page.locator('#copyegitclonebutton')).toBeVisible();
+  await expect(page.locator('#encryptedsyncstatus')).toHaveText('disabled');
+
   // Legacy inputs are gone.
   await expect(page.locator('#wasmgitaccesskey')).toHaveCount(0);
   await expect(page.locator('#remoterepo')).toHaveCount(0);

--- a/public_html/storage/storage-page.component.html.js
+++ b/public_html/storage/storage-page.component.html.js
@@ -19,4 +19,38 @@ export default /*html*/ `<div class="card">
         <p class="mt-2"><small class="text-muted">The access token is short-lived &mdash; re-copy when it expires.</small></p>
     </div>
 </div>
+<br />
+<div class="card">
+    <div class="card-header">Encrypted sync</div>
+    <div class="card-body">
+        <p>End-to-end encryption for your synced data: everything is encrypted in your browser before upload, with a
+            master key that only your wallet can unlock &mdash; the server only ever stores ciphertext.
+            <b>You are the custodian of your key</b>: export it and keep a safe copy (e.g. in a password manager).</p>
+        <p>Status: <b><span id="encryptedsyncstatus">disabled</span></b></p>
+        <p>
+            <button class="btn btn-primary" id="enableencryptedsyncbutton">Enable encrypted sync</button>
+            <button class="btn btn-outline-secondary" id="disableencryptedsyncbutton">Disable</button>
+        </p>
+        <hr />
+        <h6>Your key</h6>
+        <p>Needed to enroll other devices or wallet keys, and to recover your data if you lose access to this wallet key.</p>
+        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code id="exportedkey">Click &ldquo;Export key&rdquo; to reveal your key.</code></pre>
+        <button class="btn btn-sm btn-outline-primary" id="exportkeybutton">Export key</button>
+        <p class="mt-3">Enroll this device with a previously exported key (needed when this wallet key cannot unlock the
+            encrypted store yet):</p>
+        <div class="input-group">
+            <input type="password" class="form-control" id="importkeyinput" placeholder="exported key (64 hex characters)" />
+            <button class="btn btn-outline-primary" id="importkeybutton">Import key</button>
+        </div>
+        <hr />
+        <h6>Use from the command line (optional)</h6>
+        <p>Install the <code>egit::</code> git remote helper once:</p>
+        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code>npm install -g github:petersalomonsen/encrypted-git-storage</code></pre>
+        <p>Then clone your encrypted repository (decrypted locally with your exported key):</p>
+        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code id="egitclonecmd">Sign in, then click &ldquo;Copy encrypted clone command&rdquo;.</code></pre>
+        <button class="btn btn-sm btn-outline-primary" id="copyegitclonebutton">Copy encrypted clone command</button>
+        <p class="mt-2"><small class="text-muted">The command embeds your key and a short-lived access token &mdash;
+            treat it as a secret and re-copy when the token expires.</small></p>
+    </div>
+</div>
 <br />`;

--- a/public_html/storage/storage-page.component.js
+++ b/public_html/storage/storage-page.component.js
@@ -3,7 +3,8 @@ import wasmgitComponentHtml from './storage-page.component.html.js';
 import { modalAlert } from '../ui/modal.js';
 import { setProgressbarValue } from '../ui/progress-bar.js';
 import { getAccessToken, getAccountId, isSignedIn, loginToArizGateway, arizgatewayhost } from '../arizgateway/arizgatewayaccess.js';
-import { isEncryptedSyncEnabled, configureEgitKey, waitForController } from '../arizgateway/encryptedsync.js';
+import { isEncryptedSyncEnabled, setEncryptedSyncEnabled, configureEgitKey, waitForController } from '../arizgateway/encryptedsync.js';
+import { obtainDek, currentDekHex, enrollWithExportedKey, NeedsEnrollmentError } from '../arizgateway/encryptionkey.js';
 
 // One repository per account; the account is implied by the NEP-413 token, so the
 // repo name in the URL is a fixed label.
@@ -18,6 +19,14 @@ export const gitCloneCommand = (token) =>
     `git -c http.extraHeader="Authorization: Bearer ${token}" clone ${gatewayRepoUrl()}`;
 export const gitConfigCommand = (token) =>
     `git config http.extraHeader "Authorization: Bearer ${token}"`;
+
+// CLI for the ENCRYPTED store: the git-remote-egit helper (bin of the
+// encrypted-git-storage package) reads the master key from EGIT_KEY and sends
+// EGIT_AUTH as the Authorization header on every store request. The command
+// embeds both — the key never reaches the server, but treat the command as a
+// secret.
+export const egitCloneCommand = (keyHex, token) =>
+    `EGIT_KEY=${keyHex} EGIT_AUTH="Bearer ${token}" git clone "egit::${arizgatewayhost}/store/me" portfolio`;
 
 /**
  * Resolve the remote for this sync: the plaintext gateway git server, or — when
@@ -71,7 +80,94 @@ customElements.define('storage-page',
             this.shadowRoot.getElementById('copyconfigbutton')
                 .addEventListener('click', () => this.copyCommand('config'));
 
+            this.shadowRoot.getElementById('enableencryptedsyncbutton')
+                .addEventListener('click', () => this.enableEncryptedSync());
+            this.shadowRoot.getElementById('disableencryptedsyncbutton')
+                .addEventListener('click', () => {
+                    setEncryptedSyncEnabled(false);
+                    this.refreshEncryptedSyncStatus();
+                });
+            this.shadowRoot.getElementById('exportkeybutton')
+                .addEventListener('click', () => this.exportKey());
+            this.shadowRoot.getElementById('importkeybutton')
+                .addEventListener('click', () => this.importKey());
+            this.shadowRoot.getElementById('copyegitclonebutton')
+                .addEventListener('click', () => this.copyEgitCloneCommand());
+            this.refreshEncryptedSyncStatus();
+
             return this.shadowRoot;
+        }
+
+        refreshEncryptedSyncStatus() {
+            const enabled = isEncryptedSyncEnabled();
+            this.shadowRoot.getElementById('encryptedsyncstatus').innerText = enabled ? 'enabled' : 'disabled';
+            this.shadowRoot.getElementById('enableencryptedsyncbutton').disabled = enabled;
+            this.shadowRoot.getElementById('disableencryptedsyncbutton').disabled = !enabled;
+        }
+
+        async enableEncryptedSync() {
+            setProgressbarValue('indeterminate', 'enabling encrypted sync');
+            try {
+                await this.ensureSignedIn();
+                // Registers the service worker and unlocks (or first-time
+                // creates) the master key — the enable action IS the setup.
+                await configureEgitKey();
+                setEncryptedSyncEnabled(true);
+                setProgressbarValue(null);
+                await modalAlert('Encrypted sync enabled',
+                    'Your next Synchronize will push to the encrypted store. Export your key now and keep a safe copy — you need it to enroll other devices, and to recover your data if you lose access to this wallet key.');
+            } catch (e) {
+                setProgressbarValue(null);
+                if (e instanceof NeedsEnrollmentError) {
+                    await modalAlert('This device needs your exported key', e.message);
+                } else {
+                    console.error(e);
+                    await modalAlert('Could not enable encrypted sync', e);
+                }
+            }
+            this.refreshEncryptedSyncStatus();
+        }
+
+        async exportKey() {
+            try {
+                await this.ensureSignedIn();
+                await obtainDek();
+                const keyHex = currentDekHex();
+                this.shadowRoot.getElementById('exportedkey').textContent = keyHex;
+                try { await navigator.clipboard.writeText(keyHex); } catch { /* shown for manual copy */ }
+            } catch (e) {
+                console.error(e);
+                await modalAlert(e instanceof NeedsEnrollmentError ? 'This device needs your exported key' : 'Could not export the key', e.message ?? e);
+            }
+        }
+
+        async importKey() {
+            const input = this.shadowRoot.getElementById('importkeyinput');
+            try {
+                await this.ensureSignedIn();
+                await enrollWithExportedKey(input.value);
+                input.value = '';
+                setEncryptedSyncEnabled(true);
+                await modalAlert('Key imported',
+                    'This wallet key is now enrolled: from now on it unlocks the encrypted store by signing, without the exported key.');
+            } catch (e) {
+                console.error(e);
+                await modalAlert('Could not import the key', e.message ?? e);
+            }
+            this.refreshEncryptedSyncStatus();
+        }
+
+        async copyEgitCloneCommand() {
+            try {
+                await this.ensureSignedIn();
+                await obtainDek();
+                const cmd = egitCloneCommand(currentDekHex(), await getAccessToken());
+                this.shadowRoot.getElementById('egitclonecmd').textContent = cmd;
+                try { await navigator.clipboard.writeText(cmd); } catch { /* shown for manual copy */ }
+            } catch (e) {
+                console.error(e);
+                await modalAlert(e instanceof NeedsEnrollmentError ? 'This device needs your exported key' : 'Could not generate the command', e.message ?? e);
+            }
         }
 
         async refreshAccount() {

--- a/public_html/storage/storage-page.component.spec.js
+++ b/public_html/storage/storage-page.component.spec.js
@@ -1,7 +1,8 @@
-import { gitCloneCommand, gitConfigCommand, gatewayRepoUrl, prepareSyncRemote } from './storage-page.component.js';
+import { gitCloneCommand, gitConfigCommand, gatewayRepoUrl, prepareSyncRemote, egitCloneCommand } from './storage-page.component.js';
+import { arizgatewayhost } from '../arizgateway/arizgatewayaccess.js';
 import { mockWalletAuthenticationData } from '../arizgateway/arizgatewayaccess.spec.js';
-import { setEncryptedSyncEnabled, __setTestServiceWorkerContainer } from '../arizgateway/encryptedsync.js';
-import { __clearDekForTests } from '../arizgateway/encryptionkey.js';
+import { isEncryptedSyncEnabled, setEncryptedSyncEnabled, __setTestServiceWorkerContainer } from '../arizgateway/encryptedsync.js';
+import { __clearDekForTests, obtainDek, currentDekHex } from '../arizgateway/encryptionkey.js';
 import { fakeWallet, mockStore } from '../arizgateway/encryptionkey.mock.js';
 import { fakeSwContainer } from '../arizgateway/encryptedsync.mock.js';
 import { __setTestWallet } from '../arizgateway/arizgatewayaccess.js';
@@ -77,6 +78,118 @@ describe('storage-page component', () => {
         expect($('copyclonebutton')).to.not.equal(null);
         expect($('copyconfigbutton')).to.not.equal(null);
         expect($('gatewayaccountspan')).to.not.equal(null);
+        // encrypted sync controls are present
+        expect($('encryptedsyncstatus')).to.not.equal(null);
+        expect($('enableencryptedsyncbutton')).to.not.equal(null);
+        expect($('disableencryptedsyncbutton')).to.not.equal(null);
+        expect($('exportkeybutton')).to.not.equal(null);
+        expect($('importkeyinput')).to.not.equal(null);
+        expect($('importkeybutton')).to.not.equal(null);
+        expect($('copyegitclonebutton')).to.not.equal(null);
         el.remove();
+    });
+
+    it('builds an encrypted clone command with the key, auth and egit:: remote', () => {
+        const cmd = egitCloneCommand('ab'.repeat(32), 'TOKEN123');
+        expect(cmd).to.contain(`EGIT_KEY=${'ab'.repeat(32)}`);
+        expect(cmd).to.contain('EGIT_AUTH="Bearer TOKEN123"');
+        expect(cmd).to.contain(`git clone "egit::${arizgatewayhost}/store/me"`);
+    });
+
+    describe('encrypted sync UI flows', () => {
+        let store;
+        let sw;
+        let el;
+
+        const until = async (fn, what) => {
+            for (let i = 0; i < 500; i++) {
+                if (fn()) return;
+                await new Promise((r) => setTimeout(r, 10));
+            }
+            throw new Error('timed out waiting for ' + what);
+        };
+        const dismissModal = async () => {
+            await until(() => document.querySelector('common-modal'), 'a modal');
+            const modalEl = document.querySelector('common-modal');
+            const text = modalEl.shadowRoot.textContent;
+            modalEl.shadowRoot.querySelector('button').click();
+            await until(() => !document.querySelector('common-modal'), 'modal dismissal');
+            return text;
+        };
+
+        beforeEach(async () => {
+            __clearDekForTests();
+            setEncryptedSyncEnabled(false);
+            localStorage.setItem('ariz_gateway_access_token',
+                JSON.stringify({ token: 'test-token', accountId: 'test.near', issuedAt: Date.now() }));
+            store = mockStore();
+            sw = fakeSwContainer();
+            __setTestServiceWorkerContainer(sw);
+            fakeWallet('test.near');
+            el = document.createElement('storage-page');
+            document.body.appendChild(el);
+            await el.readyPromise;
+        });
+
+        afterEach(() => {
+            el.remove();
+            setEncryptedSyncEnabled(false);
+            store.restore();
+            __setTestWallet(null);
+            __setTestServiceWorkerContainer(null);
+            localStorage.removeItem('ariz_gateway_access_token');
+        });
+
+        it('enable: sets up the key + service worker, flips the flag and status', async () => {
+            expect(el.shadowRoot.getElementById('encryptedsyncstatus').innerText).to.equal('disabled');
+            el.shadowRoot.getElementById('enableencryptedsyncbutton').click();
+            const text = await dismissModal();
+            expect(text).to.contain('Encrypted sync enabled');
+            expect(isEncryptedSyncEnabled()).to.equal(true);
+            expect(store.wraps.size).to.equal(1); // first-setup stored a key wrap
+            expect(sw.active.messages[0].type).to.equal('egit-set-key');
+            expect(el.shadowRoot.getElementById('encryptedsyncstatus').innerText).to.equal('enabled');
+            expect(el.shadowRoot.getElementById('enableencryptedsyncbutton').disabled).to.equal(true);
+
+            el.shadowRoot.getElementById('disableencryptedsyncbutton').click();
+            expect(isEncryptedSyncEnabled()).to.equal(false);
+            expect(el.shadowRoot.getElementById('encryptedsyncstatus').innerText).to.equal('disabled');
+        });
+
+        it('export key reveals the 64-hex master key', async () => {
+            el.shadowRoot.getElementById('exportkeybutton').click();
+            await until(() => /^[0-9a-f]{64}$/.test(el.shadowRoot.getElementById('exportedkey').textContent), 'the exported key');
+            expect(el.shadowRoot.getElementById('exportedkey').textContent).to.equal(currentDekHex());
+        });
+
+        it('an unenrolled wallet key gets the enrollment modal, then imports the exported key', async () => {
+            // Device/wallet 1 created the store...
+            const dek = await obtainDek();
+            const dekHex = [...dek].map((b) => b.toString(16).padStart(2, '0')).join('');
+            store.refsExists = true;
+            // ...device/wallet 2 signs differently: not enrolled.
+            __clearDekForTests();
+            fakeWallet('test-ledger.near');
+
+            el.shadowRoot.getElementById('enableencryptedsyncbutton').click();
+            const text = await dismissModal();
+            expect(text).to.contain('exported key');
+            expect(isEncryptedSyncEnabled()).to.equal(false);
+
+            el.shadowRoot.getElementById('importkeyinput').value = dekHex;
+            el.shadowRoot.getElementById('importkeybutton').click();
+            const importText = await dismissModal();
+            expect(importText).to.contain('Key imported');
+            expect(isEncryptedSyncEnabled()).to.equal(true);
+            expect(store.wraps.size).to.equal(2); // a second wrap for the new wallet key
+            expect(currentDekHex()).to.equal(dekHex);
+        });
+
+        it('copy encrypted clone command renders a command with key and token', async () => {
+            el.shadowRoot.getElementById('copyegitclonebutton').click();
+            await until(() => el.shadowRoot.getElementById('egitclonecmd').textContent.startsWith('EGIT_KEY='), 'the clone command');
+            const cmd = el.shadowRoot.getElementById('egitclonecmd').textContent;
+            expect(cmd).to.equal(egitCloneCommand(currentDekHex(), 'test-token'));
+        });
     });
 });


### PR DESCRIPTION
## Slice 3 of the #76 frontend integration — **stacked on #84** (merge that first; this PR is based on its branch and will retarget to main when it merges)

Adds the user-facing controls for encrypted sync to the Storage page, wiring the plumbing from #83/#84:

### Encrypted sync card
- **Enable** — signs in, then `configureEgitKey()`: registers the egit service worker and creates (first setup) or unlocks the wallet-wrapped master key; flips the opt-in flag so Synchronize targets the encrypted `/egit/<account>` remote. A wallet key that can't unlock the store gets a dedicated "this device needs your exported key" modal instead of a generic error. **Disable** returns to the plaintext remote.
- **Your key** — *Export key* reveals (and copies) the 64-hex master key: per the custody model (docs/encrypted-storage.md) the user is the key's custodian. *Import key* enrolls this device/wallet key with a key exported elsewhere (`enrollWithExportedKey` → a second wrap in the store; from then on this wallet unlocks by signing).
- **CLI** — install `git-remote-egit` (`npm install -g github:petersalomonsen/encrypted-git-storage`), then `EGIT_KEY=<exported key> EGIT_AUTH="Bearer <token>" git clone "egit::<gateway>/store/me" portfolio` (builder exported as `egitCloneCommand` for tests; command rendered only on click since it embeds the key).

### Tests
- 4 new wtr specs drive the real component UI against the fake wallet / in-memory store / fake SW container: enable stores a wrap + flips flag + updates status; export reveals the key; an unenrolled wallet gets the enrollment modal and import enrolls a second wrap; the clone command embeds key + token. (13 specs in the file total, 176 across the suite, all green.)\n- Playwright dist smoke extended with the new controls (verifies they survive the rollup single-file bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)