### PR TITLE
Fix dist bundle: worker restart broke the git worker in production (#76)

### DIFF
--- a/docs/encrypted-storage.md
+++ b/docs/encrypted-storage.md
@@ -84,10 +84,22 @@ your **wallet unlocks it**, using the standard wrapped-key pattern:
 
 - Signing a fixed, app-namespaced **NEP-413 message** with a wallet key yields a
   deterministic signature (ed25519: same key + same message → the same signature
-  every time). That signature → HKDF-SHA256 → a **key-encryption key (KEK)**.
+  every time). That signature → HKDF-SHA256 → a **key-encryption key (KEK)**,
+  plus a separate HKDF output used as the **wrap id** (the name the wrap is
+  stored under). The id is derived from the *signature*, never from the public
+  key: access keys are public on-chain, so pk-named blobs would let a
+  storage-level observer map stores back to accounts. Only someone who can
+  produce the signature can even compute which blob to look for.
 - The DEK is stored **wrapped** — `AES-256-GCM(KEK, DEK)` — as a small
-  ciphertext blob in your store, one wrap per enrolled wallet key (indexed by
-  the public key that signed, which the NEP-413 response identifies).
+  ciphertext blob in your store, one wrap per enrolled wallet key.
+- **The app asks the wallet to sign that fixed message twice** and compares the
+  two signatures. RFC 8032 ed25519 is deterministic, but *hedged* (randomized)
+  implementations exist — such a wallet would happily set up encryption and
+  then never be able to derive the same KEK again, silently locking the data.
+  A wallet that signs differently each time is rejected as a KEK source; the
+  device can still be enrolled by importing the exported key instead. So when
+  enabling encrypted sync (or unlocking on a new device), expect **two
+  identical signing prompts** — that's the safety check, not a glitch.
 
 Why a wrapped master key rather than using the signature-derived key directly:
 

--- a/playwright_tests/tests/wasmgit.spec.js
+++ b/playwright_tests/tests/wasmgit.spec.js
@@ -31,3 +31,14 @@ test("storage page shows the gateway git UI (no legacy key/url inputs)", async (
   await expect(page.locator('#remoterepo')).toHaveCount(0);
   await pause500ifRecordingVideo(page);
 });
+
+// The dist build must inline every worker as a blob (rollup.config.js). A
+// worker URL that survives into the single-file bundle resolves against the
+// page origin at runtime, where the SPA fallback answers with index.html — a
+// text/html "module script" that kills the worker (this broke the git-worker
+// restart in production once). app.js legitimately keeps a bare
+// import.meta.url for routing, so assert specifically on worker-URL patterns.
+test("the dist bundle contains no unresolved worker URLs", async ({ request }) => {
+  const html = await (await request.get("http://localhost:8081/")).text();
+  expect(html).not.toMatch(/new URL\([^)]*import\.meta\.url/);
+});

--- a/public_html/storage/gitstorage.js
+++ b/public_html/storage/gitstorage.js
@@ -7,7 +7,12 @@ import { isProgressBarVisible, setProgressbarValue } from "../ui/progress-bar.js
 // (test_servers/opfs-worker-harness.mjs). Production always uses the worker.
 const useMemFs = typeof globalThis !== 'undefined' && globalThis.__GITSTORAGE_MEMFS__ === true;
 
-let worker = useMemFs ? null : new Worker(new URL('wasmgitworker.js', import.meta.url), { type: 'module' });
+// Single factory = a single worker-URL expression for the dist build
+// (rollup.config.js) to rewrite into an inlined blob worker. A second
+// occurrence once slipped into the single-file bundle unresolved and broke at
+// runtime (module worker fetched as text/html from the SPA fallback).
+const createGitWorker = () => new Worker(new URL('wasmgitworker.js', import.meta.url), { type: 'module' });
+let worker = useMemFs ? null : createGitWorker();
 
 // A worker is only service-worker controlled if it was CREATED while the page
 // was controlled — a later claim() covers the page but not already-running
@@ -32,7 +37,7 @@ export async function restartGitWorker() {
         await currentCommandInProgress.catch(() => { });
     }
     worker.terminate();
-    worker = new Worker(new URL('wasmgitworker.js', import.meta.url), { type: 'module' });
+    worker = createGitWorker();
     workerControlled = !!navigator.serviceWorker?.controller;
 }
 
@@ -43,6 +48,16 @@ const workerCommand = async (command, params) => {
     }
     currentCommandInProgress = new Promise((resolve, reject) => {
         const progressBarWasAlreadyVisible = isProgressBarVisible();
+        // A worker that fails to even load (e.g. its script URL resolving wrong)
+        // never posts a message — without this the command (and the progress
+        // bar) would hang forever.
+        worker.onerror = (e) => {
+            if (!progressBarWasAlreadyVisible) {
+                setProgressbarValue(null);
+            }
+            currentCommandInProgress = null;
+            reject(e.message ?? 'the git worker failed');
+        };
         worker.onmessage = (msg) => {
             if (msg.data.error) {
                 if (!progressBarWasAlreadyVisible) {

--- a/public_html/storage/storage-page.component.html.js
+++ b/public_html/storage/storage-page.component.html.js
@@ -31,6 +31,10 @@ export default /*html*/ `<div class="card">
             <button class="btn btn-primary" id="enableencryptedsyncbutton">Enable encrypted sync</button>
             <button class="btn btn-outline-secondary" id="disableencryptedsyncbutton">Disable</button>
         </p>
+        <p><small class="text-muted">Your wallet will ask you to sign the same message <b>twice</b>: the second
+            signature verifies that your wallet signs deterministically, so it can unlock the same key again
+            later. A wallet that signs differently each time cannot be used to unlock by signing (import an
+            exported key instead).</small></p>
         <hr />
         <h6>Your key</h6>
         <p>Needed to enroll other devices or wallet keys, and to recover your data if you lose access to this wallet key.</p>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,13 +24,19 @@ export default {
         html({ include: '**/*.html', minify: false }),
         (() => ({
             transform(code, id) {
-                const urlMatch = code.match(/(new URL\([^),]+\,\s*import.meta.url\s*\))/);
-                if (urlMatch) {
-                    const urlWithAbsolutePath = urlMatch[1].replace('import.meta.url', `'file://${id}'`);
+                // Rewrite EVERY worker-URL expression, not just the first — a
+                // second `new Worker(new URL(...))` in a module would otherwise
+                // reach the single-file bundle unresolved and fail at runtime
+                // (the SPA fallback serves index.html as the worker script).
+                for (const urlMatch of [...code.matchAll(/new URL\([^),]+\,\s*import.meta.url\s*\)/g)]) {
+                    const urlWithAbsolutePath = urlMatch[0].replace('import.meta.url', `'file://${id}'`);
 
-                    const func = new Function('return ' + urlWithAbsolutePath);
-                    const resolvedUrl = func();
-                    const pathname = resolvedUrl.pathname;
+                    let pathname;
+                    try {
+                        pathname = new Function('return ' + urlWithAbsolutePath)().pathname;
+                    } catch {
+                        continue; // matched text that isn't an evaluable expression (e.g. a comment)
+                    }
 
                     if (pathname.endsWith('.js')) {
                         code = code.replace(urlMatch[0], `URL.createObjectURL(new Blob([


### PR DESCRIPTION
Found live after deploying #85 (console: *Failed to load module script … text/html* + a hung sync).

## Root cause
The custom rollup transform that inlines workers as blobs only rewrote the **first** `new URL(…, import.meta.url)` per module. `restartGitWorker()` (#84) added a second occurrence, which survived into the single-file bundle unresolved — at runtime it resolves against the page origin, near.page's path-aware contract forwards to the gateway, the SPA fallback answers with `index.html`, and the module worker dies on the text/html MIME check. Every enable-encrypted-sync flow hits the restart path, so Synchronize hung.

## Fixes
- **gitstorage**: one `createGitWorker()` factory = a single worker-URL expression; restart reuses it. (Blob workers inherit SW control from the document at creation — verified by the Chromium probe from #84.)
- **gitstorage**: `worker.onerror` rejects the in-flight command — a worker that can't boot now surfaces an error instead of a forever-spinning progress bar.
- **rollup transform**: rewrites **every** occurrence, and skips regex matches that aren't evaluable expressions (my first attempt died on a code comment that mentioned the pattern — the transform now tolerates that instead of failing the build).
- **CI guard**: new Playwright dist test — the bundle must contain no `new URL(…import.meta.url` (app.js's bare `import.meta.url` for routing stays legal). This is the test-coverage gap that let the bug ship: harnesses exercise unbundled source, the dist smoke only checked UI presence.
- **docs**: 'Your key' had an outdated claim — wraps are named by an HKDF output of the *signature*, not the public key (pk-named blobs would de-blind the blinded store). Also documents the sign-twice determinism check (hedged ed25519 signers can't be KEK sources).
- **UI**: the double signing prompt is now explained right under the enable button.

Verified: dist builds with 0 unresolved worker URLs / 1 blob worker; both harnesses, 176 wtr specs, and the extended smoke all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)