### PR TITLE
Encrypted sync is the only sync (#76)

### DIFF
--- a/playwright_tests/tests/wasmgit.spec.js
+++ b/playwright_tests/tests/wasmgit.spec.js
@@ -1,32 +1,28 @@
 import { test, expect } from "@playwright/test";
 import { pause500ifRecordingVideo } from "../util/videorecording.js";
 
-// The Storage page now authenticates with the signed-in NEAR account (NEP-413)
-// and pushes to the user's repo on the Ariz gateway git server — there is no
-// access-key / remote-URL field any more. This smoke test verifies the new UI
-// replaced the old inputs. The full push/clone round-trip against the gateway
-// (which needs a wallet + the deployed gateway git server) is covered separately.
-test("storage page shows the gateway git UI (no legacy key/url inputs)", async ({ page }) => {
+// The Storage page syncs end-to-end ENCRYPTED only (plaintext /git hosting is
+// retired): Synchronize goes through the egit service worker, the master key
+// is wallet-unlocked, and the CLI path is git-remote-egit. This smoke test
+// verifies the encrypted-only UI in the dist bundle.
+test("storage page shows the encrypted-only sync UI", async ({ page }) => {
   await page.goto("http://localhost:8081");
 
   await page.getByRole('link', { name: 'Storage' }).click();
   await pause500ifRecordingVideo(page);
 
-  // New controls are present (locators pierce the open shadow root).
+  // Encrypted sync controls (locators pierce the open shadow root).
   await expect(page.locator('#syncbutton')).toBeVisible();
-  await expect(page.locator('#copyclonebutton')).toBeVisible();
-  await expect(page.locator('#copyconfigbutton')).toBeVisible();
-  await expect(page.locator('#gatewayaccountspan')).toBeVisible();
   await expect(page.locator('#downloadzipbutton')).toBeVisible();
-
-  // Encrypted sync controls (issue #76) are present; the opt-in defaults to off.
-  await expect(page.locator('#enableencryptedsyncbutton')).toBeVisible();
+  await expect(page.locator('#gatewayaccountspan')).toBeVisible();
   await expect(page.locator('#exportkeybutton')).toBeVisible();
   await expect(page.locator('#importkeybutton')).toBeVisible();
   await expect(page.locator('#copyegitclonebutton')).toBeVisible();
-  await expect(page.locator('#encryptedsyncstatus')).toHaveText('disabled');
 
-  // Legacy inputs are gone.
+  // Plaintext-era and legacy controls are gone.
+  await expect(page.locator('#copyclonebutton')).toHaveCount(0);
+  await expect(page.locator('#copyconfigbutton')).toHaveCount(0);
+  await expect(page.locator('#enableencryptedsyncbutton')).toHaveCount(0);
   await expect(page.locator('#wasmgitaccesskey')).toHaveCount(0);
   await expect(page.locator('#remoterepo')).toHaveCount(0);
   await pause500ifRecordingVideo(page);

--- a/public_html/arizgateway/encryptedsync.js
+++ b/public_html/arizgateway/encryptedsync.js
@@ -37,19 +37,6 @@ const swContainer = () => _testContainer ?? navigator.serviceWorker;
  */
 export const encryptedRemoteUrl = (accountId) => `${location.origin}/egit/${accountId}`;
 
-// Opt-in flag: while the plaintext /git remote still exists, encrypted sync is
-// enabled per browser from the Storage page (issue #76's migration path).
-export const ENCRYPTED_SYNC_ENABLED_KEY = 'ariz_encrypted_sync_enabled';
-
-export function isEncryptedSyncEnabled() {
-    return localStorage.getItem(ENCRYPTED_SYNC_ENABLED_KEY) === 'true';
-}
-
-export function setEncryptedSyncEnabled(enabled) {
-    if (enabled) localStorage.setItem(ENCRYPTED_SYNC_ENABLED_KEY, 'true');
-    else localStorage.removeItem(ENCRYPTED_SYNC_ENABLED_KEY);
-}
-
 /**
  * Whether this page has been service-worker controlled from the start. After a
  * FIRST-TIME registration the SW claims the page, but workers that already

--- a/public_html/arizgateway/encryptedsync.spec.js
+++ b/public_html/arizgateway/encryptedsync.spec.js
@@ -7,7 +7,6 @@ import { __clearDekForTests, currentDekHex, NeedsEnrollmentError } from './encry
 import { fakeWallet, mockStore } from './encryptionkey.mock.js';
 import {
     registerEgitServiceWorker, configureEgitKey, encryptedRemoteUrl,
-    isEncryptedSyncEnabled, setEncryptedSyncEnabled, ENCRYPTED_SYNC_ENABLED_KEY,
     pageIsControlled, waitForController,
     __setTestServiceWorkerContainer,
 } from './encryptedsync.js';
@@ -131,16 +130,6 @@ describe('encryptedsync (service worker registration + egit-set-key wiring)', ()
 
     it('encryptedRemoteUrl targets /egit/<account> on this origin', () => {
         expect(encryptedRemoteUrl('bob.near')).to.equal(`${location.origin}/egit/bob.near`);
-    });
-
-    it('the encrypted-sync opt-in flag toggles and defaults to off', () => {
-        localStorage.removeItem(ENCRYPTED_SYNC_ENABLED_KEY);
-        expect(isEncryptedSyncEnabled()).to.equal(false);
-        setEncryptedSyncEnabled(true);
-        expect(isEncryptedSyncEnabled()).to.equal(true);
-        setEncryptedSyncEnabled(false);
-        expect(isEncryptedSyncEnabled()).to.equal(false);
-        expect(localStorage.getItem(ENCRYPTED_SYNC_ENABLED_KEY)).to.equal(null);
     });
 
     it('waitForController resolves when the service worker claims the page', async () => {

--- a/public_html/storage/storage-page.component.html.js
+++ b/public_html/storage/storage-page.component.html.js
@@ -1,40 +1,20 @@
 export default /*html*/ `<div class="card">
-    <div class="card-header">Store data on the Ariz gateway git server</div>
+    <div class="card-header">Store data on the Ariz gateway &mdash; end-to-end encrypted</div>
     <div class="card-body">
-        <p>Your portfolio data lives in an in-browser git repository. <b>Synchronize</b> pushes it to your private repository on the Ariz gateway, authenticated with your signed-in NEAR account.</p>
+        <p>Your portfolio data lives in an in-browser git repository. <b>Synchronize</b> pushes it to your private,
+            <b>end-to-end encrypted</b> repository on the Ariz gateway: everything is encrypted in your browser before
+            upload, with a master key that only your wallet can unlock &mdash; the server only ever stores ciphertext.
+            <b>You are the custodian of your key</b>: export it and keep a safe copy (e.g. in a password manager).</p>
         <p>Signed in as: <span id="gatewayaccountspan">(not signed in)</span></p>
         <p>
             <button class="btn btn-primary" id="syncbutton">Synchronize</button>
             <button class="btn btn-secondary" id="downloadzipbutton">Download as zip file</button>
             <button class="btn btn-outline-danger" id="deletelocaldatabutton">Delete local data</button>
         </p>
-        <hr />
-        <h6>Use from the command line (optional)</h6>
-        <p>Clone your repository, passing your current access token as an HTTP header:</p>
-        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code id="clonecmd">Sign in, then click &ldquo;Copy clone command&rdquo;.</code></pre>
-        <button class="btn btn-sm btn-outline-primary" id="copyclonebutton">Copy clone command</button>
-        <p class="mt-3">Token expired in an existing clone? Update it (run inside the cloned repo):</p>
-        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code id="configcmd">Sign in, then click &ldquo;Copy git config command&rdquo;.</code></pre>
-        <button class="btn btn-sm btn-outline-primary" id="copyconfigbutton">Copy git config command</button>
-        <p class="mt-2"><small class="text-muted">The access token is short-lived &mdash; re-copy when it expires.</small></p>
-    </div>
-</div>
-<br />
-<div class="card">
-    <div class="card-header">Encrypted sync</div>
-    <div class="card-body">
-        <p>End-to-end encryption for your synced data: everything is encrypted in your browser before upload, with a
-            master key that only your wallet can unlock &mdash; the server only ever stores ciphertext.
-            <b>You are the custodian of your key</b>: export it and keep a safe copy (e.g. in a password manager).</p>
-        <p>Status: <b><span id="encryptedsyncstatus">disabled</span></b></p>
-        <p>
-            <button class="btn btn-primary" id="enableencryptedsyncbutton">Enable encrypted sync</button>
-            <button class="btn btn-outline-secondary" id="disableencryptedsyncbutton">Disable</button>
-        </p>
-        <p><small class="text-muted">Your wallet will ask you to sign the same message <b>twice</b>: the second
-            signature verifies that your wallet signs deterministically, so it can unlock the same key again
-            later. A wallet that signs differently each time cannot be used to unlock by signing (import an
-            exported key instead).</small></p>
+        <p><small class="text-muted">On the first synchronize of a session, your wallet will ask you to sign the same
+            message <b>twice</b>: the second signature verifies that your wallet signs deterministically, so it can
+            unlock the same key again later. A wallet that signs differently each time cannot be used to unlock by
+            signing (import an exported key instead).</small></p>
         <hr />
         <h6>Your key</h6>
         <p>Needed to enroll other devices or wallet keys, and to recover your data if you lose access to this wallet key.</p>

--- a/public_html/storage/storage-page.component.js
+++ b/public_html/storage/storage-page.component.js
@@ -3,24 +3,10 @@ import wasmgitComponentHtml from './storage-page.component.html.js';
 import { modalAlert } from '../ui/modal.js';
 import { setProgressbarValue } from '../ui/progress-bar.js';
 import { getAccessToken, getAccountId, isSignedIn, loginToArizGateway, requireWalletAccount, arizgatewayhost } from '../arizgateway/arizgatewayaccess.js';
-import { isEncryptedSyncEnabled, setEncryptedSyncEnabled, configureEgitKey, waitForController } from '../arizgateway/encryptedsync.js';
+import { configureEgitKey, waitForController } from '../arizgateway/encryptedsync.js';
 import { obtainDek, currentDekHex, enrollWithExportedKey, NeedsEnrollmentError } from '../arizgateway/encryptionkey.js';
 
-// One repository per account; the account is implied by the NEP-413 token, so the
-// repo name in the URL is a fixed label.
-const REPO_NAME = 'portfolio';
-export const gatewayRepoUrl = () => `${arizgatewayhost}/git/${REPO_NAME}`;
-
-// CLI helpers: the gateway git server authenticates the same NEP-413 bearer token
-// the app uses, passed as an HTTP header. `git -c http.extraHeader=...` is a
-// one-shot for cloning; `git config http.extraHeader ...` persists/refreshes it in
-// an existing clone (tokens are short-lived).
-export const gitCloneCommand = (token) =>
-    `git -c http.extraHeader="Authorization: Bearer ${token}" clone ${gatewayRepoUrl()}`;
-export const gitConfigCommand = (token) =>
-    `git config http.extraHeader "Authorization: Bearer ${token}"`;
-
-// CLI for the ENCRYPTED store: the git-remote-egit helper (bin of the
+// CLI for the encrypted store: the git-remote-egit helper (bin of the
 // encrypted-git-storage package) reads the master key from EGIT_KEY and sends
 // EGIT_AUTH as the Authorization header on every store request. The command
 // embeds both — the key never reaches the server, but treat the command as a
@@ -29,16 +15,15 @@ export const egitCloneCommand = (keyHex, token) =>
     `EGIT_KEY=${keyHex} EGIT_AUTH="Bearer ${token}" git clone "egit::${arizgatewayhost}/store/me" portfolio`;
 
 /**
- * Resolve the remote for this sync: the plaintext gateway git server, or — when
- * encrypted sync is enabled — the virtual /egit/<account> remote answered by
- * the service worker, which is registered and given the key + a fresh bearer
- * token here (before EVERY sync: the SW keeps its config in memory only and
- * the token expires). A git worker created before the SW claimed the page is
- * not intercepted (a claim() covers the page, not already-running workers), so
- * it is restarted — gitstorage tracks control at worker creation time.
+ * Prepare the sync remote: the virtual /egit/<account> remote answered by the
+ * service worker, which is registered and given the key + a fresh bearer token
+ * here (before EVERY sync: the SW keeps its config in memory only and the
+ * token expires). Encrypted sync is the ONLY sync — plaintext /git hosting is
+ * retired (410 on the gateway). A git worker created before the SW claimed the
+ * page is not intercepted (a claim() covers the page, not already-running
+ * workers), so it is restarted — gitstorage tracks control at worker creation.
  */
 export async function prepareSyncRemote() {
-    if (!isEncryptedSyncEnabled()) return gatewayRepoUrl();
     const { remoteUrl } = await configureEgitKey();
     if (!gitWorkerControlled()) {
         await waitForController();
@@ -75,57 +60,14 @@ customElements.define('storage-page',
             this.syncbutton = this.shadowRoot.getElementById('syncbutton');
             this.syncbutton.addEventListener('click', () => this.synchronize());
 
-            this.shadowRoot.getElementById('copyclonebutton')
-                .addEventListener('click', () => this.copyCommand('clone'));
-            this.shadowRoot.getElementById('copyconfigbutton')
-                .addEventListener('click', () => this.copyCommand('config'));
-
-            this.shadowRoot.getElementById('enableencryptedsyncbutton')
-                .addEventListener('click', () => this.enableEncryptedSync());
-            this.shadowRoot.getElementById('disableencryptedsyncbutton')
-                .addEventListener('click', () => {
-                    setEncryptedSyncEnabled(false);
-                    this.refreshEncryptedSyncStatus();
-                });
             this.shadowRoot.getElementById('exportkeybutton')
                 .addEventListener('click', () => this.exportKey());
             this.shadowRoot.getElementById('importkeybutton')
                 .addEventListener('click', () => this.importKey());
             this.shadowRoot.getElementById('copyegitclonebutton')
                 .addEventListener('click', () => this.copyEgitCloneCommand());
-            this.refreshEncryptedSyncStatus();
 
             return this.shadowRoot;
-        }
-
-        refreshEncryptedSyncStatus() {
-            const enabled = isEncryptedSyncEnabled();
-            this.shadowRoot.getElementById('encryptedsyncstatus').innerText = enabled ? 'enabled' : 'disabled';
-            this.shadowRoot.getElementById('enableencryptedsyncbutton').disabled = enabled;
-            this.shadowRoot.getElementById('disableencryptedsyncbutton').disabled = !enabled;
-        }
-
-        async enableEncryptedSync() {
-            setProgressbarValue('indeterminate', 'enabling encrypted sync');
-            try {
-                await this.requireWallet();
-                // Registers the service worker and unlocks (or first-time
-                // creates) the master key — the enable action IS the setup.
-                await configureEgitKey();
-                setEncryptedSyncEnabled(true);
-                setProgressbarValue(null);
-                await modalAlert('Encrypted sync enabled',
-                    'Your next Synchronize will push to the encrypted store. Export your key now and keep a safe copy — you need it to enroll other devices, and to recover your data if you lose access to this wallet key.');
-            } catch (e) {
-                setProgressbarValue(null);
-                if (e instanceof NeedsEnrollmentError) {
-                    await modalAlert('This device needs your exported key', e.message);
-                } else {
-                    console.error(e);
-                    await modalAlert('Could not enable encrypted sync', e);
-                }
-            }
-            this.refreshEncryptedSyncStatus();
         }
 
         async exportKey() {
@@ -147,14 +89,12 @@ customElements.define('storage-page',
                 await this.requireWallet();
                 await enrollWithExportedKey(input.value);
                 input.value = '';
-                setEncryptedSyncEnabled(true);
                 await modalAlert('Key imported',
                     'This wallet key is now enrolled: from now on it unlocks the encrypted store by signing, without the exported key.');
             } catch (e) {
                 console.error(e);
                 await modalAlert('Could not import the key', e.message ?? e);
             }
-            this.refreshEncryptedSyncStatus();
         }
 
         async copyEgitCloneCommand() {
@@ -239,20 +179,5 @@ customElements.define('storage-page',
             }
             setProgressbarValue(null);
             this.syncbutton.disabled = false;
-        }
-
-        async copyCommand(kind) {
-            try {
-                await this.ensureSignedIn();
-                const token = await getAccessToken();
-                const cmd = kind === 'clone' ? gitCloneCommand(token) : gitConfigCommand(token);
-                this.shadowRoot.getElementById(kind === 'clone' ? 'clonecmd' : 'configcmd').textContent = cmd;
-                // Best-effort: the command is shown for manual copy even if the
-                // clipboard API is unavailable/blocked.
-                try { await navigator.clipboard.writeText(cmd); } catch { /* shown for manual copy */ }
-            } catch (e) {
-                console.error(e);
-                await modalAlert('Could not generate the command', e);
-            }
         }
     });

--- a/public_html/storage/storage-page.component.spec.js
+++ b/public_html/storage/storage-page.component.spec.js
@@ -1,29 +1,21 @@
-import { gitCloneCommand, gitConfigCommand, gatewayRepoUrl, prepareSyncRemote, egitCloneCommand } from './storage-page.component.js';
-import { arizgatewayhost } from '../arizgateway/arizgatewayaccess.js';
-import { mockWalletAuthenticationData } from '../arizgateway/arizgatewayaccess.spec.js';
-import { isEncryptedSyncEnabled, setEncryptedSyncEnabled, __setTestServiceWorkerContainer } from '../arizgateway/encryptedsync.js';
+import { egitCloneCommand, prepareSyncRemote } from './storage-page.component.js';
+import { arizgatewayhost, __setTestWallet } from '../arizgateway/arizgatewayaccess.js';
+import { __setTestServiceWorkerContainer } from '../arizgateway/encryptedsync.js';
 import { __clearDekForTests, obtainDek, currentDekHex } from '../arizgateway/encryptionkey.js';
 import { fakeWallet, mockStore } from '../arizgateway/encryptionkey.mock.js';
 import { fakeSwContainer } from '../arizgateway/encryptedsync.mock.js';
-import { __setTestWallet } from '../arizgateway/arizgatewayaccess.js';
+import { mockWalletAuthenticationData } from '../arizgateway/arizgatewayaccess.spec.js';
 
-describe('storage-page component', () => {
+describe('storage-page component (encrypted-only sync)', () => {
     before(() => {
-        // A fake wallet so the component can resolve the signed-in account without
-        // loading the real wallet UI / hitting the network.
         mockWalletAuthenticationData('test.near');
     });
 
-    it('builds a clone command passing the NEP-413 token as an http.extraHeader', () => {
-        const cmd = gitCloneCommand('TOKEN123');
-        expect(cmd).to.contain('http.extraHeader="Authorization: Bearer TOKEN123"');
-        expect(cmd).to.contain(`clone ${gatewayRepoUrl()}`);
-        expect(cmd.startsWith('git -c ')).to.equal(true);
-        expect(gatewayRepoUrl()).to.contain('/git/');
-    });
-
-    it('builds a git config command to refresh an expired token in an existing clone', () => {
-        expect(gitConfigCommand('TOKEN123')).to.equal('git config http.extraHeader "Authorization: Bearer TOKEN123"');
+    it('builds an encrypted clone command with the key, auth and egit:: remote', () => {
+        const cmd = egitCloneCommand('ab'.repeat(32), 'TOKEN123');
+        expect(cmd).to.contain(`EGIT_KEY=${'ab'.repeat(32)}`);
+        expect(cmd).to.contain('EGIT_AUTH="Bearer TOKEN123"');
+        expect(cmd).to.contain(`git clone "egit::${arizgatewayhost}/store/me"`);
     });
 
     describe('prepareSyncRemote', () => {
@@ -41,21 +33,13 @@ describe('storage-page component', () => {
         });
 
         afterEach(() => {
-            setEncryptedSyncEnabled(false);
             store.restore();
             __setTestWallet(null);
             __setTestServiceWorkerContainer(null);
             localStorage.removeItem('ariz_gateway_access_token');
         });
 
-        it('uses the plaintext gateway git remote when encrypted sync is off', async () => {
-            setEncryptedSyncEnabled(false);
-            expect(await prepareSyncRemote()).to.equal(gatewayRepoUrl());
-            expect(sw.registerCalls.length).to.equal(0);
-        });
-
-        it('when enabled: configures the service worker and returns /egit/<account>', async () => {
-            setEncryptedSyncEnabled(true);
+        it('ALWAYS configures the service worker and returns /egit/<account> — plaintext is retired', async () => {
             const url = await prepareSyncRemote();
             expect(url).to.equal(`${location.origin}/egit/test.near`);
             expect(sw.registerCalls.length).to.equal(1);
@@ -65,38 +49,7 @@ describe('storage-page component', () => {
         });
     });
 
-    it('renders the new UI without the legacy access-key / remote-url inputs', async () => {
-        const el = document.createElement('storage-page');
-        document.body.appendChild(el);
-        await el.readyPromise;
-        const $ = (id) => el.shadowRoot.getElementById(id);
-        // legacy inputs are gone
-        expect($('wasmgitaccesskey')).to.equal(null);
-        expect($('remoterepo')).to.equal(null);
-        // new controls are present
-        expect($('syncbutton')).to.not.equal(null);
-        expect($('copyclonebutton')).to.not.equal(null);
-        expect($('copyconfigbutton')).to.not.equal(null);
-        expect($('gatewayaccountspan')).to.not.equal(null);
-        // encrypted sync controls are present
-        expect($('encryptedsyncstatus')).to.not.equal(null);
-        expect($('enableencryptedsyncbutton')).to.not.equal(null);
-        expect($('disableencryptedsyncbutton')).to.not.equal(null);
-        expect($('exportkeybutton')).to.not.equal(null);
-        expect($('importkeyinput')).to.not.equal(null);
-        expect($('importkeybutton')).to.not.equal(null);
-        expect($('copyegitclonebutton')).to.not.equal(null);
-        el.remove();
-    });
-
-    it('builds an encrypted clone command with the key, auth and egit:: remote', () => {
-        const cmd = egitCloneCommand('ab'.repeat(32), 'TOKEN123');
-        expect(cmd).to.contain(`EGIT_KEY=${'ab'.repeat(32)}`);
-        expect(cmd).to.contain('EGIT_AUTH="Bearer TOKEN123"');
-        expect(cmd).to.contain(`git clone "egit::${arizgatewayhost}/store/me"`);
-    });
-
-    describe('encrypted sync UI flows', () => {
+    describe('encrypted sync UI', () => {
         let store;
         let sw;
         let el;
@@ -119,7 +72,6 @@ describe('storage-page component', () => {
 
         beforeEach(async () => {
             __clearDekForTests();
-            setEncryptedSyncEnabled(false);
             localStorage.setItem('ariz_gateway_access_token',
                 JSON.stringify({ token: 'test-token', accountId: 'test.near', issuedAt: Date.now() }));
             store = mockStore();
@@ -133,27 +85,27 @@ describe('storage-page component', () => {
 
         afterEach(() => {
             el.remove();
-            setEncryptedSyncEnabled(false);
             store.restore();
             __setTestWallet(null);
             __setTestServiceWorkerContainer(null);
             localStorage.removeItem('ariz_gateway_access_token');
         });
 
-        it('enable: sets up the key + service worker, flips the flag and status', async () => {
-            expect(el.shadowRoot.getElementById('encryptedsyncstatus').innerText).to.equal('disabled');
-            el.shadowRoot.getElementById('enableencryptedsyncbutton').click();
-            const text = await dismissModal();
-            expect(text).to.contain('Encrypted sync enabled');
-            expect(isEncryptedSyncEnabled()).to.equal(true);
-            expect(store.wraps.size).to.equal(1); // first-setup stored a key wrap
-            expect(sw.active.messages[0].type).to.equal('egit-set-key');
-            expect(el.shadowRoot.getElementById('encryptedsyncstatus').innerText).to.equal('enabled');
-            expect(el.shadowRoot.getElementById('enableencryptedsyncbutton').disabled).to.equal(true);
-
-            el.shadowRoot.getElementById('disableencryptedsyncbutton').click();
-            expect(isEncryptedSyncEnabled()).to.equal(false);
-            expect(el.shadowRoot.getElementById('encryptedsyncstatus').innerText).to.equal('disabled');
+        it('renders the encrypted-only UI: no plaintext CLI, no enable/disable toggle', async () => {
+            const $ = (id) => el.shadowRoot.getElementById(id);
+            // encrypted controls present
+            expect($('syncbutton')).to.not.equal(null);
+            expect($('exportkeybutton')).to.not.equal(null);
+            expect($('importkeyinput')).to.not.equal(null);
+            expect($('importkeybutton')).to.not.equal(null);
+            expect($('copyegitclonebutton')).to.not.equal(null);
+            expect($('gatewayaccountspan')).to.not.equal(null);
+            // plaintext-era and toggle controls are gone
+            expect($('copyclonebutton')).to.equal(null);
+            expect($('copyconfigbutton')).to.equal(null);
+            expect($('enableencryptedsyncbutton')).to.equal(null);
+            expect($('disableencryptedsyncbutton')).to.equal(null);
+            expect($('encryptedsyncstatus')).to.equal(null);
         });
 
         it('export key reveals the 64-hex master key', async () => {
@@ -162,7 +114,7 @@ describe('storage-page component', () => {
             expect(el.shadowRoot.getElementById('exportedkey').textContent).to.equal(currentDekHex());
         });
 
-        it('an unenrolled wallet key gets the enrollment modal, then imports the exported key', async () => {
+        it('an unenrolled wallet key can import the exported key to enroll', async () => {
             // Device/wallet 1 created the store...
             const dek = await obtainDek();
             const dekHex = [...dek].map((b) => b.toString(16).padStart(2, '0')).join('');
@@ -171,16 +123,10 @@ describe('storage-page component', () => {
             __clearDekForTests();
             fakeWallet('test-ledger.near');
 
-            el.shadowRoot.getElementById('enableencryptedsyncbutton').click();
-            const text = await dismissModal();
-            expect(text).to.contain('exported key');
-            expect(isEncryptedSyncEnabled()).to.equal(false);
-
             el.shadowRoot.getElementById('importkeyinput').value = dekHex;
             el.shadowRoot.getElementById('importkeybutton').click();
             const importText = await dismissModal();
             expect(importText).to.contain('Key imported');
-            expect(isEncryptedSyncEnabled()).to.equal(true);
             expect(store.wraps.size).to.equal(2); // a second wrap for the new wallet key
             expect(currentDekHex()).to.equal(dekHex);
         });

--- a/test_servers/encrypted-sync-harness.mjs
+++ b/test_servers/encrypted-sync-harness.mjs
@@ -240,7 +240,6 @@ async function newAppPage() {
     // signing with the (real) test wallet, exactly like production.
     await ctx.addInitScript(({ storeOrigin, walletParams }) => {
         localStorage.setItem('ariz_gateway_host_override', storeOrigin);
-        localStorage.setItem('ariz_encrypted_sync_enabled', 'true');
         window.__realWalletParams = walletParams;
     }, {
         storeOrigin: STORE_ORIGIN,

--- a/test_servers/sw-realrepo-repro.mjs
+++ b/test_servers/sw-realrepo-repro.mjs
@@ -136,7 +136,6 @@ const browser = await chromium.launch();
 const ctx = await browser.newContext();
 await ctx.addInitScript(({ storeOrigin, walletParams }) => {
     localStorage.setItem('ariz_gateway_host_override', storeOrigin);
-    localStorage.setItem('ariz_encrypted_sync_enabled', 'true');
     window.__realWalletParams = walletParams;
 }, { storeOrigin: `http://localhost:${STORE_PORT}`, walletParams: { accountId: 'repro.near', privateJwk: walletPrivateJwk, publicKeyStr: walletPublicKey } });
 const page = await ctx.newPage();


### PR DESCRIPTION
Companion to the gateway's retirement of plaintext `/git` hosting (now 410; the last plaintext repo was deleted from the volume today after verifying its tip `6293863c` is an ancestor of the encrypted store's history — nothing lost, snapshots age out in ~5 days).

- **`prepareSyncRemote()` always goes encrypted** — the opt-in localStorage flag, the plaintext remote, and the `http.extraHeader` CLI builders + card are removed.
- The enable/disable toggle is gone (nothing to toggle); **export key / import-to-enroll / `git-remote-egit` CLI instructions remain**, and the double-signing explanation moved next to Synchronize.
- Specs rewritten for the encrypted-only surface; the Playwright dist smoke asserts the plaintext controls are gone; harnesses no longer seed the retired flag.

All green: wtr suite (full), encrypted-sync harness, dist smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)