### PR TITLE
Storage page: CLI helper install via release tarball (npm 11 git-dep quirk)

### DIFF
--- a/public_html/storage/storage-page.component.html.js
+++ b/public_html/storage/storage-page.component.html.js
@@ -29,7 +29,7 @@ export default /*html*/ `<div class="card">
         <hr />
         <h6>Use from the command line (optional)</h6>
         <p>Install the <code>egit::</code> git remote helper once:</p>
-        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code>npm install -g github:petersalomonsen/encrypted-git-storage</code></pre>
+        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code>npm install -g https://github.com/petersalomonsen/encrypted-git-storage/archive/refs/tags/v0.1.3.tar.gz</code></pre>
         <p>Then clone your encrypted repository (decrypted locally with your exported key):</p>
         <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code id="egitclonecmd">Sign in, then click &ldquo;Copy encrypted clone command&rdquo;.</code></pre>
         <button class="btn btn-sm btn-outline-primary" id="copyegitclonebutton">Copy encrypted clone command</button>


### PR DESCRIPTION
`npm install -g github:petersalomonsen/encrypted-git-storage` is broken on npm 11.12: global **git deps** are installed as a symlink into `~/.npm/_cacache/tmp/git-clone*`, which npm then cleans up — leaving a dangling package and `git: 'remote-egit' is not a git command`. (Hit live twice today; `--install-links=true` also works, but the tarball URL needs no flags and skips the git-dep machinery entirely.)

The Storage page now instructs:
`npm install -g https://github.com/petersalomonsen/encrypted-git-storage/archive/refs/tags/v0.1.3.tar.gz`

Verified end-to-end on macOS/npm 11.12: real install, helper on PATH, `git ls-remote egit::…` reaches the live store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)