### PR TITLE
Use encrypted-git-storage from the npm registry (^0.1.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@web/test-runner": "0.19.0",
     "@web/test-runner-playwright": "^0.11.1",
     "cgi": "^0.3.1",
-    "encrypted-git-storage": "github:petersalomonsen/encrypted-git-storage#v0.1.2",
+    "encrypted-git-storage": "^0.1.4",
     "http-server": "^14.1.1",
     "ipfs-car": "^1.2.0",
     "jspm": "^3.2.0",

--- a/public_html/storage/storage-page.component.html.js
+++ b/public_html/storage/storage-page.component.html.js
@@ -29,7 +29,7 @@ export default /*html*/ `<div class="card">
         <hr />
         <h6>Use from the command line (optional)</h6>
         <p>Install the <code>egit::</code> git remote helper once:</p>
-        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code>npm install -g https://github.com/petersalomonsen/encrypted-git-storage/archive/refs/tags/v0.1.3.tar.gz</code></pre>
+        <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code>npm install -g encrypted-git-storage</code></pre>
         <p>Then clone your encrypted repository (decrypted locally with your exported key):</p>
         <pre class="border rounded p-2 bg-light" style="white-space:pre-wrap;word-break:break-all;"><code id="egitclonecmd">Sign in, then click &ldquo;Copy encrypted clone command&rdquo;.</code></pre>
         <button class="btn btn-sm btn-outline-primary" id="copyegitclonebutton">Copy encrypted clone command</button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,9 +2187,10 @@ encodeurl@~2.0.0:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
-"encrypted-git-storage@github:petersalomonsen/encrypted-git-storage#v0.1.2":
-  version "0.1.2"
-  resolved "https://codeload.github.com/petersalomonsen/encrypted-git-storage/tar.gz/b3ee2019b97d6dda296105c78a44c758d7ee9940"
+encrypted-git-storage@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/encrypted-git-storage/-/encrypted-git-storage-0.1.4.tgz#cef04ae0e68c4efa15fee7fa5d4cb5df4482f234"
+  integrity sha512-tNnOxp3p35X16D44bD3Ni24tXhMFO2gsl5TWR0641eAoek1SYssRiwsRrITouTteVARsFLfo4mS+D84w3U936g==
   dependencies:
     "@aws-sdk/client-s3" "^3.658.0"
     express "^4.21.2"


### PR DESCRIPTION
encrypted-git-storage is now published to npm. The Storage page instructs plain `npm install -g encrypted-git-storage`, and the harness devDependency tracks the registry (`^0.1.4`) instead of a git tag — no more git-dep prepare/symlink quirks (npm 11's dangling-symlink issue, yarn's skipped prepare). Registry install verified end-to-end on macOS (helper on PATH, live store handshake); encrypted-sync harness green with the registry package (its committed `dist/sw.js` included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)