### PR TITLE
Fix incremental sync: recreate .git/objects/pack lost by the IDBFS→OPFS migration (#76)

### DIFF
--- a/public_html/storage/wasmgitworker.js
+++ b/public_html/storage/wasmgitworker.js
@@ -50,8 +50,19 @@ const ready = (async () => {
     await git.syncRepo(REPO).catch(() => {});
     try { FS.mkdir(WORKDIR); } catch (e) { /* exists */ }
     FS.chdir(WORKDIR);
+    ensureOdbPackDir();
     return git;
 })();
+
+// The IDBFS->OPFS migration copied FILES only, so repos that never held a
+// packfile lost their EMPTY .git/objects/pack directory — and libgit2's fetch
+// cannot create it: the downloaded pack is silently never indexed and the
+// fetch dies with "target OID for the reference doesn't exist" (diagnosed
+// from a real user repo). Recreate it whenever a repo is present.
+function ensureOdbPackDir() {
+    if (!FS.analyzePath(`${WORKDIR}/.git/objects`).exists) return;
+    try { FS.mkdir(`${WORKDIR}/.git/objects/pack`); } catch (e) { /* exists */ }
+}
 
 // Run a git command via the async callMain, capturing stdout/stderr.
 async function runGit(args) {
@@ -110,6 +121,7 @@ self.onmessage = async (msg) => {
                 // so a failing push reports the true root cause instead of a
                 // bare non-fast-forward error.
                 FS.chdir(WORKDIR);
+                ensureOdbPackDir(); // fetch cannot create it (migrated repos lost it)
                 captureOutput = true; stdout = ''; stderr = '';
                 await git.run(['fetch', 'origin']);
                 const fetchErrors = stderr.trim();

--- a/test_servers/opfs-worker-harness.mjs
+++ b/test_servers/opfs-worker-harness.mjs
@@ -153,6 +153,75 @@ const browser = await chromium.launch();
     results.push({ name: 'B: IDBFS -> OPFS migration on startup', migrated, errors });
 }
 
+// ---- Test C: repo migrated WITHOUT .git/objects/pack (empty dirs are lost in
+// the IDBFS->OPFS migration) must still be able to fetch — libgit2 cannot
+// create the pack dir itself, so a downloaded pack silently never got indexed
+// ("target OID for the reference doesn't exist"; diagnosed from a real user
+// repo). The worker now recreates the dir; this guards that.
+{
+    const fsp = await import('node:fs/promises');
+    const os = await import('node:os');
+    const pathm = await import('node:path');
+    const root = await fsp.mkdtemp(pathm.join(os.tmpdir(), 'ow-legacy-'));
+    const run = (cwd, ...args) => pexec('git', ['-C', cwd, ...args], { env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' } });
+
+    // Upstream bare repo (served by the same git backend) with commits c1 + c2.
+    const legacyBare = pathm.join(pathm.dirname(bareRepo), 'legacy.git');
+    await pexec('git', ['init', '--bare', '--initial-branch=master', legacyBare]);
+    await pexec('git', ['--git-dir=' + legacyBare, 'config', 'http.receivepack', 'true']);
+    const work = pathm.join(root, 'work');
+    await fsp.mkdir(work);
+    await run(work, 'init', '-b', 'master');
+    await fsp.writeFile(pathm.join(work, 'a.txt'), 'first\n');
+    await run(work, 'add', '.'); await run(work, 'commit', '-m', 'c1');
+    await run(work, 'push', legacyBare, 'master');
+    const edit = pathm.join(root, 'edit');
+    await run(root, 'clone', '-q', legacyBare, 'edit');
+    await fsp.writeFile(pathm.join(edit, 'b.txt'), 'second, from another device\n');
+    await run(edit, 'add', '.'); await run(edit, 'commit', '-m', 'c2');
+    await run(edit, 'push', '-q');
+
+    // The device's local repo is at c1 with a LOOSE odb and NO objects/pack dir
+    // (the migration-lost shape).
+    await fsp.rm(pathm.join(work, '.git/objects/pack'), { recursive: true, force: true });
+
+    // Collect the repo's files for import into OPFS.
+    const files = [];
+    const walk = async (dir) => {
+        for (const e of await fsp.readdir(dir, { withFileTypes: true })) {
+            const p = pathm.join(dir, e.name);
+            if (e.isDirectory()) await walk(p);
+            else files.push({ rel: pathm.relative(work, p), b64: (await fsp.readFile(p)).toString('base64') });
+        }
+    };
+    await walk(work);
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+    await page.goto(`${ORIGIN}/test.html`);
+
+    const out = await page.evaluate(async ({ entries, url }) => {
+        const gs = await import('/storage/gitstorage.js');
+        try {
+            const dirs = [...new Set(entries.map((f) => f.rel.split('/').slice(0, -1).join('/')).filter(Boolean))]
+                .sort((a, b) => a.split('/').length - b.split('/').length);
+            for (const d of dirs) { try { await gs.mkdir(d); } catch { } }
+            for (const { rel, b64 } of entries) {
+                await gs.writeFile(rel, Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+            }
+            await gs.configure_user({ accessToken: 'ANON', username: 't', useremail: 't@t' });
+            await gs.set_remote(url);
+            await gs.sync();
+            return { ok: true, readback: await gs.readTextFile('b.txt') };
+        } catch (e) { return { ok: false, error: String(e).slice(0, 400) }; }
+    }, { entries: files, url: `${ORIGIN}/legacy.git` });
+
+    await ctx.close();
+    results.push({ name: 'C: fetch into migrated repo without .git/objects/pack', out, errors });
+}
+
 await browser.close();
 git.close();
 app.close();
@@ -165,7 +234,7 @@ console.log('\n===== OPFS WORKER RESULTS =====');
 console.log(JSON.stringify(results, null, 2));
 console.log('remote refs:', JSON.stringify(remoteRefs), '\nremote report.txt =', JSON.stringify(remoteFile));
 
-const A = results[0], B = results[1];
+const A = results[0], B = results[1], C = results[2];
 const pass =
     A.out.ok && A.out.readback === 'hello from opfs worker' && A.out.log.includes('ok:push') &&
     remoteRefs.includes('refs/heads/master') &&
@@ -174,6 +243,7 @@ const pass =
     A.delcheck.afterExists === false &&
     remoteFile === 'hello from opfs worker' &&
     B.migrated.readback === '{"legacy":true}' &&
-    A.errors.length === 0 && B.errors.length === 0;
+    C.out.ok && C.out.readback === 'second, from another device\n' &&
+    A.errors.length === 0 && B.errors.length === 0 && C.errors.length === 0;
 console.log('\n===== ' + (pass ? 'PASS' : 'FAIL') + ' =====');
 process.exit(pass ? 0 : 1);

--- a/test_servers/sw-realrepo-repro.mjs
+++ b/test_servers/sw-realrepo-repro.mjs
@@ -1,0 +1,213 @@
+// ULTIMATE-fidelity repro: browser 1's ACTUAL repository (from the user's zip
+// export, .git and all) imported into OPFS, syncing against a store holding the
+// EXACT production packs, through the REAL service worker + key flow.
+//
+//   node test_servers/sw-realrepo-repro.mjs <repoDir> <prod-pack0> <prod-pack1> <OLD> <NEW>
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+import { chromium } from '@playwright/test';
+
+const APP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../public_html');
+const EGS_ROOT = path.resolve(APP_ROOT, '../node_modules/encrypted-git-storage');
+const { encrypt, sha256hex } = await import(path.join(EGS_ROOT, 'src/core/crypto.js'));
+const { emptyManifest, advanceManifest } = await import(path.join(EGS_ROOT, 'src/core/format.js'));
+const { encryptManifest } = await import(path.join(EGS_ROOT, 'src/core/manifest-io.js'));
+
+const [repoDir, pack0Path, pack1Path, OLD, NEW] = process.argv.slice(2);
+const pack0 = fs.readFileSync(pack0Path);
+const pack1 = fs.readFileSync(pack1Path);
+
+// ---- wallet key + node-side derivation mirror (as in sw-prod-bytes-repro) ----
+const { publicKey: walletPubObj, privateKey: walletPrivObj } = crypto.generateKeyPairSync('ed25519');
+const walletPrivateJwk = walletPrivObj.export({ format: 'jwk' });
+const walletRawPub = walletPubObj.export({ type: 'spki', format: 'der' }).subarray(-32);
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const b58encode = (bytes) => {
+    let n = BigInt('0x' + Buffer.from(bytes).toString('hex')); let out = '';
+    while (n > 0n) { out = B58[Number(n % 58n)] + out; n /= 58n; }
+    for (const b of bytes) { if (b === 0) out = '1' + out; else break; }
+    return out;
+};
+const walletPublicKey = 'ed25519:' + b58encode(walletRawPub);
+function serializeNep413Payload({ message, nonce, recipient, callbackUrl = null }) {
+    const enc = new TextEncoder();
+    const u32le = (n) => { const b = new Uint8Array(4); new DataView(b.buffer).setUint32(0, n, true); return b; };
+    const str = (s) => { const b = enc.encode(s); return [u32le(b.length), b]; };
+    const chunks = [u32le(2147484061), ...str(message), nonce, ...str(recipient),
+        ...(callbackUrl == null ? [new Uint8Array([0])] : [new Uint8Array([1]), ...str(callbackUrl)])];
+    const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+    let off = 0; for (const c of chunks) { out.set(c, off); off += c.length; }
+    return out;
+}
+const DERIVATION_MESSAGE = 'Unlock your encrypted Ariz Portfolio storage.\n\n'
+    + 'Signing this message derives the key that protects your synced data. '
+    + 'Only sign it on arizportfolio.near.page or a client you trust.';
+function deriveKekAndWrapId() {
+    const payload = serializeNep413Payload({
+        message: DERIVATION_MESSAGE,
+        nonce: new TextEncoder().encode('ariz-encrypted-storage-nonce-v1!'),
+        recipient: 'encrypted-storage.arizportfolio.near',
+    });
+    const digest = crypto.createHash('sha256').update(payload).digest();
+    const sig = crypto.sign(null, digest, walletPrivObj);
+    const salt = Buffer.from('ariz-egit-salt-v1');
+    return {
+        kek: Buffer.from(crypto.hkdfSync('sha256', sig, salt, Buffer.from('ariz-egit-kek-v1'), 32)),
+        wrapId: Buffer.from(crypto.hkdfSync('sha256', sig, salt, Buffer.from('ariz-egit-wrap-id-v1'), 16)).toString('hex'),
+    };
+}
+function unwrapDek(kek, blob) {
+    const iv = blob.subarray(0, 12), ct = blob.subarray(12, blob.length - 16), tag = blob.subarray(blob.length - 16);
+    const d = crypto.createDecipheriv('aes-256-gcm', kek, iv);
+    d.setAuthTag(tag);
+    return Buffer.concat([d.update(ct), d.final()]);
+}
+
+// ---- in-memory store ----------------------------------------------------------
+const store = { refs: null, etag: 0, packs: new Map(), keys: new Map() };
+const APP_PORT = 8090, STORE_PORT = 8089;
+const APP_ORIGIN = `http://localhost:${APP_PORT}`;
+http.createServer(async (req, res) => {
+    const cors = {
+        'Access-Control-Allow-Origin': APP_ORIGIN,
+        'Access-Control-Allow-Methods': 'GET,HEAD,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': req.headers['access-control-request-headers'] ?? '*',
+        'Access-Control-Expose-Headers': 'ETag',
+    };
+    if (req.method === 'OPTIONS') { res.writeHead(204, cors); return res.end(); }
+    const reply = (s, b, h = {}) => { res.writeHead(s, { ...cors, ...h }); res.end(b); };
+    const body = () => new Promise((r) => { const c = []; req.on('data', (d) => c.push(d)); req.on('end', () => r(Buffer.concat(c))); });
+    const sub = (req.url || '').split('?')[0].replace(/^\/store\/me/, '');
+    if (sub === '/refs') {
+        if (req.method === 'GET') return store.refs ? reply(200, store.refs, { ETag: `"v${store.etag}"` }) : reply(404, 'no refs');
+        if (req.method === 'PUT') { store.refs = await body(); store.etag++; return reply(204); }
+    }
+    const pk = sub.match(/^\/packs\/(\d+)$/);
+    if (pk) {
+        if (req.method === 'GET') return store.packs.has(pk[1]) ? reply(200, store.packs.get(pk[1])) : reply(404, 'no pack');
+        if (req.method === 'PUT') { store.packs.set(pk[1], await body()); return reply(204); }
+    }
+    if (sub === '/packs') return reply(200, JSON.stringify([...store.packs.entries()].map(([n, b]) => ({ n: Number(n), size: b.length, lastModified: 0 }))));
+    const wr = sub.match(/^\/keys\/([0-9a-f]{32,64})$/);
+    if (wr) {
+        if (req.method === 'GET') return store.keys.has(wr[1]) ? reply(200, store.keys.get(wr[1])) : reply(404, 'no wrap');
+        if (req.method === 'PUT') { store.keys.set(wr[1], await body()); return reply(204); }
+    }
+    reply(404, 'nf ' + sub);
+}).listen(STORE_PORT);
+
+const realWalletModule = `
+const serializeNep413Payload = ${serializeNep413Payload.toString()};
+export async function installRealTestWallet({ accountId, privateJwk, publicKeyStr }) {
+    const { __setTestWallet } = await import('/arizgateway/arizgatewayaccess.js');
+    const key = await crypto.subtle.importKey('jwk', privateJwk, { name: 'Ed25519' }, false, ['sign']);
+    __setTestWallet({
+        accountId,
+        async getAccounts() { return [{ accountId }]; },
+        async signMessage({ message, recipient, nonce }) {
+            const payload = serializeNep413Payload({ message, nonce: new Uint8Array(nonce), recipient });
+            const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', payload));
+            const sig = new Uint8Array(await crypto.subtle.sign('Ed25519', key, digest));
+            return { accountId, publicKey: publicKeyStr, signature: btoa(String.fromCharCode(...sig)) };
+        },
+        async signOut() { },
+    });
+}
+`;
+const MIME = { '.html': 'text/html; charset=utf-8', '.js': 'application/javascript', '.wasm': 'application/wasm', '.json': 'application/json' };
+http.createServer((req, res) => {
+    const urlPath = (req.url || '/').split('?')[0];
+    if (urlPath === '/test.html') { res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' }); return res.end('<!doctype html><html><head><meta charset="utf-8"></head><body>real repo repro</body></html>'); }
+    if (urlPath === '/sw.js') { res.writeHead(200, { 'Content-Type': 'application/javascript' }); return res.end("import './egs/src/service-worker/sw.js';\n"); }
+    if (urlPath === '/realwallet.js') { res.writeHead(200, { 'Content-Type': 'application/javascript' }); return res.end(realWalletModule); }
+    const root = urlPath.startsWith('/egs/') ? EGS_ROOT : APP_ROOT;
+    const rel = urlPath.startsWith('/egs/') ? urlPath.slice('/egs'.length) : urlPath;
+    fs.readFile(path.join(root, rel), (err, data) => {
+        if (err) { res.writeHead(404); return res.end('nf'); }
+        res.writeHead(200, { 'Content-Type': MIME[path.extname(rel)] || 'application/octet-stream' });
+        res.end(data);
+    });
+}).listen(APP_PORT);
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+await ctx.addInitScript(({ storeOrigin, walletParams }) => {
+    localStorage.setItem('ariz_gateway_host_override', storeOrigin);
+    localStorage.setItem('ariz_encrypted_sync_enabled', 'true');
+    window.__realWalletParams = walletParams;
+}, { storeOrigin: `http://localhost:${STORE_PORT}`, walletParams: { accountId: 'repro.near', privateJwk: walletPrivateJwk, publicKeyStr: walletPublicKey } });
+const page = await ctx.newPage();
+page.on('console', (m) => { const t = m.text(); if (/variant|Bad news|target OID|refish|Error|EOF|index|Failed/.test(t)) console.log('[browser]', t.split('\n')[0].slice(0, 200)); });
+await page.goto(`${APP_ORIGIN}/test.html`);
+
+// Phase 0: SW + key setup (browser mints DEK; node unwraps it for store seeding).
+const { remoteUrl } = await page.evaluate(async () => {
+    const { installRealTestWallet } = await import('/realwallet.js');
+    await installRealTestWallet(window.__realWalletParams);
+    await import('/storage/gitstorage.js');
+    const es = await import('/arizgateway/encryptedsync.js');
+    return await es.configureEgitKey();
+});
+const { kek, wrapId } = deriveKekAndWrapId();
+const dek = unwrapDek(kek, store.keys.get(wrapId));
+console.log('DEK unwrapped; seeding store with PRODUCTION packs');
+
+const m1 = advanceManifest(emptyManifest(), { refUpdates: { 'refs/heads/master': OLD }, pack: { n: 0, sha: await sha256hex(pack0), size: pack0.length } });
+const m2 = advanceManifest(m1, { refUpdates: { 'refs/heads/master': NEW }, pack: { n: 1, sha: await sha256hex(pack1), size: pack1.length } });
+store.refs = Buffer.from(await encryptManifest(dek, m2)); store.etag++;
+store.packs.set('0', Buffer.from(await encrypt(dek, pack0)));
+store.packs.set('1', Buffer.from(await encrypt(dek, pack1)));
+
+// Phase 1: import browser 1's ACTUAL repo (incl. .git) into OPFS.
+const files = [];
+(function walk(dir) {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, e.name);
+        if (e.isDirectory()) walk(p);
+        else files.push(p);
+    }
+})(repoDir);
+// Ablation: SKIP=<regex> drops matching repo-relative paths from the import.
+const skip = process.env.SKIP ? new RegExp(process.env.SKIP) : null;
+const kept = skip ? files.filter((f) => !skip.test(path.relative(repoDir, f))) : [...files];
+if (skip) console.log(`SKIP=${process.env.SKIP}: importing ${kept.length}/${files.length} files`);
+files.length = 0; files.push(...kept);
+console.log(`importing ${files.length} files into OPFS…`);
+const dirs = [...new Set(files.map((f) => path.dirname(path.relative(repoDir, f))).filter((d) => d && d !== '.'))]
+    .sort((a, b) => a.split('/').length - b.split('/').length);
+if (process.env.ADD_DIRS) dirs.push(...process.env.ADD_DIRS.split(','));
+await page.evaluate(async (dirList) => {
+    const gs = await import('/storage/gitstorage.js');
+    for (const d of dirList) { try { await gs.mkdir(d); } catch { } }
+}, dirs);
+for (let i = 0; i < files.length; i += 40) {
+    const batch = files.slice(i, i + 40).map((f) => ({ rel: path.relative(repoDir, f), b64: fs.readFileSync(f).toString('base64') }));
+    await page.evaluate(async (entries) => {
+        const gs = await import('/storage/gitstorage.js');
+        for (const { rel, b64 } of entries) {
+            const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+            await gs.writeFile(rel, bytes);
+        }
+    }, batch);
+}
+console.log('repo imported');
+
+// Phase 2: browser 1's failing step — the app's sync flow.
+const out = await page.evaluate(async (remoteUrl) => {
+    const gs = await import('/storage/gitstorage.js');
+    try {
+        await gs.configure_user({ accessToken: 'x', username: 'repro.near', useremail: 'repro.near' });
+        await gs.set_remote(remoteUrl);
+        await gs.sync();
+        const t = await gs.readTextFile('accountdata/petersalomonsen.near/records.json').catch(() => null);
+        return { ok: true, gotB: t !== null };
+    } catch (e) { return { ok: false, error: String(e).slice(0, 700) }; }
+}, remoteUrl);
+console.log('sync with REAL browser-1 repo:', JSON.stringify(out, null, 1));
+
+await browser.close();
+console.log(out.ok ? '===== NOT REPRODUCED =====' : '===== REPRODUCED =====');
+process.exit(out.ok ? 1 : 0);


### PR DESCRIPTION
## The bug that broke browser 1's sync
Diagnosed end-to-end with real forensics (user's zip exports of both repos + the captured production upload-pack response):

1. Every layer of the served data was proven correct: the store held both packs, the merged pack indexed cleanly with `git index-pack --strict`, contained the wanted commit, and byte-matched what browser 2's clone received (recomputed pack id `735ee1bc…` = browser 2's on-disk pack).
2. The failure only reproduced after importing **browser 1's actual repository** into the test browser's OPFS. Ablation isolated it to one thing: **`.git/objects/pack/` does not exist** — the repo was migrated from IDBFS, and the migration copies files only, dropping empty directories. Pre-creating the directory made the same repo sync perfectly.
3. libgit2's fetch cannot create the directory itself: the downloaded pack silently never lands in the odb → *'target OID for the reference doesn't exist'* → no `origin/master` → merge no-op → push rejected non-FF. Pushes/commits never touched the pack dir, so the repo looked healthy for months until the first multi-device fetch.

## Fix
`ensureOdbPackDir()` in the git worker — at boot and before every sync (idempotent mkdir when a repo is present).

## Tests
- **opfs-worker-harness Test C**: builds a migrated-shape repo (real git, loose odb, pack dir deleted), imports it into OPFS, and syncs in a commit pushed from another clone. Without the fix it fails with the exact production error chain; with it, the other device's file reads back.
- `test_servers/sw-realrepo-repro.mjs` kept as the diagnostic tool (imports any real repo + pack bytes through the full SW/key stack).

Upstream note: the proper long-term fix belongs in wasm-git/libgit2's OPFS layer (create parent dirs when writing pack files) — recommended follow-up in petersalomonsen/wasm-git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)