### PR TITLE
Pick up a newer deployed /sw.js before configuring encrypted sync (#76)

### DIFF
--- a/public_html/arizgateway/encryptedsync.js
+++ b/public_html/arizgateway/encryptedsync.js
@@ -76,9 +76,42 @@ export async function waitForController(timeoutMs = 10000) {
     });
 }
 
+// After an update() check, give a newly fetched SW version this long to
+// install + activate before proceeding with whatever is currently active.
+const UPDATE_ACTIVATION_TIMEOUT_MS = 15000;
+
+/**
+ * A stale INSTALLED service worker keeps answering /egit with old behavior
+ * long after a newer /sw.js is deployed (this shipped a v0.1.0 SW that
+ * silently dropped the store URL + auth config). update() re-fetches the
+ * script bypassing the browser cache; if that yields a new version, wait for
+ * it to activate (the SW uses skipWaiting + clients.claim) so the caller
+ * configures the CURRENT code, not the stale one. Best-effort: failures fall
+ * back to the active worker.
+ */
+async function pickUpUpdatedServiceWorker(registration) {
+    try {
+        await registration.update();
+    } catch {
+        return; // offline / transient — keep the active worker
+    }
+    const fresh = registration.installing ?? registration.waiting;
+    if (!fresh) return;
+    await new Promise((resolve) => {
+        const timer = setTimeout(resolve, UPDATE_ACTIVATION_TIMEOUT_MS);
+        fresh.addEventListener('statechange', () => {
+            if (fresh.state === 'activated' || fresh.state === 'redundant') {
+                clearTimeout(timer);
+                resolve();
+            }
+        });
+    });
+}
+
 /**
  * Register /sw.js (module SW, scope '/'), retrying transient failures, and
- * resolve with the ready registration (an active service worker). Safe to call
+ * resolve with the ready registration (an active service worker), after
+ * picking up a newer deployed /sw.js if there is one. Safe to call
  * repeatedly — re-registering an installed SW is a no-op.
  */
 export async function registerEgitServiceWorker({ attempts = REGISTER_ATTEMPTS, retryDelayMs = REGISTER_RETRY_DELAY_MS } = {}) {
@@ -90,7 +123,9 @@ export async function registerEgitServiceWorker({ attempts = REGISTER_ATTEMPTS, 
     for (let attempt = 1; attempt <= attempts; attempt++) {
         try {
             await sw.register(SW_URL, { type: 'module', scope: '/' });
-            return await sw.ready;
+            const registration = await sw.ready;
+            await pickUpUpdatedServiceWorker(registration);
+            return registration;
         } catch (e) {
             lastError = e;
             if (attempt < attempts) {

--- a/public_html/arizgateway/encryptedsync.mock.js
+++ b/public_html/arizgateway/encryptedsync.mock.js
@@ -1,8 +1,9 @@
 // Fake ServiceWorkerContainer for the encrypted-sync specs (not a spec file
 // itself — wtr only runs *.spec.js): register() fails `failures` times before
-// succeeding (near.page's transient 400s), and the active worker records
-// egit-set-key messages and acks on the transferred port like the real SW.
-export function fakeSwContainer({ failures = 0, ack = true, controlled = true } = {}) {
+// succeeding (near.page's transient 400s), the active worker records
+// egit-set-key messages and acks on the transferred port like the real SW,
+// and the ready registration supports the update()/installing lifecycle.
+export function fakeSwContainer({ failures = 0, ack = true, controlled = true, updateInstallsNewVersion = false } = {}) {
     const active = {
         messages: [],
         postMessage(message, transfer) {
@@ -10,9 +11,28 @@ export function fakeSwContainer({ failures = 0, ack = true, controlled = true } 
             if (ack) transfer?.[0]?.postMessage({ type: 'egit-key-set', repoId: message.repoId });
         },
     };
+    const registration = {
+        active,
+        updateCalls: 0,
+        installing: null,
+        waiting: null,
+        async update() {
+            this.updateCalls++;
+            if (updateInstallsNewVersion && !this.installing) {
+                const stateListeners = [];
+                this.installing = {
+                    state: 'installing',
+                    addEventListener(type, listener) { if (type === 'statechange') stateListeners.push(listener); },
+                    // Test helper: the new version finishes activating.
+                    activate() { this.state = 'activated'; stateListeners.forEach((l) => l()); },
+                };
+            }
+        },
+    };
     const listeners = new Map();
     return {
         active,
+        registration,
         registerCalls: [],
         controller: controlled ? active : null,
         async register(url, options) {
@@ -22,7 +42,7 @@ export function fakeSwContainer({ failures = 0, ack = true, controlled = true } 
             }
             return {};
         },
-        get ready() { return Promise.resolve({ active }); },
+        get ready() { return Promise.resolve(registration); },
         addEventListener(type, listener) { listeners.set(type, listener); },
         // Test helper: simulate the SW claiming the page after activation.
         claim() {

--- a/public_html/arizgateway/encryptedsync.spec.js
+++ b/public_html/arizgateway/encryptedsync.spec.js
@@ -51,6 +51,22 @@ describe('encryptedsync (service worker registration + egit-set-key wiring)', ()
         expect(registration.active).to.equal(sw.active);
     });
 
+    it('checks for an updated /sw.js and waits for the new version to activate', async () => {
+        // A stale INSTALLED SW once kept serving v0.1.0 behavior (dropping the
+        // store URL + auth) long after a newer /sw.js was deployed.
+        sw = fakeSwContainer({ updateInstallsNewVersion: true });
+        __setTestServiceWorkerContainer(sw);
+        let resolved = false;
+        const registering = registerEgitServiceWorker().then((r) => { resolved = true; return r; });
+        // Yield so registration reaches the update() check and installs the new version.
+        await new Promise((r) => setTimeout(r, 10));
+        expect(sw.registration.updateCalls).to.equal(1);
+        expect(resolved).to.equal(false); // waiting for the new version to activate
+        sw.registration.installing.activate();
+        const registration = await registering;
+        expect(registration).to.equal(sw.registration);
+    });
+
     it('gives up after the configured attempts and reports the last error', async () => {
         sw = fakeSwContainer({ failures: Infinity });
         __setTestServiceWorkerContainer(sw);


### PR DESCRIPTION
Companion to the production fix for the first real encrypted push (diagnosed via the new gateway auth logging):

```
auth failed: GET /store/petersalomonsen.near/refs — failed to parse token
```

Wrong path (same-origin default instead of the gateway `/store/me`) and no Authorization header = the **v0.1.0** service worker, whose `egit-set-key` handler ignored `storeBaseUrl`/`headers`. The vendored `/sw.js` in ariz-gateway had never been bumped to v0.1.1 (now deployed and propagated), and the user's browser additionally held it as an installed SW.

This PR makes the app defend itself against stale installed SWs: `registerEgitServiceWorker` runs `registration.update()` after `ready` (Chrome bypasses the HTTP cache for the main-script update check) and, when that installs a new version, waits for it to activate before `configureEgitKey` sends the key — so the config always lands in current code instead of whatever was installed weeks ago.

New spec drives the update lifecycle through the fake container (update() called; registration resolves only after the fresh worker activates). All affected specs + the real-auth harness pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)