### PR TITLE
Reconnect the wallet when encrypted sync needs it (#76)

### DIFF
--- a/public_html/arizgateway/arizgatewayaccess.js
+++ b/public_html/arizgateway/arizgatewayaccess.js
@@ -96,8 +96,29 @@ export async function signAndSendTransaction(receiverId, actions) {
 }
 
 export async function loginToArizGateway() {
+    if (_testWallet) return; // injected test wallet == connected
     const connector = await getConnector();
     await connector.connect(); // opens the wallet-selection modal
+}
+
+/**
+ * The account id of the CONNECTED wallet, reconnecting (wallet dialog) if the
+ * session is gone. A fresh cached bearer token OUTLIVES the wallet session —
+ * isSignedIn() stays true and token-only features (API reads, clone command)
+ * keep working while the connector is disconnected. Features that need wallet
+ * signatures (encrypted-sync key derivation) or the live account id must call
+ * this instead of relying on isSignedIn().
+ */
+export async function requireWalletAccount() {
+    let accountId = await getAccountId();
+    if (!accountId) {
+        await loginToArizGateway();
+        accountId = await getAccountId();
+    }
+    if (!accountId) {
+        throw new Error('Not signed in — connect your NEAR wallet to use encrypted sync');
+    }
+    return accountId;
 }
 
 export async function logout() {

--- a/public_html/arizgateway/encryptedsync.js
+++ b/public_html/arizgateway/encryptedsync.js
@@ -1,4 +1,4 @@
-import { arizgatewayhost, getAccessToken, getAccountId } from './arizgatewayaccess.js';
+import { arizgatewayhost, getAccessToken, requireWalletAccount } from './arizgatewayaccess.js';
 import { obtainDek, bytesToHex } from './encryptionkey.js';
 
 // Encrypted gateway sync plumbing (issue #76).
@@ -112,10 +112,10 @@ export async function registerEgitServiceWorker({ attempts = REGISTER_ATTEMPTS, 
  */
 export async function configureEgitKey({ attempts, retryDelayMs } = {}) {
     const registration = await registerEgitServiceWorker({ attempts, retryDelayMs });
-    const accountId = await getAccountId();
-    if (!accountId) {
-        throw new Error('Not signed in — sign in with your NEAR account to use encrypted sync');
-    }
+    // Needs the WALLET (key-derivation signatures + account id), not just a
+    // fresh cached token — reconnects with the wallet dialog if the session
+    // is gone.
+    const accountId = await requireWalletAccount();
     const dek = await obtainDek();
     const token = await getAccessToken();
 

--- a/public_html/arizgateway/encryptedsync.spec.js
+++ b/public_html/arizgateway/encryptedsync.spec.js
@@ -89,6 +89,22 @@ describe('encryptedsync (service worker registration + egit-set-key wiring)', ()
         expect(store.wraps.size).to.equal(1);
     });
 
+    it('requires the WALLET, not just a fresh cached token (token outlives the session)', async () => {
+        // Cached token is fresh (seeded in beforeEach) but the wallet session
+        // is gone (no accounts even after a reconnect attempt) —
+        // configureEgitKey must fail asking for the wallet, NOT silently use
+        // the token, and must not touch the service worker.
+        __setTestWallet({
+            async getAccounts() { return []; },
+            async signMessage() { throw new Error('no wallet session'); },
+            async signOut() { },
+        });
+        let message = '';
+        await configureEgitKey().catch((e) => { message = e.message; });
+        expect(message).to.contain('connect your NEAR wallet');
+        expect(sw.active.messages.length).to.equal(0);
+    });
+
     it('propagates NeedsEnrollmentError without configuring the service worker', async () => {
         store.refsExists = true; // data exists, but this wallet key has no wrap
         let error = null;

--- a/public_html/storage/storage-page.component.js
+++ b/public_html/storage/storage-page.component.js
@@ -2,7 +2,7 @@ import { exists, git_init, git_clone, configure_user, set_remote, sync, commit_a
 import wasmgitComponentHtml from './storage-page.component.html.js';
 import { modalAlert } from '../ui/modal.js';
 import { setProgressbarValue } from '../ui/progress-bar.js';
-import { getAccessToken, getAccountId, isSignedIn, loginToArizGateway, arizgatewayhost } from '../arizgateway/arizgatewayaccess.js';
+import { getAccessToken, getAccountId, isSignedIn, loginToArizGateway, requireWalletAccount, arizgatewayhost } from '../arizgateway/arizgatewayaccess.js';
 import { isEncryptedSyncEnabled, setEncryptedSyncEnabled, configureEgitKey, waitForController } from '../arizgateway/encryptedsync.js';
 import { obtainDek, currentDekHex, enrollWithExportedKey, NeedsEnrollmentError } from '../arizgateway/encryptionkey.js';
 
@@ -108,7 +108,7 @@ customElements.define('storage-page',
         async enableEncryptedSync() {
             setProgressbarValue('indeterminate', 'enabling encrypted sync');
             try {
-                await this.ensureSignedIn();
+                await this.requireWallet();
                 // Registers the service worker and unlocks (or first-time
                 // creates) the master key — the enable action IS the setup.
                 await configureEgitKey();
@@ -130,7 +130,7 @@ customElements.define('storage-page',
 
         async exportKey() {
             try {
-                await this.ensureSignedIn();
+                await this.requireWallet();
                 await obtainDek();
                 const keyHex = currentDekHex();
                 this.shadowRoot.getElementById('exportedkey').textContent = keyHex;
@@ -144,7 +144,7 @@ customElements.define('storage-page',
         async importKey() {
             const input = this.shadowRoot.getElementById('importkeyinput');
             try {
-                await this.ensureSignedIn();
+                await this.requireWallet();
                 await enrollWithExportedKey(input.value);
                 input.value = '';
                 setEncryptedSyncEnabled(true);
@@ -159,7 +159,7 @@ customElements.define('storage-page',
 
         async copyEgitCloneCommand() {
             try {
-                await this.ensureSignedIn();
+                await this.requireWallet();
                 await obtainDek();
                 const cmd = egitCloneCommand(currentDekHex(), await getAccessToken());
                 this.shadowRoot.getElementById('egitclonecmd').textContent = cmd;
@@ -180,6 +180,14 @@ customElements.define('storage-page',
             if (!(await isSignedIn())) {
                 await loginToArizGateway();
             }
+        }
+
+        // The encrypted-sync features sign with the WALLET; a fresh cached
+        // token is not enough (it outlives the wallet session). Reconnects
+        // via the wallet dialog when needed, then syncs the account display.
+        async requireWallet() {
+            await requireWalletAccount();
+            await this.refreshAccount();
         }
 
         dispatchSyncEvent() {


### PR DESCRIPTION
Found live: the Storage page showed **'(not signed in)'** and encrypted sync errored *'Not signed in'* — while account data loaded fine and the clone command still produced a valid token.

## Root cause
A fresh cached NEP-413 bearer token **outlives the wallet session**: token-only features (API reads, CLI clone command) keep working after near-connect disconnects, and `isSignedIn()` (token freshness) stays true. Encrypted sync is the first feature that needs the **wallet itself** every session — key-derivation signatures and the live account id — and the flow hit the missing session and gave up instead of reconnecting. No signing prompt appeared because it never got that far.

## Fix
`requireWalletAccount()` in `arizgatewayaccess.js`: returns the connected wallet's account id, first opening the wallet-connect dialog if the session is gone; clear error if that still yields no account. `configureEgitKey` and the Storage page's encrypted handlers (enable / export key / import key / encrypted clone command) use it; plaintext sync keeps the token-only path (nice property: no wallet popup needed while the token is fresh).

**Tests:** new spec — with a fresh cached token but a session-less wallet, `configureEgitKey` must ask for the wallet and not touch the service worker (35 specs green in the affected files, harness still passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)